### PR TITLE
[Misc] Fix various SonarCloud issues (modifier order and redundant varargs array creation)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/internal/DefaultAnnotationService.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/internal/DefaultAnnotationService.java
@@ -87,9 +87,9 @@ public class DefaultAnnotationService implements AnnotationService
             // skip these fields as we don't want to overwrite them with whatever is in this map. Setters should be used
             // for these values or constructor
             Collection<String> skippedFields =
-                Arrays.asList(new String[] {Annotation.SELECTION_FIELD, Annotation.SELECTION_LEFT_CONTEXT_FIELD,
+                Arrays.asList(Annotation.SELECTION_FIELD, Annotation.SELECTION_LEFT_CONTEXT_FIELD,
                     Annotation.SELECTION_RIGHT_CONTEXT_FIELD, Annotation.ORIGINAL_SELECTION_FIELD,
-                    Annotation.AUTHOR_FIELD, Annotation.STATE_FIELD});
+                    Annotation.AUTHOR_FIELD, Annotation.STATE_FIELD);
             for (Map.Entry<String, Object> field : metadata.entrySet()) {
                 if (!skippedFields.contains(field.getKey())) {
                     annotation.set(field.getKey(), field.getValue());

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/SingleAnnotationRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/SingleAnnotationRESTResource.java
@@ -143,9 +143,9 @@ public class SingleAnnotationRESTResource extends AbstractAnnotationRESTResource
             // skip these fields as we don't want to overwrite them with whatever is in this map. Setters should be used
             // for these values or constructor
             Collection<String> skippedFields =
-                Arrays.asList(new String[] {Annotation.SELECTION_FIELD, Annotation.SELECTION_LEFT_CONTEXT_FIELD,
+                Arrays.asList(Annotation.SELECTION_FIELD, Annotation.SELECTION_LEFT_CONTEXT_FIELD,
                     Annotation.SELECTION_RIGHT_CONTEXT_FIELD, Annotation.ORIGINAL_SELECTION_FIELD,
-                    Annotation.AUTHOR_FIELD, Annotation.STATE_FIELD});
+                    Annotation.AUTHOR_FIELD, Annotation.STATE_FIELD);
 
             for (Map.Entry<String, Object> field : annotationMetaData.entrySet()) {
                 if (!skippedFields.contains(field.getKey())) {

--- a/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/source/table/DocumentTableBlockDataSource.java
+++ b/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/source/table/DocumentTableBlockDataSource.java
@@ -120,7 +120,7 @@ public class DocumentTableBlockDataSource extends AbstractTableBlockDataSource
         List<TableBlock> tableBlocks = xdom.getBlocks(new ClassBlockMatcher(TableBlock.class), Block.Axes.DESCENDANT);
         TableBlock result = null;
         this.logger.debug("Table id is [{}], there are [{}] tables in the document [{}]",
-            new Object[]{this.tableId, tableBlocks.size(), this.documentReference});
+            this.tableId, tableBlocks.size(), this.documentReference);
         if (null != tableId) {
             for (TableBlock tableBlock : tableBlocks) {
                 String id = tableBlock.getParameter("id");

--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/ObjectMethodsProxy.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/ObjectMethodsProxy.java
@@ -50,7 +50,7 @@ public final class ObjectMethodsProxy
         try {
             if (method.equals(Object.class.getMethod("hashCode"))) {
                 return proxyHashCode(proxy);
-            } else if (method.equals(Object.class.getMethod("equals", new Class[] {Object.class}))) {
+            } else if (method.equals(Object.class.getMethod("equals", Object.class))) {
                 return proxyEquals(proxy, args[0]);
             } else if (method.equals(Object.class.getMethod("toString"))) {
                 return proxyToString(proxy);

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/notify/DocChangeRule.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/notify/DocChangeRule.java
@@ -74,7 +74,7 @@ public class DocChangeRule implements XWikiNotificationRule
         } catch (Exception e) {
             // protect from bad listeners
             LOGGER.error("Failed to notify target [{}] for event [{}], newdoc = [{}], olddoc = [{}]",
-                new Object[] {getTarget(), this, newdoc, olddoc, e});
+                getTarget(), this, newdoc, olddoc, e);
         }
     }
 
@@ -90,7 +90,7 @@ public class DocChangeRule implements XWikiNotificationRule
         } catch (Exception e) {
             // protect from bad listeners
             LOGGER.error("Failed to notify target [{}] for pre event [{}], newdoc = [{}], olddoc = [{}]",
-                new Object[] {getTarget(), this, newdoc, olddoc, e});
+                getTarget(), this, newdoc, olddoc, e);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/notify/XWikiActionRule.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/notify/XWikiActionRule.java
@@ -79,7 +79,7 @@ public class XWikiActionRule implements XWikiNotificationRule
         } catch (Throwable e) {
             // protect from bad listeners
             LOGGER.error("Failed to notify target [{}] for event [{}], doc = [{}], action = [{}]",
-                new Object[] {getTarget(), this, doc, action, e});
+                getTarget(), this, doc, action, e);
         }
     }
 
@@ -92,7 +92,7 @@ public class XWikiActionRule implements XWikiNotificationRule
         } catch (Throwable e) {
             // protect from bad listeners
             LOGGER.error("Failed to notify target [{}] for pre event [{}], doc = [{}], action = [{}]",
-                new Object[] {getTarget(), this, doc, action, e});
+                getTarget(), this, doc, action, e);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/plugin/query/OrderClause.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/plugin/query/OrderClause.java
@@ -22,9 +22,9 @@ package com.xpn.xwiki.plugin.query;
 @Deprecated
 public class OrderClause
 {
-    public final static int ASC = 1;
+    public static final int ASC = 1;
 
-    public final static int DESC = 2;
+    public static final int DESC = 2;
 
     private String property;
 

--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-wiki/src/main/java/org/xwiki/localization/wiki/internal/DocumentTranslationBundleFactory.java
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-wiki/src/main/java/org/xwiki/localization/wiki/internal/DocumentTranslationBundleFactory.java
@@ -89,7 +89,7 @@ public class DocumentTranslationBundleFactory implements TranslationBundleFactor
     /**
      * The identifier of this {@link TranslationBundleFactory}.
      */
-    public final static String ID = "document";
+    public static final String ID = "document";
 
     /**
      * The prefix to use in all wiki document based translations.

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/CachedFilterPreferencesModelBridgeTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/CachedFilterPreferencesModelBridgeTest.java
@@ -56,11 +56,11 @@ import static org.mockito.Mockito.when;
 @ComponentTest
 class CachedFilterPreferencesModelBridgeTest
 {
-    private final static DocumentReference USER = new DocumentReference("wiki", "XWiki", "User");
+    private static final DocumentReference USER = new DocumentReference("wiki", "XWiki", "User");
 
-    private final static String USER_STRING = "wiki:XWiki.User";
+    private static final String USER_STRING = "wiki:XWiki.User";
 
-    private final static WikiReference WIKI = new WikiReference("wiki");
+    private static final WikiReference WIKI = new WikiReference("wiki");
 
     @InjectMockComponents
     private CachedFilterPreferencesModelBridge cachedModelBridge;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -6204,7 +6204,7 @@ public class XWiki implements EventListener
                     LOGGER.debug("Using custom URLFactory Service Class [{}]", urlFactoryServiceClass);
                 }
                 factoryService = (XWikiURLFactoryService) Class.forName(urlFactoryServiceClass)
-                    .getConstructor(new Class<?>[] { XWiki.class }).newInstance(new Object[] { this });
+                    .getConstructor(XWiki.class).newInstance(this);
             } catch (Exception e) {
                 LOGGER.warn("Failed to initialize URLFactory Service [{}]", urlFactoryServiceClass, e);
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiAttachment.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiAttachment.java
@@ -1037,7 +1037,7 @@ public class XWikiAttachment implements Cloneable
             return getAttachment_archive().getVersions();
         } catch (Exception ex) {
             LOGGER.warn("Cannot retrieve versions of attachment [{}@{}]: {}",
-                new Object[] {getFilename(), getDoc().getDocumentReference(), ex.getMessage()});
+                getFilename(), getDoc().getDocumentReference(), ex.getMessage());
             return new Version[] {new Version(this.getVersion())};
         }
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/export/html/HtmlPackager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/export/html/HtmlPackager.java
@@ -480,7 +480,7 @@ public class HtmlPackager
 
             // Don't include vm and LESS files by default
             FileFilter filter =
-                new NotFileFilter(new SuffixFileFilter(new String[]{ ".vm", ".less", "skin.properties" }));
+                new NotFileFilter(new SuffixFileFilter(".vm", ".less", "skin.properties"));
 
             addDirToZip(file, filter, out, "skins" + ZIPPATH_SEPARATOR + skinName + ZIPPATH_SEPARATOR,
                 exportedSkinFiles);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/DocumentInfo.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/DocumentInfo.java
@@ -43,25 +43,25 @@ public class DocumentInfo
 
     private int fileType;
 
-    public final static int TYPE_SAMPLE = 0;
+    public static final int TYPE_SAMPLE = 0;
 
-    public final static int TYPE_NORMAL = 1;
+    public static final int TYPE_NORMAL = 1;
 
-    public final static int ACTION_NOT_DEFINED = -1;
+    public static final int ACTION_NOT_DEFINED = -1;
 
-    public final static int ACTION_OVERWRITE = 0;
+    public static final int ACTION_OVERWRITE = 0;
 
-    public final static int ACTION_SKIP = 1;
+    public static final int ACTION_SKIP = 1;
 
-    public final static int ACTION_MERGE = 2;
+    public static final int ACTION_MERGE = 2;
 
-    public final static int INSTALL_IMPOSSIBLE = 0;
+    public static final int INSTALL_IMPOSSIBLE = 0;
 
-    public final static int INSTALL_ALREADY_EXIST = 1;
+    public static final int INSTALL_ALREADY_EXIST = 1;
 
-    public final static int INSTALL_OK = 2;
+    public static final int INSTALL_OK = 2;
 
-    public final static int INSTALL_ERROR = 4;
+    public static final int INSTALL_ERROR = 4;
 
     public DocumentInfo(XWikiDocument doc)
     {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/rightsmanager/RightsManagerGroupsApi.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/rightsmanager/RightsManagerGroupsApi.java
@@ -151,7 +151,7 @@ public class RightsManagerGroupsApi extends Api
                 RightsManager.getInstance().countAllWikiUsersOrGroups(false, wikiName,
                     RightsManagerPluginApi.createMatchingTable(matchFields), this.context);
         } catch (RightsManagerException e) {
-            logError(MessageFormat.format("Try to count all groups in wiki [{0}]", new Object[] { wikiName }), e);
+            logError(MessageFormat.format("Try to count all groups in wiki [{0}]", wikiName), e);
         }
 
         return count;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/rightsmanager/RightsManagerPluginApi.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/rightsmanager/RightsManagerPluginApi.java
@@ -212,7 +212,7 @@ public class RightsManagerPluginApi extends PluginApi<RightsManagerPlugin>
         try {
             memberList = RightsManager.getInstance().getAllGroupsNamesForMember(member, 0, 0, this.context);
         } catch (RightsManagerException e) {
-            logError(MessageFormat.format("Try to get all groups containing user [{0}]", new Object[] { member }), e);
+            logError(MessageFormat.format("Try to get all groups containing user [{0}]", member), e);
 
             memberList = Collections.emptyList();
         }
@@ -272,7 +272,7 @@ public class RightsManagerPluginApi extends PluginApi<RightsManagerPlugin>
                 RightsManager.getInstance().getAllMatchedMembersNamesForGroup(group, matchField, nb, start, orderAsc,
                     this.context);
         } catch (RightsManagerException e) {
-            logError(MessageFormat.format("Try to get all matched member of group [{0}]", new Object[] { group }), e);
+            logError(MessageFormat.format("Try to get all matched member of group [{0}]", group), e);
 
             memberList = Collections.emptyList();
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/rightsmanager/RightsManagerRightsApi.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/rightsmanager/RightsManagerRightsApi.java
@@ -98,7 +98,7 @@ public class RightsManagerRightsApi extends Api
             parent = convert(xdoc);
         } catch (RightsManagerException e) {
             logError(
-                MessageFormat.format("Try to get parent rights preference for [{0}]", new Object[] { spaceOrPage }), e);
+                MessageFormat.format("Try to get parent rights preference for [{0}]", spaceOrPage), e);
         }
 
         return parent;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/rightsmanager/RightsManagerUsersApi.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/rightsmanager/RightsManagerUsersApi.java
@@ -151,7 +151,7 @@ public class RightsManagerUsersApi extends Api
                 RightsManager.getInstance().countAllWikiUsersOrGroups(true, wikiName,
                     RightsManagerPluginApi.createMatchingTable(matchFields), this.context);
         } catch (RightsManagerException e) {
-            logError(MessageFormat.format("Try to count all users in wiki [{0}]", new Object[] { wikiName }), e);
+            logError(MessageFormat.format("Try to count all users in wiki [{0}]", wikiName), e);
         }
 
         return count;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/script/sheet/SheetScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/script/sheet/SheetScriptService.java
@@ -224,7 +224,7 @@ public class SheetScriptService implements ScriptService
         try {
             // HACK: We try to get the modifiable XWikiDocument instance wrapped by the document API using reflection
             // because the corresponding method that clones the wrapped XWikiDocument instance is protected.
-            Method getDocMethod = Document.class.getDeclaredMethod("getDoc", new Class[] {});
+            Method getDocMethod = Document.class.getDeclaredMethod("getDoc");
             getDocMethod.setAccessible(true);
             return (DocumentModelBridge) getDocMethod.invoke(document);
         } catch (Exception e) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SkinAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SkinAction.java
@@ -146,7 +146,7 @@ public class SkinAction extends XWikiAction
         String defaultbaseskin = xwiki.getDefaultBaseSkin(context);
 
         LOGGER.debug("document: [{}] ; baseskin: [{}] ; defaultbaseskin: [{}]",
-            new Object[] { doc.getDocumentReference(), baseskin, defaultbaseskin });
+            doc.getDocumentReference(), baseskin, defaultbaseskin);
 
         // Since we don't know exactly what does the URL point at, meaning that we don't know where the skin identifier
         // ends and where the path to the file starts, we must try to split at every '/' character.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/includeservletasstring/IncludeServletAsString.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/includeservletasstring/IncludeServletAsString.java
@@ -40,7 +40,7 @@ public class IncludeServletAsString
     {
     }
 
-    static public String invokeServletAndReturnAsString(String url, HttpServletRequest servletRequest,
+    public static String invokeServletAndReturnAsString(String url, HttpServletRequest servletRequest,
         HttpServletResponse servletResponse) throws IOException, ServletException
     {
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/LevelsClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/LevelsClassTest.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.when;
  */
 class LevelsClassTest
 {
-    private final static List<String> DEFAULT_LIST = Arrays.asList(
+    private static final List<String> DEFAULT_LIST = Arrays.asList(
         "admin",
         "programming",
         "edit",

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/include/IncludeMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/include/IncludeMacroTest.java
@@ -103,9 +103,9 @@ import static org.xwiki.rendering.test.integration.junit5.BlockAssert.assertBloc
 @AllComponents(excludes = {CurrentMacroEntityReferenceResolver.class, DefaultAuthorizationManager.class})
 class IncludeMacroTest
 {
-    private final static DocumentReference INCLUDER_AUTHOR = new DocumentReference("wiki", "XWiki", "includer");
+    private static final DocumentReference INCLUDER_AUTHOR = new DocumentReference("wiki", "XWiki", "includer");
 
-    private final static DocumentReference INCLUDED_AUTHOR = new DocumentReference("wiki", "XWiki", "included");
+    private static final DocumentReference INCLUDED_AUTHOR = new DocumentReference("wiki", "XWiki", "included");
 
     private static final DocumentReference INCLUDED_PAGE = new DocumentReference("wiki", "Space", "IncludedPage");
 

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/test/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroFactoryTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/test/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroFactoryTest.java
@@ -81,7 +81,7 @@ import static org.mockito.Mockito.when;
 @ComponentList(DefaultWikiMacro.class)
 class DefaultWikiMacroFactoryTest
 {
-    private final static DocumentReference DOCUMENT_REFERENCE = new DocumentReference("xwiki", "Macros", "Test");
+    private static final DocumentReference DOCUMENT_REFERENCE = new DocumentReference("xwiki", "Macros", "Test");
 
     private BaseObject macroObject;
 

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/RightTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/RightTest.java
@@ -40,7 +40,7 @@ class RightTest
 {
     static class FooRight implements RightDescription
     {
-        final static String NAME = "foo";
+        static final String NAME = "foo";
 
         @Override
         public String getName()

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/test/java/org/xwiki/security/authorization/testwikibuilding/AbstractTestWiki.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/test/java/org/xwiki/security/authorization/testwikibuilding/AbstractTestWiki.java
@@ -50,7 +50,7 @@ import com.xpn.xwiki.XWikiContext;
 public abstract class AbstractTestWiki
 {
     /** The subdirectory in the classpath were the test wiki definitions will be found. */
-    private final static String TEST_WIKI_DEFINITIONS_DIRECTORY = "testwikis";
+    private static final String TEST_WIKI_DEFINITIONS_DIRECTORY = "testwikis";
 
     /** The wiki description that is currently being parsed and built. */
     private HasWikiContents currentWiki;

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/sx/SxDocumentSource.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/sx/SxDocumentSource.java
@@ -112,8 +112,8 @@ public class SxDocumentSource implements SxSource
                     }
                 } catch (Exception ex) {
                     LOGGER.warn("SX object [{}#{}] has an invalid cache policy: [{}]",
-                        new Object[]{this.document.getFullName(), sxObj.getStringValue(NAME_PROPERTY_NAME),
-                            sxObj.getStringValue(CACHE_POLICY_PROPERTY_NAME)});
+                        this.document.getFullName(), sxObj.getStringValue(NAME_PROPERTY_NAME),
+                        sxObj.getStringValue(CACHE_POLICY_PROPERTY_NAME));
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-uiextension/xwiki-platform-uiextension-api/src/test/java/org/xwiki/uiextension/UIExtensionPointFiltersTest.java
+++ b/xwiki-platform-core/xwiki-platform-uiextension/xwiki-platform-uiextension-api/src/test/java/org/xwiki/uiextension/UIExtensionPointFiltersTest.java
@@ -44,19 +44,19 @@ import static org.xwiki.uiextension.UIExtensions.TestUix7value2;
 
 class UIExtensionPointFiltersTest
 {
-    private final static UIExtension TEST_UIX_1_VALUE_Z = new TestUix1valueZ();
+    private static final UIExtension TEST_UIX_1_VALUE_Z = new TestUix1valueZ();
 
-    private final static UIExtension TEST_UIX_2_VALUE_Y = new TestUix2valueY();
+    private static final UIExtension TEST_UIX_2_VALUE_Y = new TestUix2valueY();
 
-    private final static UIExtension TEST_UIX_3_VALUE_X = new TestUix3valueX();
+    private static final UIExtension TEST_UIX_3_VALUE_X = new TestUix3valueX();
 
-    private final static UIExtension TEST_UIX_4_VALUE_W = new TestUix4valueW();
+    private static final UIExtension TEST_UIX_4_VALUE_W = new TestUix4valueW();
 
-    private final static UIExtension TEST_UIX_5_VALUE_1 = new TestUix5value1();
+    private static final UIExtension TEST_UIX_5_VALUE_1 = new TestUix5value1();
 
-    private final static UIExtension TEST_UIX_6_VALUE_11 = new TestUix6value11();
+    private static final UIExtension TEST_UIX_6_VALUE_11 = new TestUix6value11();
 
-    private final static UIExtension TEST_UIX_7_VALUE_2 = new TestUix7value2();
+    private static final UIExtension TEST_UIX_7_VALUE_2 = new TestUix7value2();
 
     public static Stream<Arguments> filterSource()
     {

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/group/GroupsCacheTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/group/GroupsCacheTest.java
@@ -71,15 +71,15 @@ class GroupsCacheTest
 
     private MapCache<GroupCacheEntry> cache = spy(new MapCache<>());
 
-    private final static DocumentReference USER = new DocumentReference("userwiki", "userspace", "userdocument");
+    private static final DocumentReference USER = new DocumentReference("userwiki", "userspace", "userdocument");
 
-    private final static DocumentReference GROUP1 =
+    private static final DocumentReference GROUP1 =
         new DocumentReference("groupwiki1", "groupspace1", "groupdocument1");
 
-    private final static DocumentReference GROUP2 =
+    private static final DocumentReference GROUP2 =
         new DocumentReference("groupwiki2", "groupspace2", "groupdocument2");
 
-    private final static List<String> WIKIS = Arrays.asList("wiki1", "wiki2");
+    private static final List<String> WIKIS = Arrays.asList("wiki1", "wiki2");
 
     @BeforeComponent
     public void beforeComponent() throws CacheException


### PR DESCRIPTION
This clears a batch of mechanical, behaviour-preserving SonarCloud findings across several modules (54 issues, 28 files).

## Rules fixed

* **[java:S1124](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS1124&rule_key=java%3AS1124)** — *Modifiers should be declared in the correct order* (34 issues). Reordered `final static` → `static final` and `static public` → `public static` to comply with the Java Language Specification. Pure syntactic change, no behaviour impact.
* **[java:S3878](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS3878&rule_key=java%3AS3878)** — *Arrays should not be created for varargs parameters* (20 issues). Removed redundant `new Object[]{...}` / `new String[]{...}` / `new Class[]{...}` wrappers when the array was passed straight into a varargs parameter (`MessageFormat.format`, SLF4J loggers, `Arrays.asList`, reflection `getMethod`/`getConstructor`/`newInstance`, varargs constructors). Spreading the elements is equivalent and clearer.

## Verification

Built with `mvn clean install` (Checkstyle + tests, no `-DskipTests`) across all 14 affected modules — **BUILD SUCCESS**, all tests green.

## Notes

* No visibility or public-API change: the S1124 constants were already `public` and stay `public`; no `@since` needed.
* Left out a handful of genuinely ambiguous S3878 sites (e.g. an empty-array delegation that could change overload resolution) and the slow `-feed`/`-solr` modules, to keep this batch safe and cheap.

SonarCloud issue keys: see the linked rules above (organization `xwiki`, project `org.xwiki.platform:xwiki-platform`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HB6QiW4NqCnTpGFNkxs14U)_