### PR TITLE
[Misc] Use pattern matching for instanceof in various leaf modules (SonarCloud java:S6201)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-multi/src/main/java/org/xwiki/component/internal/ComponentCreatedListener.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-multi/src/main/java/org/xwiki/component/internal/ComponentCreatedListener.java
@@ -83,8 +83,8 @@ public class ComponentCreatedListener extends AbstractEventListener
     {
         ComponentManager componentManager = provider.get();
 
-        if (componentManager instanceof AbstractEntityComponentManager) {
-            ((AbstractEntityComponentManager) componentManager).onComponentAdded();
+        if (componentManager instanceof AbstractEntityComponentManager entityComponentManager) {
+            entityComponentManager.onComponentAdded();
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-multi/src/main/java/org/xwiki/component/internal/DocumentDeletedListener.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-multi/src/main/java/org/xwiki/component/internal/DocumentDeletedListener.java
@@ -82,9 +82,9 @@ public class DocumentDeletedListener implements EventListener
         ComponentManager componentManager =
             this.componentManagerManager.getComponentManager(new DocumentNamespace(document).serialize(), false);
 
-        if (componentManager instanceof Disposable) {
+        if (componentManager instanceof Disposable disposable) {
             try {
-                ((Disposable) componentManager).dispose();
+                disposable.dispose();
             } catch (ComponentLifecycleException e) {
                 this.logger.error(String.format("Failed to dispose component manager for document [%s]", document), e);
             }

--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-multi/src/main/java/org/xwiki/component/internal/WikiDeletedListener.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-multi/src/main/java/org/xwiki/component/internal/WikiDeletedListener.java
@@ -82,9 +82,9 @@ public class WikiDeletedListener implements EventListener
         ComponentManager componentManager =
             this.componentManagerManager.getComponentManager(new WikiNamespace(wiki).serialize(), false);
 
-        if (componentManager instanceof Disposable) {
+        if (componentManager instanceof Disposable disposable) {
             try {
-                ((Disposable) componentManager).dispose();
+                disposable.dispose();
             } catch (ComponentLifecycleException e) {
                 this.logger.error(String.format("Failed to dispose component manager for wiki [%s]", wiki), e);
             }

--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/DefaultWikiComponentManagerEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/DefaultWikiComponentManagerEventListener.java
@@ -93,9 +93,8 @@ public class DefaultWikiComponentManagerEventListener extends AbstractEventListe
     @Override
     public void onEvent(Event event, Object source, Object data)
     {
-        if (source instanceof DocumentModelBridge) {
+        if (source instanceof DocumentModelBridge document) {
             // Get the document reference
-            DocumentModelBridge document = (DocumentModelBridge) source;
             DocumentReference documentReference = document.getDocumentReference();
 
             if (event instanceof  DocumentCreatedEvent || event instanceof DocumentUpdatedEvent) {

--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/bridge/DefaultWikiObjectComponentManagerEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/bridge/DefaultWikiObjectComponentManagerEventListener.java
@@ -93,8 +93,8 @@ public class DefaultWikiObjectComponentManagerEventListener extends AbstractEven
     @Override
     public void onEvent(Event event, Object source, Object data)
     {
-        if (event instanceof AbstractDocumentEvent) {
-            handleDocumentEvents((AbstractDocumentEvent) event, (XWikiDocument) source);
+        if (event instanceof AbstractDocumentEvent documentEvent) {
+            handleDocumentEvents(documentEvent, (XWikiDocument) source);
 
             /*
              * If we are at application startup time, we have to instantiate every document or object that we can find

--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/bridge/WikiObjectComponentManagerEventListenerProxy.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/bridge/WikiObjectComponentManagerEventListenerProxy.java
@@ -173,8 +173,8 @@ public class WikiObjectComponentManagerEventListenerProxy
              * the current event and build the components from it.
              */
             List<WikiComponent> wikiComponents;
-            if (componentBuilder instanceof WikiBaseObjectComponentBuilder) {
-                wikiComponents = ((WikiBaseObjectComponentBuilder) componentBuilder).buildComponents(baseObject);
+            if (componentBuilder instanceof WikiBaseObjectComponentBuilder objectComponentBuilder) {
+                wikiComponents = objectComponentBuilder.buildComponents(baseObject);
             } else {
                 wikiComponents = componentBuilder.buildComponents(objectReference);
             }

--- a/xwiki-platform-core/xwiki-platform-container/xwiki-platform-container-servlet/src/main/java/org/xwiki/container/servlet/filters/internal/SavedRequestRestorerFilter.java
+++ b/xwiki-platform-core/xwiki-platform-container/xwiki-platform-container-servlet/src/main/java/org/xwiki/container/servlet/filters/internal/SavedRequestRestorerFilter.java
@@ -228,12 +228,12 @@ public class SavedRequestRestorerFilter implements Filter
     {
         ServletRequest filteredRequest = request;
         // This filter works only for HTTP requests, because they are the only ones with a session.
-        if (request instanceof HttpServletRequest
+        if (request instanceof HttpServletRequest httpRequest
             && !Boolean.valueOf((String) request.getAttribute(ATTRIBUTE_APPLIED))) {
             // Get the saved request, if any (returns null if not applicable)
-            SavedRequest savedRequest = getSavedRequest((HttpServletRequest) request);
+            SavedRequest savedRequest = getSavedRequest(httpRequest);
             // Merge the new and the saved request
-            filteredRequest = new SavedRequestWrapper((HttpServletRequest) request, savedRequest);
+            filteredRequest = new SavedRequestWrapper(httpRequest, savedRequest);
             filteredRequest.setAttribute(ATTRIBUTE_APPLIED, "true");
         }
         // Forward the request

--- a/xwiki-platform-core/xwiki-platform-container/xwiki-platform-container-servlet/src/main/java/org/xwiki/container/servlet/filters/internal/SetHTTPHeaderFilter.java
+++ b/xwiki-platform-core/xwiki-platform-container/xwiki-platform-container-servlet/src/main/java/org/xwiki/container/servlet/filters/internal/SetHTTPHeaderFilter.java
@@ -56,8 +56,7 @@ public class SetHTTPHeaderFilter implements Filter
         throws IOException, ServletException
     {
         // If the response is an HTTP response
-        if (response instanceof HttpServletResponse) {
-            HttpServletResponse httpResponse = (HttpServletResponse) response;
+        if (response instanceof HttpServletResponse httpResponse) {
             // Set the attribute
             httpResponse.addHeader(httpHeaderName, httpHeaderValue);
         }

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/main/java/org/xwiki/display/internal/DocumentContentAsyncExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/main/java/org/xwiki/display/internal/DocumentContentAsyncExecutor.java
@@ -168,11 +168,9 @@ public class DocumentContentAsyncExecutor
     {
         // Traverse the XDOM and adapt all image and heading blocks.
         content.getBlocks(block -> {
-            if (block instanceof ImageBlock) {
-                ImageBlock imageBlock = (ImageBlock) block;
+            if (block instanceof ImageBlock imageBlock) {
                 imageBlock.setId(adaptId(idGenerator, imageBlock.getId()));
-            } else if (block instanceof HeaderBlock) {
-                HeaderBlock headerBlock = (HeaderBlock) block;
+            } else if (block instanceof HeaderBlock headerBlock) {
                 headerBlock.setId(adaptId(idGenerator, headerBlock.getId()));
             }
             return false;

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/main/java/org/xwiki/display/internal/DocumentContentDisplayer.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/main/java/org/xwiki/display/internal/DocumentContentDisplayer.java
@@ -92,7 +92,7 @@ public class DocumentContentDisplayer implements DocumentDisplayer
             // Execute
             Block block = this.executor.execute(renderer, configuration);
 
-            return block instanceof XDOM ? (XDOM) block : new XDOM(Arrays.asList(block));
+            return block instanceof XDOM xdom ? xdom : new XDOM(Arrays.asList(block));
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);
         } finally {

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-api/src/main/java/com/xpn/xwiki/internal/plugin/image/DefaultImageProcessor.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-api/src/main/java/com/xpn/xwiki/internal/plugin/image/DefaultImageProcessor.java
@@ -118,8 +118,8 @@ public class DefaultImageProcessor implements ImageProcessor
     protected int getBestImageTypeFor(Image image)
     {
         int imageType = BufferedImage.TYPE_4BYTE_ABGR;
-        if (image instanceof BufferedImage) {
-            imageType = ((BufferedImage) image).getType();
+        if (image instanceof BufferedImage bufferedImage) {
+            imageType = bufferedImage.getType();
             if (imageType == BufferedImage.TYPE_BYTE_INDEXED || imageType == BufferedImage.TYPE_BYTE_BINARY
                 || imageType == BufferedImage.TYPE_CUSTOM) {
                 // INDEXED and BINARY: GIFs or indexed PNGs may lose their transparent bits, for safety revert to ABGR.

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-api/src/main/java/com/xpn/xwiki/internal/plugin/image/ThumbnailatorImageProcessor.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-api/src/main/java/com/xpn/xwiki/internal/plugin/image/ThumbnailatorImageProcessor.java
@@ -68,8 +68,8 @@ public class ThumbnailatorImageProcessor extends DefaultImageProcessor
     @Override
     public void writeImage(RenderedImage image, String mimeType, float quality, OutputStream out) throws IOException
     {
-        if (image instanceof BufferedImage) {
-            Thumbnails.of((BufferedImage) image).scale(1).outputFormat(getFormatNameForMimeType(mimeType))
+        if (image instanceof BufferedImage bufferedImage) {
+            Thumbnails.of(bufferedImage).scale(1).outputFormat(getFormatNameForMimeType(mimeType))
                 .outputQuality(quality).toOutputStream(out);
         } else {
             super.writeImage(image, mimeType, quality, out);
@@ -79,9 +79,9 @@ public class ThumbnailatorImageProcessor extends DefaultImageProcessor
     @Override
     public RenderedImage scaleImage(Image image, int width, int height)
     {
-        if (image instanceof BufferedImage) {
+        if (image instanceof BufferedImage bufferedImage) {
             try {
-                return Thumbnails.of((BufferedImage) image).forceSize(width, height)
+                return Thumbnails.of(bufferedImage).forceSize(width, height)
                     .imageType(getBestImageTypeFor(image)).asBufferedImage();
             } catch (IOException e) {
                 // If the scaling fails with Thumbnailator, we fall back to the default image processor.

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-observation/src/main/java/org/xwiki/observation/legacy/LegacyEventDispatcher.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-observation/src/main/java/org/xwiki/observation/legacy/LegacyEventDispatcher.java
@@ -96,18 +96,18 @@ public class LegacyEventDispatcher implements EventListener
     @Override
     public void onEvent(Event event, Object source, Object data)
     {
-        if (event instanceof DocumentDeletedEvent) {
+        if (event instanceof DocumentDeletedEvent documentDeletedEvent) {
             this.getObservationManager().notify(
-                new DocumentDeleteEvent(((DocumentDeletedEvent) event).getEventFilter()), source, data);
-        } else if (event instanceof DocumentCreatedEvent) {
-            this.getObservationManager().notify(new DocumentSaveEvent(((DocumentCreatedEvent) event).getEventFilter()),
+                new DocumentDeleteEvent(documentDeletedEvent.getEventFilter()), source, data);
+        } else if (event instanceof DocumentCreatedEvent documentCreatedEvent) {
+            this.getObservationManager().notify(new DocumentSaveEvent(documentCreatedEvent.getEventFilter()),
                 source, data);
-        } else if (event instanceof DocumentUpdatedEvent) {
+        } else if (event instanceof DocumentUpdatedEvent documentUpdatedEvent) {
             this.getObservationManager().notify(
-                new DocumentUpdateEvent(((DocumentUpdatedEvent) event).getEventFilter()), source, data);
-        } else if (event instanceof ActionExecutedEvent) {
+                new DocumentUpdateEvent(documentUpdatedEvent.getEventFilter()), source, data);
+        } else if (event instanceof ActionExecutedEvent actionExecutedEvent) {
             this.getObservationManager().notify(
-                new ActionExecutionEvent(((ActionExecutedEvent) event).getActionName()), source, data);
+                new ActionExecutionEvent(actionExecutedEvent.getActionName()), source, data);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/main/java/org/xwiki/like/internal/CacheHandlingLikeEventsListener.java
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/main/java/org/xwiki/like/internal/CacheHandlingLikeEventsListener.java
@@ -90,8 +90,7 @@ public class CacheHandlingLikeEventsListener extends AbstractEventListener
     @Override
     public void onEvent(Event event, Object source, Object data)
     {
-        if (data instanceof EntityReference) {
-            EntityReference target = (EntityReference) data;
+        if (data instanceof EntityReference target) {
             this.likeManagerProvider.get().clearCache(target);
             this.cleanCacheUIX((WikiReference) target.extractReference(EntityType.WIKI));
         }

--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/main/java/org/xwiki/like/script/LikeScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/main/java/org/xwiki/like/script/LikeScriptService.java
@@ -127,8 +127,7 @@ public class LikeScriptService implements ScriptService
         XWikiContext xWikiContext = this.contextProvider.get();
         DocumentReference currentUser = xWikiContext.getUserReference();
 
-        if (entityReference instanceof DocumentReference) {
-            DocumentReference documentReference = (DocumentReference) entityReference;
+        if (entityReference instanceof DocumentReference documentReference) {
             if (isAuthorized(documentReference)) {
                 UserReference userReference = this.userReferenceResolver.resolve(currentUser);
                 try {
@@ -157,8 +156,7 @@ public class LikeScriptService implements ScriptService
         XWikiContext xWikiContext = this.contextProvider.get();
         DocumentReference currentUser = xWikiContext.getUserReference();
 
-        if (entityReference instanceof DocumentReference) {
-            DocumentReference documentReference = (DocumentReference) entityReference;
+        if (entityReference instanceof DocumentReference documentReference) {
             if (this.isAuthorized(documentReference)) {
                 UserReference userReference = this.userReferenceResolver.resolve(currentUser);
                 try {

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-general/src/main/java/org/xwiki/mail/internal/AddressesConverter.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-general/src/main/java/org/xwiki/mail/internal/AddressesConverter.java
@@ -48,8 +48,8 @@ public class AddressesConverter extends AbstractConverter<Address[]>
             return null;
         }
 
-        if (value instanceof Address[]) {
-            return (Address[]) value;
+        if (value instanceof Address[] addressArray) {
+            return addressArray;
         }
 
         Address[] addresses;

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-general/src/main/java/org/xwiki/mail/internal/configuration/GeneralMailConfigurationUpdatedEventGenerator.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-general/src/main/java/org/xwiki/mail/internal/configuration/GeneralMailConfigurationUpdatedEventGenerator.java
@@ -96,9 +96,7 @@ public class GeneralMailConfigurationUpdatedEventGenerator implements EventListe
     {
         ObservationManager observationManager = this.observationManagerProvider.get();
 
-        if (source instanceof XWikiDocument) {
-            XWikiDocument document = (XWikiDocument) source;
-
+        if (source instanceof XWikiDocument document) {
             // Test that the document is really a mail configuration document.
             LocalDocumentReference localDocumentReference = new LocalDocumentReference(document.getDocumentReference());
             if (!AbstractMailConfigClassDocumentConfigurationSource.MAILCONFIG_REFERENCE
@@ -127,8 +125,8 @@ public class GeneralMailConfigurationUpdatedEventGenerator implements EventListe
 
     private void clearCache(ConfigurationSource mainWikiMailConfigSource)
     {
-        if (mainWikiMailConfigSource instanceof AbstractGeneralMailConfigClassDocumentConfigurationSource) {
-            ((AbstractGeneralMailConfigClassDocumentConfigurationSource) mainWikiMailConfigSource).clearCache();
+        if (mainWikiMailConfigSource instanceof AbstractGeneralMailConfigClassDocumentConfigurationSource config) {
+            config.clearCache();
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/RatingDeletedEntityListener.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/RatingDeletedEntityListener.java
@@ -91,11 +91,9 @@ public class RatingDeletedEntityListener extends AbstractEventListener
         if (event instanceof DocumentDeletedEvent && !this.observationContext.isIn(RENAMING_EVENT)) {
             XWikiDocument sourceDoc = (XWikiDocument) source;
             this.handleDeletedReference(sourceDoc.getDocumentReference());
-        } else if (event instanceof XObjectDeletedEvent) {
-            XObjectDeletedEvent xObjectDeletedEvent = (XObjectDeletedEvent) event;
+        } else if (event instanceof XObjectDeletedEvent xObjectDeletedEvent) {
             this.handleDeletedReference(xObjectDeletedEvent.getReference());
-        } else if (event instanceof WikiDeletedEvent) {
-            WikiDeletedEvent wikiDeletedEvent = (WikiDeletedEvent) event;
+        } else if (event instanceof WikiDeletedEvent wikiDeletedEvent) {
             this.handleDeletedReference(new WikiReference(wikiDeletedEvent.getWikiId()));
         }
     }

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/SolrRatingsManager.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/SolrRatingsManager.java
@@ -584,8 +584,8 @@ public class SolrRatingsManager implements RatingsManager
                 throw new RatingsException(String.format("The reference [%s] is not an existing page.", reference));
             }
         } catch (Exception e) {
-            if (e instanceof RatingsException) {
-                throw (RatingsException) e;
+            if (e instanceof RatingsException ratingsException) {
+                throw ratingsException;
             } else {
                 throw new RatingsException(String.format("An error occurred while checking of [%s] exists", reference),
                     e);

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentStore.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentStore.java
@@ -468,8 +468,7 @@ public class FilesystemAttachmentStore implements XWikiAttachmentStoreInterface
             // If the store supports deleting in the same transaction then do it.
             final AttachmentVersioningStore avs = context.getWiki().getDefaultAttachmentArchiveStore();
 
-            if (avs instanceof FilesystemAttachmentVersioningStore) {
-                final FilesystemAttachmentVersioningStore favs = (FilesystemAttachmentVersioningStore) avs;
+            if (avs instanceof FilesystemAttachmentVersioningStore favs) {
                 favs.getArchiveDeleteRunnable(attachment.loadArchive(context)).runIn(this);
             } else {
                 new TransactionRunnable<HibernateTransaction>()

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentVersioningStore.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentVersioningStore.java
@@ -87,8 +87,8 @@ public class FilesystemAttachmentVersioningStore implements AttachmentVersioning
         try {
             return this.loadArchive(attachment, this.fileTools.getAttachmentFileProvider(attachment.getReference()));
         } catch (Exception e) {
-            if (e instanceof XWikiException) {
-                throw (XWikiException) e;
+            if (e instanceof XWikiException xWikiException) {
+                throw xWikiException;
             }
             final Object[] args = { attachment.getFilename(), UNKNOWN_NAME };
             if (attachment.getDoc() != null) {
@@ -156,8 +156,8 @@ public class FilesystemAttachmentVersioningStore implements AttachmentVersioning
         try {
             this.getArchiveSaveRunnable(archive, context).start();
         } catch (Exception e) {
-            if (e instanceof XWikiException) {
-                throw (XWikiException) e;
+            if (e instanceof XWikiException xWikiException) {
+                throw xWikiException;
             }
             final Object[] args = { UNKNOWN_NAME, UNKNOWN_NAME };
             if (archive.getAttachment() != null) {
@@ -209,8 +209,8 @@ public class FilesystemAttachmentVersioningStore implements AttachmentVersioning
             final XWikiAttachmentArchive archive = this.loadArchive(attachment, context, bTransaction);
             this.getArchiveDeleteRunnable(archive).start();
         } catch (Exception e) {
-            if (e instanceof XWikiException) {
-                throw (XWikiException) e;
+            if (e instanceof XWikiException xWikiException) {
+                throw xWikiException;
             }
             final Object[] args = { attachment.getFilename(), UNKNOWN_NAME };
             if (attachment.getDoc() != null) {


### PR DESCRIPTION
Replace `instanceof` checks followed by an explicit cast with `instanceof` pattern matching (Java 16+), as flagged by SonarCloud rule [java:S6201](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS6201&rule_key=java%3AS6201).

This clears 32 open `java:S6201` issues across the following leaf modules, which are not covered by any other open SonarCloud PR:

* `xwiki-platform-component-multi`
* `xwiki-platform-component-wiki`
* `xwiki-platform-container-servlet`
* `xwiki-platform-display-api`
* `xwiki-platform-image-processing-api`
* `xwiki-platform-legacy-observation`
* `xwiki-platform-like-api`
* `xwiki-platform-mail-general`
* `xwiki-platform-ratings-api`
* `xwiki-platform-store-filesystem-oldcore`

All changes are behaviour-preserving. Casts outside the pattern variable's flow scope were left untouched. Verified with `mvn clean install` (Checkstyle + Spoon) on all 10 modules.

SonarCloud rule: https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS6201&rule_key=java%3AS6201

---
_Generated by [Claude Code](https://claude.ai/code/session_01KtMoqiZiXuMTxH5oq2PnaX)_