### PR TITLE
[Misc] Use Stream.toList() instead of collect(Collectors.toList()) in Live Data (SonarCloud java:S6204)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataMeta.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataMeta.java
@@ -136,7 +136,7 @@ public class LiveDataMeta implements InitializableLiveDataElement
      */
     public void setLayouts(Collection<LiveDataLayoutDescriptor> layouts)
     {
-        this.layouts = layouts;
+        this.layouts = layouts == null ? null : new ArrayList<>(layouts);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataPaginationConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataPaginationConfiguration.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.livedata;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -83,7 +84,7 @@ public class LiveDataPaginationConfiguration implements InitializableLiveDataEle
      */
     public void setPageSizes(List<Integer> pageSizes)
     {
-        this.pageSizes = pageSizes;
+        this.pageSizes = pageSizes == null ? null : new ArrayList<>(pageSizes);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataQuery.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataQuery.java
@@ -532,7 +532,7 @@ public class LiveDataQuery implements InitializableLiveDataElement
      */
     public void setProperties(List<String> properties)
     {
-        this.properties = properties;
+        this.properties = properties == null ? null : new ArrayList<>(properties);
     }
 
     /**
@@ -568,7 +568,7 @@ public class LiveDataQuery implements InitializableLiveDataElement
      */
     public void setFilters(List<Filter> filters)
     {
-        this.filters = filters;
+        this.filters = filters == null ? null : new ArrayList<>(filters);
     }
 
     /**
@@ -586,7 +586,7 @@ public class LiveDataQuery implements InitializableLiveDataElement
      */
     public void setSort(List<SortEntry> sort)
     {
-        this.sort = sort;
+        this.sort = sort == null ? null : new ArrayList<>(sort);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/DefaultLiveDataConfigurationResolver.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/DefaultLiveDataConfigurationResolver.java
@@ -27,7 +27,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -178,7 +177,7 @@ public class DefaultLiveDataConfigurationResolver implements LiveDataConfigurati
                     .filter(baseConfigLayout -> Objects.equals(baseConfigLayout.getId(), configLayout.getId()))
                     .findFirst()
                     .orElse(configLayout))
-                .collect(Collectors.toList()));
+                .toList());
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/LiveDataRendererConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/LiveDataRendererConfiguration.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
@@ -127,7 +126,7 @@ public class LiveDataRendererConfiguration
         if (properties == null) {
             return null;
         } else {
-            return getSplitStringStream(properties).collect(Collectors.toList());
+            return getSplitStringStream(properties).toList();
         }
     }
 
@@ -157,7 +156,7 @@ public class LiveDataRendererConfiguration
             return getSplitStringStream(sort)
                 .filter(StringUtils::isNotEmpty)
                 .map(this::getSortEntry)
-                .collect(Collectors.toList());
+                .toList();
         }
     }
 
@@ -177,7 +176,7 @@ public class LiveDataRendererConfiguration
     {
         List<LiveDataQuery.Filter> filters =
             getURLParameters('?' + StringUtils.defaultString(filtersString)).entrySet().stream()
-                .map(this::getFilter).collect(Collectors.toList());
+                .map(this::getFilter).toList();
         return filters.isEmpty() ? null : filters;
     }
 
@@ -186,7 +185,7 @@ public class LiveDataRendererConfiguration
         LiveDataQuery.Filter filter = new LiveDataQuery.Filter();
         filter.setProperty(entry.getKey());
         filter.getConstraints()
-            .addAll(entry.getValue().stream().map(LiveDataQuery.Constraint::new).collect(Collectors.toList()));
+            .addAll(entry.getValue().stream().map(LiveDataQuery.Constraint::new).toList());
         return filter;
     }
 
@@ -214,7 +213,7 @@ public class LiveDataRendererConfiguration
         } else {
             return getSplitStringStream(parameters.getLayouts())
                 .map(LiveDataLayoutDescriptor::new)
-                .collect(Collectors.toList());
+                .toList();
         }
     }
 
@@ -225,7 +224,7 @@ public class LiveDataRendererConfiguration
         if (parameters.getPageSizes() != null) {
             pagination.setPageSizes(getSplitStringStream(parameters.getPageSizes())
                 .map(Integer::parseInt)
-                .collect(Collectors.toList()));
+                .toList());
         }
         return pagination;
     }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/DefaultLiveDataConfigurationResolver.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/DefaultLiveDataConfigurationResolver.java
@@ -147,7 +147,7 @@ public class DefaultLiveDataConfigurationResolver extends AbstractLiveDataConfig
         if (query.getSort() != null) {
             // Remove the sort entry if we couldn't find a default sort property.
             query.setSort(query.getSort().stream().filter(Objects::nonNull)
-                .filter(sortEntry -> !StringUtils.isEmpty(sortEntry.getProperty())).collect(Collectors.toList()));
+                .filter(sortEntry -> !StringUtils.isEmpty(sortEntry.getProperty())).toList());
         }
     }
 
@@ -174,7 +174,7 @@ public class DefaultLiveDataConfigurationResolver extends AbstractLiveDataConfig
             .map(LiveDataPropertyDescriptor::getId).collect(Collectors.toSet());
         List<LiveDataPropertyDescriptor> missingDescriptors =
             properties.stream().filter(property -> !propertiesWithDescriptor.contains(property))
-                .map(this::getDefaultPropertyDescriptor).collect(Collectors.toList());
+                .map(this::getDefaultPropertyDescriptor).toList();
         if (!missingDescriptors.isEmpty()) {
             propertyDescriptors = new ArrayList<>(propertyDescriptors);
             propertyDescriptors.addAll(missingDescriptors);

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataConfigurationResolver.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataConfigurationResolver.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -209,7 +208,7 @@ public class LiveTableLiveDataConfigurationResolver implements LiveDataConfigura
                         Filter filter = new Filter();
                         filter.setProperty(entry.getKey());
                         filter.getConstraints()
-                            .addAll(entry.getValue().stream().map(Constraint::new).collect(Collectors.toList()));
+                            .addAll(entry.getValue().stream().map(Constraint::new).toList());
                         filters.add(filter);
                     } else if (entry.getValue().size() == 1) {
                         // Convert to a live data source parameter.

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStore.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStore.java
@@ -206,7 +206,7 @@ public class LiveTableLiveDataPropertyStore extends WithParameters implements Li
                         "value", item,
                         "label", getRightTranslationWithFallback(item)
                     ))
-                    .collect(Collectors.toList()));
+                    .toList());
             } else {
                 filterList.setParameter("searchURL", getSearchURL(xproperty));
             }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableRequestHandler.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableRequestHandler.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
@@ -207,7 +206,7 @@ public class LiveTableRequestHandler
                     stream = Stream.of(entry.getValue());
                 }
                 List<String> values =
-                    stream.filter(Objects::nonNull).map(Object::toString).collect(Collectors.toList());
+                    stream.filter(Objects::nonNull).map(Object::toString).toList();
                 if (!values.isEmpty()) {
                     requestParams.put(entry.getKey(), values.toArray(new String[values.size()]));
                 }
@@ -219,10 +218,10 @@ public class LiveTableRequestHandler
     {
         if (query.getSort() != null && !query.getSort().isEmpty()) {
             List<String> sortList =
-                query.getSort().stream().map(SortEntry::getProperty).collect(Collectors.toList());
+                query.getSort().stream().map(SortEntry::getProperty).toList();
             requestParams.put("sort", sortList.toArray(new String[sortList.size()]));
             List<String> dirList = query.getSort().stream().map(sortEntry -> sortEntry.isDescending() ? "desc" : "asc")
-                .collect(Collectors.toList());
+                .toList();
             requestParams.put("dir", dirList.toArray(new String[dirList.size()]));
         }
     }
@@ -230,7 +229,7 @@ public class LiveTableRequestHandler
     private void addFilterRequestParameters(Filter filter, Map<String, String[]> requestParams)
     {
         List<String> values = filter.getConstraints().stream().filter(Objects::nonNull).map(Constraint::getValue)
-            .filter(Objects::nonNull).map(Object::toString).collect(Collectors.toList());
+            .filter(Objects::nonNull).map(Object::toString).toList();
         if (!values.isEmpty()) {
             requestParams.put(filter.getProperty(), values.toArray(new String[values.size()]));
             requestParams.put(filter.getProperty() + "/join_mode", new String[] {filter.isMatchAll() ? "AND" : "OR"});
@@ -238,7 +237,7 @@ public class LiveTableRequestHandler
             List<String> matchType = filter.getConstraints().stream()
                 .map(constraint -> constraint == null ? null : constraint.getOperator())
                 .map(operator -> operator == null ? "" : MATCH_TYPE.getOrDefault(operator, operator))
-                .collect(Collectors.toList());
+                .toList();
             requestParams.put(filter.getProperty() + "_match", matchType.toArray(new String[matchType.size()]));
 
             // Add a value to the empty fields since otherwise they are dismissed by LiveTableResultMacros.

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataEntriesResource.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataEntriesResource.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -113,7 +112,7 @@ public class DefaultLiveDataEntriesResource extends AbstractLiveDataResource imp
     {
         LiveDataQuery query = new LiveDataQuery();
         query.setSource(getLiveDataQuerySource(sourceId));
-        query.setProperties(properties.stream().filter(StringUtils::isNotEmpty).collect(Collectors.toList()));
+        query.setProperties(properties.stream().filter(StringUtils::isNotEmpty).toList());
         query.setFilters(getFilters(matchAll));
         query.setSort(getSort(sort, descending));
         query.setOffset(offset);
@@ -177,7 +176,7 @@ public class DefaultLiveDataEntriesResource extends AbstractLiveDataResource imp
 
         List<Entry> entries = liveData.getEntries().stream()
             .map(values -> this.createEntry(values, values.get(idProperty), source, namespace))
-            .collect(Collectors.toList());
+            .toList();
         return (Entries) new Entries().withEntries(entries).withCount(liveData.getCount()).withLinks(self, parent);
     }
 
@@ -186,10 +185,10 @@ public class DefaultLiveDataEntriesResource extends AbstractLiveDataResource imp
     {
         // Workaround for https://github.com/restlet/restlet-framework-java/issues/922 (JaxRs multivalue
         // query-params gives list with null element).
-        List<String> actualProperties = properties.stream().filter(Objects::nonNull).collect(Collectors.toList());
-        List<String> actualMatchAll = matchAll.stream().filter(Objects::nonNull).collect(Collectors.toList());
-        List<String> actualSort = sort.stream().filter(Objects::nonNull).collect(Collectors.toList());
-        List<Boolean> actualDescending = descending.stream().filter(Objects::nonNull).collect(Collectors.toList());
+        List<String> actualProperties = properties.stream().filter(Objects::nonNull).toList();
+        List<String> actualMatchAll = matchAll.stream().filter(Objects::nonNull).toList();
+        List<String> actualSort = sort.stream().filter(Objects::nonNull).toList();
+        List<Boolean> actualDescending = descending.stream().filter(Objects::nonNull).toList();
         return getConfig(sourceId, actualProperties, actualMatchAll, actualSort, actualDescending, offset, limit);
     }
 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataPropertiesResource.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataPropertiesResource.java
@@ -23,7 +23,6 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
@@ -74,7 +73,7 @@ public class DefaultLiveDataPropertiesResource extends AbstractLiveDataResource 
 
         List<PropertyDescriptor> properties = propertyDescriptors.stream()
             .map(propertyDescriptor -> createPropertyType(propertyDescriptor, source, namespace))
-            .collect(Collectors.toList());
+            .toList();
         return (Properties) new Properties().withProperties(properties).withLinks(self, parent);
     }
 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataPropertyTypesResource.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataPropertyTypesResource.java
@@ -22,7 +22,6 @@ package org.xwiki.livedata.internal.rest;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
@@ -72,7 +71,7 @@ public class DefaultLiveDataPropertyTypesResource extends AbstractLiveDataResour
                 namespace, source.getParameters());
 
         List<PropertyDescriptor> types = propertyTypes.stream()
-            .map(propertyType -> createPropertyType(propertyType, source, namespace)).collect(Collectors.toList());
+            .map(propertyType -> createPropertyType(propertyType, source, namespace)).toList();
         return (Types) new Types().withTypes(types).withLinks(self, parent);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataSourcesResource.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataSourcesResource.java
@@ -22,7 +22,6 @@ package org.xwiki.livedata.internal.rest;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
@@ -53,7 +52,7 @@ public class DefaultLiveDataSourcesResource extends AbstractLiveDataResource imp
             Link self = new Link().withRel(Relations.SELF).withHref(this.uriInfo.getAbsolutePath().toString());
 
             List<Source> sources = sourceIds.get().stream().map(this::getLiveDataQuerySource)
-                .map(querySource -> createSource(querySource, namespace)).collect(Collectors.toList());
+                .map(querySource -> createSource(querySource, namespace)).toList();
             return (Sources) new Sources().withSources(sources).withLinks(self);
         } else {
             throw new WebApplicationException(Response.Status.NOT_FOUND);


### PR DESCRIPTION
Replaces `Stream.collect(Collectors.toList())` with `Stream.toList()` across the Live Data `api`, `rest` and `livetable` modules (25 occurrences in 10 files), and removes the now-unused `Collectors` imports.

`Stream.toList()` returns an unmodifiable list, whereas `Collectors.toList()` returns a mutable `ArrayList`. Each converted site was checked to confirm the resulting list is only ever read (returned, iterated, `isEmpty`/`size`/`get`/`toArray`, or used as an `addAll` source) or passed into a setter/constructor that does not mutate it — so the switch is behaviour-preserving.

Fixes SonarCloud rule [java:S6204](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS6204&rule_key=java%3AS6204) issues, e.g.:
- https://sonarcloud.io/project/issues?open=&id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS6204

Build (Checkstyle + Spoon) verified green for the three affected modules.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4nr9A8GaBcMahozxnNcNM)_