### PR TITLE
[Misc] Simplify code flagged by SonarCloud

### DIFF
--- a/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-default/src/main/java/org/xwiki/export/pdf/internal/chrome/ChromeManagerProvider.java
+++ b/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-default/src/main/java/org/xwiki/export/pdf/internal/chrome/ChromeManagerProvider.java
@@ -60,7 +60,7 @@ public class ChromeManagerProvider implements Provider<BrowserManager>, Disposab
     @Override
     public BrowserManager get()
     {
-        return this.instances.computeIfAbsent(this.wikiDescriptorManager.getCurrentWikiId(), (wikiId) -> {
+        return this.instances.computeIfAbsent(this.wikiDescriptorManager.getCurrentWikiId(), wikiId -> {
             return this.chromeManagerManagerProvider.get();
         }).get();
     }

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/notify/PropertyChangedRule.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/notify/PropertyChangedRule.java
@@ -83,18 +83,10 @@ public class PropertyChangedRule extends DocChangeRule {
         for (int i = 0; i < vobj1.size(); i++) {
             if (!((vobj1.get(i) == null) && (vobj2.get(i) == null))) {
                 if (vobj1.get(i) == null) {
-                    if (((BaseObject)vobj2.get(i)).safeget(propertyName) == null) {
-                        return true;
-                    } else {
-                        return false;
-                    }
+                    return ((BaseObject)vobj2.get(i)).safeget(propertyName) == null;
                 }
                 if (vobj2.get(i) == null) {
-                    if (((BaseObject)vobj1.get(i)).safeget(propertyName) == null) {
-                        return true;
-                    } else {
-                        return false;
-                    }
+                    return ((BaseObject)vobj1.get(i)).safeget(propertyName) == null;
                 }
                 BaseProperty prop1 = 
                     (BaseProperty) ((BaseObject)vobj1.get(i)).safeget(propertyName);

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/EntityReference.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/EntityReference.java
@@ -656,11 +656,7 @@ public class EntityReference implements Serializable, Cloneable, Comparable<Enti
             currentReference2 = currentReference2.getParent();
         }
 
-        if (currentReference2 == null || to.isAllowedAncestor(currentReference2.getType())) {
-            return true;
-        }
-
-        return false;
+        return currentReference2 == null || to.isAllowedAncestor(currentReference2.getType());
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/DefaultDocumentReferenceProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/DefaultDocumentReferenceProviderTest.java
@@ -61,7 +61,7 @@ class DefaultDocumentReferenceProviderTest implements TestConstants
         when(this.entityProvider.getDefaultReference(EntityType.DOCUMENT)).thenReturn(DEFAULT_DOCUMENT_REFERENCE);
         when(this.spaceProvider.get())
             .thenReturn(new SpaceReference(DEFAULT_SPACE_REFERENCE.appendParent(DEFAULT_WIKI_REFERENCE)));
-        when(this.entityReferenceFactory.getReference(any())).thenAnswer((invocation) -> invocation.getArgument(0));
+        when(this.entityReferenceFactory.getReference(any())).thenAnswer(invocation -> invocation.getArgument(0));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/DefaultPageReferenceProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/DefaultPageReferenceProviderTest.java
@@ -60,7 +60,7 @@ class DefaultPageReferenceProviderTest implements TestConstants
     {
         when(this.entityProvider.getDefaultReference(EntityType.PAGE)).thenReturn(DEFAULT_PAGE_REFERENCE);
         when(this.wikiReferenceProvider.get()).thenReturn(new WikiReference(DEFAULT_WIKI_REFERENCE));
-        when(this.entityReferenceFactory.getReference(any())).thenAnswer((invocation) -> invocation.getArgument(0));
+        when(this.entityReferenceFactory.getReference(any())).thenAnswer(invocation -> invocation.getArgument(0));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/DefaultSpaceReferenceProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/DefaultSpaceReferenceProviderTest.java
@@ -60,7 +60,7 @@ class DefaultSpaceReferenceProviderTest implements TestConstants
     {
         when(this.entityProvider.getDefaultReference(EntityType.SPACE)).thenReturn(DEFAULT_SPACE_REFERENCE);
         when(this.wikiReferenceProvider.get()).thenReturn(new WikiReference(DEFAULT_WIKI_REFERENCE));
-        when(this.entityReferenceFactory.getReference(any())).thenAnswer((invocation) -> invocation.getArgument(0));
+        when(this.entityReferenceFactory.getReference(any())).thenAnswer(invocation -> invocation.getArgument(0));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/DefaultWikiReferenceProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/DefaultWikiReferenceProviderTest.java
@@ -53,7 +53,7 @@ class DefaultWikiReferenceProviderTest implements TestConstants
     void beforeEach()
     {
         when(this.entityProvider.getDefaultReference(EntityType.WIKI)).thenReturn(DEFAULT_WIKI_REFERENCE);
-        when(this.entityReferenceFactory.getReference(any())).thenAnswer((invocation) -> invocation.getArgument(0));
+        when(this.entityReferenceFactory.getReference(any())).thenAnswer(invocation -> invocation.getArgument(0));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -4043,11 +4043,7 @@ public class XWiki implements EventListener
         map.put(XWikiUser.ACTIVE_PROPERTY, "1");
         map.put(XWikiUsersDocumentInitializer.FIRST_NAME_FIELD, xwikiname);
 
-        if (createUser(xwikiname, map, userRights, context) == 1) {
-            return true;
-        } else {
-            return false;
-        }
+        return createUser(xwikiname, map, userRights, context) == 1;
     }
 
     public void sendConfirmationEmail(String xwikiname, String password, String email, String message,

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
@@ -2291,11 +2291,7 @@ public class Document extends Api
     {
         try {
             XWikiLock lock = this.doc.getLock(getXWikiContext());
-            if (lock != null && !getXWikiContext().getUser().equals(lock.getUserName())) {
-                return true;
-            } else {
-                return false;
-            }
+            return lock != null && !getXWikiContext().getUser().equals(lock.getUserName());
         } catch (Exception e) {
             return false;
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiAttachment.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiAttachment.java
@@ -1304,11 +1304,7 @@ public class XWikiAttachment implements Cloneable
     public boolean isImage(XWikiContext context)
     {
         String contenttype = getMimeType(context);
-        if (contenttype.startsWith("image/")) {
-            return true;
-        } else {
-            return false;
-        }
+        return contenttype.startsWith("image/");
     }
 
     public XWikiAttachment getAttachmentRevision(String rev, XWikiContext context) throws XWikiException

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -5018,15 +5018,11 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
 
         // Datas
 
-        if (!equalsData(doc)) {
-            return false;
-        }
-
         // We consider that 2 documents are still equal even when they have different original
         // documents (see getOriginalDocument() for more details as to what is an original
         // document).
 
-        return true;
+        return equalsData(doc);
     }
 
     /**
@@ -8281,11 +8277,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
             }
         }
 
-        if (HTML_TAG_PATTERN.matcher(content2).find()) {
-            return true;
-        }
-
-        return false;
+        return HTML_TAG_PATTERN.matcher(content2).find();
     }
 
     public boolean isProgrammaticContent()

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseObject.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseObject.java
@@ -341,11 +341,7 @@ public class BaseObject extends BaseCollection<BaseObjectReference> implements O
             return false;
         }
 
-        if (getNumber() != ((BaseObject) obj).getNumber()) {
-            return false;
-        }
-
-        return true;
+        return getNumber() == ((BaseObject) obj).getNumber();
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
@@ -515,11 +515,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
             return false;
         }
 
-        if (!getNameField().equals(bclass.getNameField())) {
-            return false;
-        }
-
-        return true;
+        return getNameField().equals(bclass.getNameField());
     }
 
     public void merge(BaseClass bclass)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
@@ -953,11 +953,8 @@ public class Package
      */
     private boolean documentContainsHistory(DocumentInfo doc)
     {
-        if ((doc.getDoc().getDocumentArchive() == null) || (doc.getDoc().getDocumentArchive().getNodes() == null)
-            || doc.getDoc().getDocumentArchive().getNodes().isEmpty()) {
-            return false;
-        }
-        return true;
+        return doc.getDoc().getDocumentArchive() != null && doc.getDoc().getDocumentArchive().getNodes() != null
+            && !doc.getDoc().getDocumentArchive().getNodes().isEmpty();
     }
 
     private List<String> getStringList(String name, XWikiContext context)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/stats/impl/XWikiStats.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/stats/impl/XWikiStats.java
@@ -199,11 +199,7 @@ public class XWikiStats extends BaseCollection
             return false;
         }
 
-        if (getNumber() != ((BaseCollection) obj).getNumber()) {
-            return false;
-        }
-
-        return true;
+        return getNumber() == ((BaseCollection) obj).getNumber();
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyPersistentLoginManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyPersistentLoginManager.java
@@ -547,11 +547,8 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
     @Override
     public boolean rememberingLogin(HttpServletRequest request)
     {
-        if ("true".equals(getCookieValue(request.getCookies(), getCookiePrefix() + COOKIE_REMEMBERME, DEFAULT_VALUE))) {
-            return true;
-        } else {
-            return false;
-        }
+        return "true".equals(
+            getCookieValue(request.getCookies(), getCookiePrefix() + COOKIE_REMEMBERME, DEFAULT_VALUE));
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/util/Util.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/util/Util.java
@@ -727,12 +727,8 @@ public class Util
      */
     public static boolean isValidXMLElementName(String elementName)
     {
-        if (elementName == null || elementName.isEmpty() || elementName.matches("(?i)^(xml).*")
-            || !elementName.matches("(^[a-zA-Z\\_]+[\\w\\.\\-]*$)")) {
-            return false;
-        }
-
-        return true;
+        return elementName != null && !elementName.isEmpty() && !elementName.matches("(?i)^(xml).*")
+            && elementName.matches("(^[a-zA-Z\\_]+[\\w\\.\\-]*$)");
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/PreviewAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/PreviewAction.java
@@ -119,10 +119,7 @@ public class PreviewAction extends EditAction
             return false;
         }
         // CSRF prevention
-        if (!csrfTokenCheck(context, true)) {
-            return false;
-        }
-        return true;
+        return csrfTokenCheck(context, true);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/test/MockitoOldcore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/test/MockitoOldcore.java
@@ -384,7 +384,7 @@ public class MockitoOldcore
         // Make sure to provide a EntityReferenceFactory
         if (!getMocker().hasComponent(EntityReferenceFactory.class)) {
             EntityReferenceFactory factory = getMocker().registerMockComponent(EntityReferenceFactory.class);
-            when(factory.getReference(any())).thenAnswer((invocation) -> invocation.getArgument(0));
+            when(factory.getReference(any())).thenAnswer(invocation -> invocation.getArgument(0));
         }
 
         // Make sure a default ConfigurationSource is available

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/src/main/java/org/xwiki/rest/model/jaxb/MapAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/src/main/java/org/xwiki/rest/model/jaxb/MapAdapter.java
@@ -63,7 +63,7 @@ public class MapAdapter extends XmlAdapter<Map, java.util.Map<String, java.lang.
             return null;
         } else {
             java.util.Map<String, java.lang.Object> output = new HashMap<>();
-            input.getEntries().forEach((entry) -> output.put(entry.getKey(), entry.getValue()));
+            input.getEntries().forEach(entry -> output.put(entry.getKey(), entry.getValue()));
             return output;
         }
     }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/BaseAttachmentsResource.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/BaseAttachmentsResource.java
@@ -337,7 +337,7 @@ public class BaseAttachmentsResource extends XWikiResource
         // * the media type is stored (which means it was already filtered at the query level) or
         // * the file name matches the filter or
         // * the computed media type matches the filter
-        return (attachment) -> acceptedMediaTypes.isEmpty() || !StringUtils.isEmpty(attachment.getMimeType())
+        return attachment -> acceptedMediaTypes.isEmpty() || !StringUtils.isEmpty(attachment.getMimeType())
             || hasAcceptedFileNameExtension(attachment, acceptedFileNameExtensions)
             || hasAcceptedMediaType(attachment, acceptedMediaTypes);
     }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/group/DefaultGroupManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/group/DefaultGroupManagerTest.java
@@ -128,10 +128,10 @@ class DefaultGroupManagerTest
 
         WikiDescriptorManager wikiManager = this.oldcore.getWikiDescriptorManager();
 
-        when(wikiManager.getAllIds()).thenAnswer((invocation) -> {
+        when(wikiManager.getAllIds()).thenAnswer(invocation -> {
             return wikis;
         });
-        when(wikiManager.getCurrentWikiId()).thenAnswer((invocation) -> {
+        when(wikiManager.getCurrentWikiId()).thenAnswer(invocation -> {
             return oldcore.getXWikiContext().getWikiId();
         });
 


### PR DESCRIPTION
## Description

Fixes a batch of 24 mechanical, behaviour-preserving SonarCloud issues across 7 modules:

* **`java:S1126`** — *Replace this if-then-else statement by a single return statement* (15 issues): collapsed `if (cond) { return true; } else { return false; }` (and equivalent `equals()`-style shapes) into a single `return` expression, applying De Morgan where the condition was negated.
* **`java:S1611`** — *Remove redundant parentheses around lambda parameters* (9 issues): `(x) -> ...` → `x -> ...`.

No behaviour change. All 7 affected modules build and their tests pass locally
(`mvn clean install -Plegacy,snapshot`).

### SonarCloud rules

* https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS1126&rule_key=java%3AS1126
* https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS1611&rule_key=java%3AS1611

### Modules touched

xwiki-platform-oldcore, xwiki-platform-legacy-oldcore, xwiki-platform-model-api,
xwiki-platform-export-pdf-default, xwiki-platform-rest-model, xwiki-platform-rest-server,
xwiki-platform-user-default


---
_Generated by [Claude Code](https://claude.ai/code/session_016uByJQGeSn1MuftxSNS5DF)_