### PR TITLE
[Misc] Use pattern matching for instanceof in various modules (SonarCloud java:S6201)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-renderer/src/main/java/org/xwiki/chart/internal/plot/AbstractCategoryPlotGenerator.java
+++ b/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-renderer/src/main/java/org/xwiki/chart/internal/plot/AbstractCategoryPlotGenerator.java
@@ -45,20 +45,20 @@ public abstract class AbstractCategoryPlotGenerator implements PlotGenerator
         CategoryAxis domainAxis;
         ValueAxis rangeAxis;
 
-        if (model.getDataset() instanceof CategoryDataset) {
-            dataset = (CategoryDataset) model.getDataset();
+        if (model.getDataset() instanceof CategoryDataset categoryDataset) {
+            dataset = categoryDataset;
         } else {
             throw new PlotGeneratorException("Incompatible dataset for category plot.");
         }
 
-        if (model.getAxis(0) instanceof CategoryAxis) {
-            domainAxis = (CategoryAxis) model.getAxis(0);
+        if (model.getAxis(0) instanceof CategoryAxis categoryAxis) {
+            domainAxis = categoryAxis;
         } else {
             throw new PlotGeneratorException("Incompatible axis 0 for category plot.");
         }
 
-        if (model.getAxis(1) instanceof ValueAxis) {
-            rangeAxis = (ValueAxis) model.getAxis(1);
+        if (model.getAxis(1) instanceof ValueAxis valueAxis) {
+            rangeAxis = valueAxis;
         } else {
             throw new PlotGeneratorException("Incompatible axis 1 for category plot.");
         }

--- a/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-renderer/src/main/java/org/xwiki/chart/internal/plot/AbstractXYPlotGenerator.java
+++ b/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-renderer/src/main/java/org/xwiki/chart/internal/plot/AbstractXYPlotGenerator.java
@@ -44,20 +44,20 @@ public abstract class AbstractXYPlotGenerator implements PlotGenerator
         ValueAxis domainAxis;
         ValueAxis rangeAxis;
 
-        if (model.getDataset() instanceof XYDataset) {
-            dataset = (XYDataset) model.getDataset();
+        if (model.getDataset() instanceof XYDataset xyDataset) {
+            dataset = xyDataset;
         } else {
             throw new PlotGeneratorException("Incompatible dataset for xy plot.");
         }
 
-        if (model.getAxis(0) instanceof ValueAxis) {
-            domainAxis = (ValueAxis) model.getAxis(0);
+        if (model.getAxis(0) instanceof ValueAxis domainValueAxis) {
+            domainAxis = domainValueAxis;
         } else {
             throw new PlotGeneratorException("Incompatible axis 0 for xy plot.");
         }
 
-        if (model.getAxis(1) instanceof ValueAxis) {
-            rangeAxis = (ValueAxis) model.getAxis(1);
+        if (model.getAxis(1) instanceof ValueAxis rangeValueAxis) {
+            rangeAxis = rangeValueAxis;
         } else {
             throw new PlotGeneratorException("Incompatible axis 1 for xy plot.");
         }

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/WikiReader.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/WikiReader.java
@@ -101,8 +101,8 @@ public class WikiReader
         InputStream stream;
 
         InputSource source = this.properties.getSource();
-        if (source instanceof InputStreamInputSource) {
-            stream = ((InputStreamInputSource) source).getInputStream();
+        if (source instanceof InputStreamInputSource inputStreamInputSource) {
+            stream = inputStreamInputSource.getInputStream();
         } else {
             throw new FilterException("Unsupported source type [" + source.getClass() + "]");
         }

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/XARInputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/XARInputFilterStream.java
@@ -81,10 +81,10 @@ public class XARInputFilterStream extends AbstractBeanInputFilterStream<XARInput
         if (this.properties.isForceDocument() || inputSource instanceof ReaderInputSource
             || inputSource instanceof SourceInputSource) {
             readDocument(filter, proxyFilter);
-        } else if (inputSource instanceof InputStreamInputSource) {
+        } else if (inputSource instanceof InputStreamInputSource inputStreamInputSource) {
             InputStream stream;
             try {
-                stream = ((InputStreamInputSource) inputSource).getInputStream();
+                stream = inputStreamInputSource.getInputStream();
             } catch (IOException e) {
                 throw new FilterException("Failed to get input stream", e);
             }

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/output/XAROutputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/output/XAROutputFilterStream.java
@@ -576,9 +576,9 @@ public class XAROutputFilterStream extends AbstractBeanOutputFilterStream<XAROut
 
     private InputStream getInputStream(InputSource content) throws FilterException
     {
-        if (content instanceof InputStreamInputSource) {
+        if (content instanceof InputStreamInputSource inputStreamInputSource) {
             try {
-                return ((InputStreamInputSource) content).getInputStream();
+                return inputStreamInputSource.getInputStream();
             } catch (IOException e) {
                 throw new FilterException("Failed to get the content input stream", e);
             }

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/output/XARWikiWriter.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/output/XARWikiWriter.java
@@ -78,12 +78,12 @@ public class XARWikiWriter implements Closeable
         OutputTarget target = this.xarProperties.getTarget();
 
         try {
-            if (target instanceof FileOutputTarget && ((FileOutputTarget) target).getFile().isDirectory()) {
+            if (target instanceof FileOutputTarget fileOutputTarget && fileOutputTarget.getFile().isDirectory()) {
                 this.zipStream =
-                    new ZipArchiveOutputStream(new File(((FileOutputTarget) target).getFile(), name + ".xar"));
-            } else if (target instanceof OutputStreamOutputTarget) {
+                    new ZipArchiveOutputStream(new File(fileOutputTarget.getFile(), name + ".xar"));
+            } else if (target instanceof OutputStreamOutputTarget outputStreamOutputTarget) {
                 this.zipStream = new ZipArchiveOutputStream(
-                    new CloseShieldOutputStream(((OutputStreamOutputTarget) target).getOutputStream()));
+                    new CloseShieldOutputStream(outputStreamOutputTarget.getOutputStream()));
             } else {
                 throw new FilterException(String.format("Unsupported output target [%s]. Only [%s] is supported",
                     target, OutputStreamOutputTarget.class));

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/FileSystemMailContentStore.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/FileSystemMailContentStore.java
@@ -147,8 +147,7 @@ public class FileSystemMailContentStore implements MailContentStore, Initializab
         List<File> temporaryFiles = new ArrayList<>();
         try {
             Object content = message.getContent();
-            if (content instanceof Multipart) {
-                Multipart multipart = (Multipart) content;
+            if (content instanceof Multipart multipart) {
                 for (int i = 0; i < multipart.getCount(); i++) {
                     Part part = multipart.getBodyPart(i);
                     String[] temporaryFileLocations =

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/factory/template/DefaultMailTemplateManager.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/factory/template/DefaultMailTemplateManager.java
@@ -243,8 +243,8 @@ public class DefaultMailTemplateManager implements MailTemplateManager
         } else {
             // Note: we support both a Locale type and String mostly for backward-compatibility reasons (the first
             // version of this API only supported String and we've moved to support Locale).
-            if (languageValue instanceof Locale) {
-                locale = (Locale) languageValue;
+            if (languageValue instanceof Locale localeValue) {
+                locale = localeValue;
             } else {
                 locale = LocaleUtils.toLocale(languageValue.toString());
             }

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/thread/PrepareMailRunnable.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/thread/PrepareMailRunnable.java
@@ -143,8 +143,8 @@ public class PrepareMailRunnable extends AbstractMailRunnable
                 // Update the listener with the total number of messages prepared so that the user can know when
                 // all the messages have been processed for the batch. We update here, even in case of failure
                 // so that waiting process have a chance to see an end.
-                if (result instanceof UpdateableMailStatusResult) {
-                    ((UpdateableMailStatusResult) result).setTotalSize(messageCounter);
+                if (result instanceof UpdateableMailStatusResult updateableResult) {
+                    updateableResult.setTotalSize(messageCounter);
                 }
                 listener.onPrepareEnd(Collections.emptyMap());
             }

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/script/ScriptMimeMessage.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/script/ScriptMimeMessage.java
@@ -125,7 +125,7 @@ public class ScriptMimeMessage extends ExtendedMimeMessage
         BodyPart bodyPart;
 
         try {
-            if (!(content instanceof BodyPart)) {
+            if (!(content instanceof BodyPart contentPart)) {
                 MimeBodyPartFactory factory = getBodyPartFactory(mimeType, content.getClass());
 
                 // Pass the mime type in the parameters so that generic Mime Body Part factories can use it.
@@ -136,7 +136,7 @@ public class ScriptMimeMessage extends ExtendedMimeMessage
 
                 bodyPart = factory.create(content, enhancedParameters);
             } else {
-                bodyPart = (BodyPart) content;
+                bodyPart = contentPart;
             }
             Multipart multipart = getMultipart();
             multipart.addBodyPart(bodyPart);
@@ -278,8 +278,8 @@ public class ScriptMimeMessage extends ExtendedMimeMessage
             setContent(multipart);
         } else {
             Object contentObject = getContent();
-            if (contentObject instanceof Multipart) {
-                multipart = (Multipart) contentObject;
+            if (contentObject instanceof Multipart multipartContent) {
+                multipart = multipartContent;
             } else {
                 throw new MessagingException(String.format("Unknown mail content type [%s]: [%s]",
                     contentObject.getClass().getName(), contentObject));

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/DefaultMentionXDOMService.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/DefaultMentionXDOMService.java
@@ -74,7 +74,7 @@ public class DefaultMentionXDOMService implements MentionXDOMService
 
     private static boolean matchMentionMacro(Block block)
     {
-        return block instanceof MacroBlock && Objects.equals(((MacroBlock) block).getId(), MENTION_MACRO_NAME);
+        return block instanceof MacroBlock macroBlock && Objects.equals(macroBlock.getId(), MENTION_MACRO_NAME);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/DefaultQuoteService.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/DefaultQuoteService.java
@@ -91,8 +91,8 @@ public class DefaultQuoteService implements QuoteService
         public boolean match(Block block)
         {
             boolean ret;
-            if (block instanceof MacroBlock) {
-                ret = "mention".equals(((MacroBlock) block).getId())
+            if (block instanceof MacroBlock macroBlock) {
+                ret = "mention".equals(macroBlock.getId())
                     && Objects.equals(Objects.toString(block.getParameter("anchor"), ""), this.anchorId);
             } else {
                 ret = false;

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/UserMentionEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/UserMentionEventListener.java
@@ -194,9 +194,9 @@ public class UserMentionEventListener implements EventListener
                 String name = entityReference.getName();
                 PropertyInterface field =
                     doc.getXObject(entityReference.extractReference(EntityType.OBJECT)).getField(name);
-                if (field instanceof BaseStringProperty) {
+                if (field instanceof BaseStringProperty baseStringProperty) {
                     xdom =
-                        this.xdomService.parse(((BaseStringProperty) field).getValue(), doc.getSyntax()).orElse(null);
+                        this.xdomService.parse(baseStringProperty.getValue(), doc.getSyntax()).orElse(null);
                 } else {
                     xdom = null;
                 }

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/analyzer/CreatedDocumentMentionsAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/analyzer/CreatedDocumentMentionsAnalyzer.java
@@ -160,8 +160,7 @@ public class CreatedDocumentMentionsAnalyzer extends AbstractDocumentMentionsAna
     {
         List<MentionNotificationParameters> mentionNotificationParametersList = new ArrayList<>();
         for (Object o : baseObject.getProperties()) {
-            if (o instanceof LargeStringProperty) {
-                LargeStringProperty largeStringProperty = (LargeStringProperty) o;
+            if (o instanceof LargeStringProperty largeStringProperty) {
                 String content = largeStringProperty.getValue();
                 this.xdomService
                     .parse(content, syntax)

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzer.java
@@ -224,8 +224,8 @@ public class UpdatedDocumentMentionsAnalyzer extends AbstractDocumentMentionsAna
                     });
             } else {
                 for (Object o : baseObject.getProperties()) {
-                    if (o instanceof LargeStringProperty) {
-                        handleProperty(oldBaseObject, (LargeStringProperty) o, version, TEXT_FIELD, authorReference,
+                    if (o instanceof LargeStringProperty largeStringProperty) {
+                        handleProperty(oldBaseObject, largeStringProperty, version, TEXT_FIELD, authorReference,
                             syntax).ifPresent(mentionNotificationParametersList::add);
                     }
                 }

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/document/XDOMOfficeDocument.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/document/XDOMOfficeDocument.java
@@ -146,8 +146,8 @@ public class XDOMOfficeDocument implements OfficeDocument
     private String getTitle(Block parent)
     {
         for (Block block : parent.getChildren()) {
-            if (block instanceof HeaderBlock) {
-                String title = renderTitle((HeaderBlock) block);
+            if (block instanceof HeaderBlock headerBlock) {
+                String title = renderTitle(headerBlock);
                 if (!StringUtils.isBlank(title)) {
                     return title;
                 }

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/filter/AnchorFilter.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/filter/AnchorFilter.java
@@ -97,6 +97,6 @@ public class AnchorFilter extends AbstractHTMLFilter
      */
     private boolean isAnchor(Node node)
     {
-        return node instanceof Element && !"".equals(((Element) node).getAttribute(ATTRIBUTE_NAME));
+        return node instanceof Element element && !"".equals(element.getAttribute(ATTRIBUTE_NAME));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/filter/StyleFilter.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/filter/StyleFilter.java
@@ -87,8 +87,7 @@ public class StyleFilter extends AbstractHTMLFilter
      */
     private void filter(Node node, Map<String, String> attributeMappings)
     {
-        if (node instanceof Element) {
-            Element element = (Element) node;
+        if (node instanceof Element element) {
             String allowedAttributes = attributeMappings.get(element.getNodeName().toLowerCase());
             NamedNodeMap currentAttributes = element.getAttributes();
             if (null == allowedAttributes) {

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/splitter/TargetDocumentDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/splitter/TargetDocumentDescriptor.java
@@ -110,8 +110,7 @@ public class TargetDocumentDescriptor
     public boolean equals(Object obj)
     {
         boolean equals = false;
-        if (obj instanceof TargetDocumentDescriptor) {
-            TargetDocumentDescriptor other = (TargetDocumentDescriptor) obj;
+        if (obj instanceof TargetDocumentDescriptor other) {
             equals = other.getDocumentReference().equals(getDocumentReference());
         }
         return equals;

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/JAXBConverter.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/JAXBConverter.java
@@ -133,8 +133,7 @@ public class JAXBConverter implements Initializable
         Object value = any;
 
         // Parse elements
-        if (any instanceof Element) {
-            Element valueElement = (Element) any;
+        if (any instanceof Element valueElement) {
             if (valueElement.hasChildNodes()) {
                 NodeList children = valueElement.getChildNodes();
                 for (int i = 0; i < children.getLength(); ++i) {

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
@@ -358,9 +358,7 @@ public class ModelFactory
                 property.getAttributes().add(attribute);
             }
 
-            if (propertyClass instanceof ListClass) {
-                ListClass listClass = (ListClass) propertyClass;
-
+            if (propertyClass instanceof ListClass listClass) {
                 List allowedValueList = listClass.getList(xwikiContext);
 
                 if (!allowedValueList.isEmpty()) {
@@ -1077,8 +1075,8 @@ public class ModelFactory
         }
 
         java.lang.Object value = ((BaseProperty) property).getObfuscatedValue();
-        if (value instanceof List) {
-            return StringUtils.join((List) value, "|");
+        if (value instanceof List list) {
+            return StringUtils.join(list, "|");
         } else if (value != null) {
             return value.toString();
         } else {

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/exceptions/XWikiRestExceptionMapper.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/exceptions/XWikiRestExceptionMapper.java
@@ -52,15 +52,12 @@ public class XWikiRestExceptionMapper implements ExceptionMapper<XWikiRestExcept
     {
         Throwable cause = exception.getCause();
 
-        if (cause instanceof XWikiException) {
-            XWikiException xwikiException = (XWikiException) cause;
+        if (cause instanceof XWikiException xwikiException) {
             if (xwikiException.getCode() == XWikiException.ERROR_XWIKI_ACCESS_DENIED) {
                 return Response.status(Status.UNAUTHORIZED).entity(exception.getMessage())
                     .type(MediaType.TEXT_PLAIN_TYPE).build();
             }
-        } else if (cause instanceof QueryException) {
-            QueryException queryException = (QueryException) cause;
-
+        } else if (cause instanceof QueryException queryException) {
             return Response.serverError().entity(
                 String.format("%s\n%s\n", exception.getMessage(), ExceptionUtils.getRootCauseMessage(queryException)))
                 .type(MediaType.TEXT_PLAIN_TYPE).build();

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractClassPropertyValuesProvider.java
@@ -184,8 +184,7 @@ public abstract class AbstractClassPropertyValuesProvider<T> implements ClassPro
         // Oracle databases treat NULL and empty strings similarly. Thus the list passed as parameter can have some
         // elements being NULL (for XWiki string properties which were empty strings). This means we need to check
         // for NULL and ignore NULL entries from the list.
-        if (result instanceof Object[]) {
-            Object[] row = (Object[]) result;
+        if (result instanceof Object[] row) {
             if (row.length > 0 && row[0] != null) {
                 value = new PropertyValue(row[0]);
                 if (row.length > 1 && row[1] != null) {

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractDocumentListClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractDocumentListClassPropertyValuesProvider.java
@@ -149,8 +149,7 @@ public abstract class AbstractDocumentListClassPropertyValuesProvider<T extends 
     protected PropertyValue getValueFromQueryResult(Object result, T propertyDefinition)
     {
         PropertyValue value = super.getValueFromQueryResult(result, propertyDefinition);
-        if (value != null && value.getValue() instanceof DocumentReference) {
-            DocumentReference documentReference = (DocumentReference) value.getValue();
+        if (value != null && value.getValue() instanceof DocumentReference documentReference) {
             WikiReference wikiReference =
                 propertyDefinition.getOwnerDocument().getDocumentReference().getWikiReference();
             // Serialize the document reference relative to the wiki were the property is defined.

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/DefaultClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/DefaultClassPropertyValuesProvider.java
@@ -93,8 +93,8 @@ public class DefaultClassPropertyValuesProvider implements ClassPropertyValuesPr
             XWikiDocument document = xcontext.getWiki().getDocument(propertyReference.getParent(), xcontext);
             BaseClass xclass = document.getXClass();
             PropertyInterface xproperty = xclass.get(propertyReference.getName());
-            if (xproperty instanceof PropertyClass) {
-                return ((PropertyClass) xproperty).getClassType();
+            if (xproperty instanceof PropertyClass propertyClass) {
+                return propertyClass.getClassType();
             } else {
                 throw new XWikiRestException(String.format("No such property [%s].",
                     this.entityReferenceSerializer.serialize(propertyReference)));


### PR DESCRIPTION
Fixes 34 SonarCloud [java:S6201](https://rules.sonarsource.com/java/RSPEC-6201) findings ("Replace this instanceof check and cast with pattern matching for instanceof") by binding a pattern variable and removing the redundant cast/local declaration.

Modules touched (all mechanical, behaviour-preserving conversions):
* `xwiki-platform-rest-server` — 8
* `xwiki-platform-chart-renderer` — 6
* `xwiki-platform-filter-stream-xar` — 6
* `xwiki-platform-mail-send-default` — 5
* `xwiki-platform-mentions-default` — 5
* `xwiki-platform-office-importer` — 4

SonarCloud issues for the rule: https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS6201&issueStatuses=OPEN

The 6 affected modules build cleanly (`mvn clean install` with `-DskipTests`, Checkstyle + Spoon run).

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7BovemqWq4vcyKjiVYACZ)_