### PR TITLE
[Misc] Fix various SonarCloud issues (use instanceof pattern matching)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -630,8 +630,8 @@ public class XWiki implements EventListener
 
     private MutableRenderingContext getMutableRenderingContext()
     {
-        return getRenderingContext() instanceof MutableRenderingContext
-            ? (MutableRenderingContext) getRenderingContext() : null;
+        return getRenderingContext() instanceof MutableRenderingContext mutableRenderingContext
+            ? mutableRenderingContext : null;
     }
 
     private VelocityEvaluator getVelocityEvaluator()
@@ -1166,7 +1166,7 @@ public class XWiki implements EventListener
             ResourceReference reference =
                 resourceResolver.resolve(extendedURL, type, Collections.<String, Object>emptyMap());
             entityResourceReference =
-                reference instanceof EntityResourceReference ? (EntityResourceReference) reference : null;
+                reference instanceof EntityResourceReference entityReference ? entityReference : null;
         } catch (Exception e) {
             throw new XWikiException(XWikiException.MODULE_XWIKI, XWikiException.ERROR_XWIKI_APP_URL_EXCEPTION,
                 String.format("Failed to extract Entity Resource Reference from URL [%s]", url), e);
@@ -1491,8 +1491,8 @@ public class XWiki implements EventListener
     public XWikiStoreInterface getNotCacheStore()
     {
         XWikiStoreInterface store = getStore();
-        if (store instanceof XWikiCacheStoreInterface) {
-            store = ((XWikiCacheStoreInterface) store).getStore();
+        if (store instanceof XWikiCacheStoreInterface cacheStore) {
+            store = cacheStore.getStore();
         }
         return store;
     }
@@ -1500,12 +1500,12 @@ public class XWiki implements EventListener
     public XWikiHibernateStore getHibernateStore()
     {
         XWikiStoreInterface store = getStore();
-        if (store instanceof XWikiHibernateStore) {
-            return (XWikiHibernateStore) store;
-        } else if (store instanceof XWikiCacheStoreInterface) {
-            store = ((XWikiCacheStoreInterface) store).getStore();
-            if (store instanceof XWikiHibernateStore) {
-                return (XWikiHibernateStore) store;
+        if (store instanceof XWikiHibernateStore hibernateStore) {
+            return hibernateStore;
+        } else if (store instanceof XWikiCacheStoreInterface cacheStore) {
+            store = cacheStore.getStore();
+            if (store instanceof XWikiHibernateStore hibernateStore) {
+                return hibernateStore;
             } else {
                 return null;
             }
@@ -1650,8 +1650,8 @@ public class XWiki implements EventListener
             return Class.forName(storeclass).getConstructor(classes).newInstance(args);
         } catch (Exception e) {
             Throwable ecause = e;
-            if (e instanceof InvocationTargetException) {
-                ecause = ((InvocationTargetException) e).getTargetException();
+            if (e instanceof InvocationTargetException invocationTargetException) {
+                ecause = invocationTargetException.getTargetException();
             }
             Object[] args = { param, storeclass };
             throw new XWikiException(XWikiException.MODULE_XWIKI_STORE,
@@ -3040,9 +3040,8 @@ public class XWiki implements EventListener
             if (StringUtils.isEmpty(result)) {
                 if (spaceReference == null) {
                     result = getXWikiPreference(preferenceKey, defaultValue, context);
-                } else if (spaceReference.getParent() instanceof SpaceReference) {
-                    result = getSpacePreference(preferenceKey, (SpaceReference) spaceReference.getParent(),
-                        defaultValue, context);
+                } else if (spaceReference.getParent() instanceof SpaceReference parentSpaceReference) {
+                    result = getSpacePreference(preferenceKey, parentSpaceReference, defaultValue, context);
                 } else if (spaceReference.getParent() instanceof WikiReference) {
                     result =
                         getXWikiPreference(preferenceKey, spaceReference.getParent().getName(), defaultValue, context);
@@ -3905,8 +3904,8 @@ public class XWiki implements EventListener
             PropertyInterface validationKeyClass =
                 getClass(XWikiUsersDocumentInitializer.CLASS_REFERENCE_STRING, context)
                     .get(XWikiUsersDocumentInitializer.VALIDKEY_FIELD);
-            if (validationKeyClass instanceof PasswordClass) {
-                validationKey = ((PasswordClass) validationKeyClass).getEquivalentPassword(storedKey, validationKey);
+            if (validationKeyClass instanceof PasswordClass passwordClass) {
+                validationKey = passwordClass.getEquivalentPassword(storedKey, validationKey);
             }
 
             // Compare the two keys
@@ -4990,8 +4989,8 @@ public class XWiki implements EventListener
 
         Map<EntityReference, EntityReference> updatedReferences =
             Map.of(sourceDoc.getDocumentReference(), newDocumentReference);
-        if (currentJob instanceof AbstractCopyOrMoveJob) {
-            updatedReferences = ((AbstractCopyOrMoveJob) currentJob).getSelectedEntities();
+        if (currentJob instanceof AbstractCopyOrMoveJob copyOrMoveJob) {
+            updatedReferences = copyOrMoveJob.getSelectedEntities();
         }
         // Step 1: Refactor the relative links contained in the document to make sure they are relative to the new
         // document's location.
@@ -5356,8 +5355,8 @@ public class XWiki implements EventListener
 
     private boolean isDaemon(XWikiRequest request)
     {
-        return request.getHttpServletRequest() instanceof XWikiServletRequestStub
-            && ((XWikiServletRequestStub) request.getHttpServletRequest()).isDaemon();
+        return request.getHttpServletRequest() instanceof XWikiServletRequestStub servletRequestStub
+            && servletRequestStub.isDaemon();
     }
 
     private String getWikiProtocol(WikiDescriptor wikiDescriptor)
@@ -7801,15 +7800,15 @@ public class XWiki implements EventListener
     @Override
     public void onEvent(Event event, Object source, Object data)
     {
-        if (event instanceof JobFinishedEvent) {
+        if (event instanceof JobFinishedEvent jobFinishedEvent) {
             // An extension just been initialized (after an install or upgrade for example)
-            onJobFinished((JobFinishedEvent) event);
-        } else if (event instanceof WikiDeletedEvent) {
+            onJobFinished(jobFinishedEvent);
+        } else if (event instanceof WikiDeletedEvent wikiDeletedEvent) {
             // A wiki has been deleted
-            onWikiDeletedEvent((WikiDeletedEvent) event);
-        } else if (event instanceof ComponentDescriptorAddedEvent) {
+            onWikiDeletedEvent(wikiDeletedEvent);
+        } else if (event instanceof ComponentDescriptorAddedEvent componentDescriptorAddedEvent) {
             // A new mandatory document initializer has been installed
-            onMandatoryDocumentInitializerAdded((ComponentDescriptorAddedEvent) event, (ComponentManager) source);
+            onMandatoryDocumentInitializerAdded(componentDescriptorAddedEvent, (ComponentManager) source);
         } else {
             // Document modifications
 
@@ -7864,8 +7863,8 @@ public class XWiki implements EventListener
         ComponentManager componentManager)
     {
         String namespace;
-        if (componentManager instanceof NamespacedComponentManager) {
-            namespace = ((NamespacedComponentManager) componentManager).getNamespace();
+        if (componentManager instanceof NamespacedComponentManager namespacedComponentManager) {
+            namespace = namespacedComponentManager.getNamespace();
         } else {
             namespace = null;
         }
@@ -8098,8 +8097,8 @@ public class XWiki implements EventListener
     {
         ConfigurationSource configuration = getConfiguration();
 
-        if (configuration instanceof XWikiCfgConfigurationSource) {
-            ((XWikiCfgConfigurationSource) configuration).set(config);
+        if (configuration instanceof XWikiCfgConfigurationSource cfgConfigurationSource) {
+            cfgConfigurationSource.set(config);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/PropertyClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/PropertyClass.java
@@ -223,8 +223,8 @@ public class PropertyClass extends Collection implements Comparable<PropertyClas
     public List<String> getListValues()
     {
         com.xpn.xwiki.objects.classes.PropertyClass pclass = getBasePropertyClass();
-        if (pclass instanceof ListClass) {
-            return ((ListClass) pclass).getList(this.context);
+        if (pclass instanceof ListClass listClass) {
+            return listClass.getList(this.context);
         } else {
             // Although we prefer to return empty lists from API methods, here returning any kind of list doesn't make
             // sense, since the property does not have a list of possible values at all (like, a number property).
@@ -242,8 +242,8 @@ public class PropertyClass extends Collection implements Comparable<PropertyClas
     public Map<String, ListItem> getMapValues()
     {
         com.xpn.xwiki.objects.classes.PropertyClass pclass = getBasePropertyClass();
-        if (pclass instanceof ListClass) {
-            return ((ListClass) pclass).getMap(this.context);
+        if (pclass instanceof ListClass listClass) {
+            return listClass.getMap(this.context);
         } else {
             // Although we prefer to return empty maps from API methods, here returning any kind of map doesn't make
             // sense, since the property does not have a list of possible values at all (like, a number property).

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
@@ -990,12 +990,11 @@ public class XWiki extends Api
         if (docs != null) {
             for (java.lang.Object obj : docs) {
                 try {
-                    if (obj instanceof XWikiDocument) {
-                        XWikiDocument doc = (XWikiDocument) obj;
+                    if (obj instanceof XWikiDocument doc) {
                         Document wrappedDoc = doc.newDocument(getXWikiContext());
                         result.add(wrappedDoc);
-                    } else if (obj instanceof Document) {
-                        result.add((Document) obj);
+                    } else if (obj instanceof Document document) {
+                        result.add(document);
                     } else if (obj instanceof String) {
                         Document doc = getDocument(obj.toString());
                         if (doc != null) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/DefaultDocumentAccessBridge.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/DefaultDocumentAccessBridge.java
@@ -167,8 +167,8 @@ public class DefaultDocumentAccessBridge implements DocumentAccessBridge
     {
         XWikiContext xcontext = getContext();
 
-        if (document instanceof XWikiDocument) {
-            return ((XWikiDocument) document).getTranslatedDocument(xcontext);
+        if (document instanceof XWikiDocument xwikiDocument) {
+            return xwikiDocument.getTranslatedDocument(xcontext);
         } else {
             return getTranslatedDocumentInstance(document.getDocumentReference());
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -299,8 +299,8 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         @Override
         public boolean equals(Object obj)
         {
-            if (obj instanceof XWikiAttachmentToRemove) {
-                return this.attachment.equals(((XWikiAttachmentToRemove) obj).getAttachment());
+            if (obj instanceof XWikiAttachmentToRemove attachmentToRemove) {
+                return this.attachment.equals(attachmentToRemove.getAttachment());
             }
 
             return false;
@@ -599,7 +599,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         public List<BaseObject> put(DocumentReference key, List<BaseObject> value)
         {
             // Makes sure to always insert BaseObjects
-            return xObjects.put(key, value instanceof BaseObjects ? (BaseObjects) value : new BaseObjects(value));
+            return xObjects.put(key, value instanceof BaseObjects baseObjects ? baseObjects : new BaseObjects(value));
         }
 
         @Override
@@ -3090,8 +3090,8 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
      */
     public BaseObject getXObject(EntityReference reference)
     {
-        if (reference instanceof DocumentReference) {
-            return getXObject((DocumentReference) reference);
+        if (reference instanceof DocumentReference documentReference) {
+            return getXObject(documentReference);
         } else if (reference.getType() == EntityType.DOCUMENT) {
             // class reference
             return getXObject(
@@ -3170,8 +3170,8 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
      */
     private BaseObjectReference getBaseObjectReference(ObjectReference objectReference)
     {
-        if (objectReference instanceof BaseObjectReference) {
-            return (BaseObjectReference) objectReference;
+        if (objectReference instanceof BaseObjectReference baseObjectReference) {
+            return baseObjectReference;
         } else {
             return new BaseObjectReference(objectReference);
         }
@@ -5919,13 +5919,11 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
 
         for (Object fieldClass : xclass.getProperties()) {
             // Wiki content stored in xobjects
-            if (fieldClass instanceof TextAreaClass && ((TextAreaClass) fieldClass).isWikiContent()) {
-                TextAreaClass textAreaClass = (TextAreaClass) fieldClass;
+            if (fieldClass instanceof TextAreaClass textAreaClass && textAreaClass.isWikiContent()) {
                 PropertyInterface field = xobject.getField(textAreaClass.getName());
 
                 // Make sure the field is the right type (might happen while a document is being migrated)
-                if (field instanceof LargeStringProperty) {
-                    LargeStringProperty largeField = (LargeStringProperty) field;
+                if (field instanceof LargeStringProperty largeField) {
 
                     try {
                         XDOM dom = parseContent(getSyntax(), largeField.getValue(), getDocumentReference());
@@ -8464,8 +8462,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
                 if (currentBlock instanceof SectionBlock) {
                     // The next children block is a HeaderBlock but we check to be on the safe side...
                     Block nextChildrenBlock = currentBlock.getChildren().get(0);
-                    if (nextChildrenBlock instanceof HeaderBlock) {
-                        HeaderBlock headerBlock = (HeaderBlock) nextChildrenBlock;
+                    if (nextChildrenBlock instanceof HeaderBlock headerBlock) {
                         if (headerBlock.getLevel().getAsInt() <= sectionDepth) {
                             filteredHeaders.add(headerBlock);
                         }
@@ -9091,13 +9088,11 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
                 if (bobject != null) {
                     BaseClass bclass = bobject.getXClass(context);
                     for (Object fieldClass : bclass.getProperties()) {
-                        if (fieldClass instanceof TextAreaClass && ((TextAreaClass) fieldClass).isWikiContent()) {
-                            TextAreaClass textAreaClass = (TextAreaClass) fieldClass;
+                        if (fieldClass instanceof TextAreaClass textAreaClass && textAreaClass.isWikiContent()) {
                             PropertyInterface field = bobject.getField(textAreaClass.getName());
 
                             // Make sure the field is the right type (might happen while a document is being migrated)
-                            if (field instanceof LargeStringProperty) {
-                                LargeStringProperty largeField = (LargeStringProperty) field;
+                            if (field instanceof LargeStringProperty largeField) {
 
                                 largeField.setValue(performSyntaxConversion(largeField.getValue(),
                                     getDocumentReference(), getSyntax(), targetSyntax));
@@ -9351,8 +9346,8 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
                         + "replacing it.", classReference, getDocumentReference());
             }
             return relativeXClassReference;
-        } else if (reference instanceof LocalDocumentReference) {
-            return new DocumentReference((LocalDocumentReference) reference, getDocumentReference().getWikiReference());
+        } else if (reference instanceof LocalDocumentReference localDocumentReference) {
+            return new DocumentReference(localDocumentReference, getDocumentReference().getWikiReference());
         } else {
             DocumentReference defaultReference =
                 new DocumentReference(getDocumentReference().getWikiReference().getName(), XWiki.SYSTEM_SPACE,

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/XWikiConfigDelegate.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/XWikiConfigDelegate.java
@@ -44,8 +44,8 @@ public class XWikiConfigDelegate extends XWikiConfig
     {
         this.source = source;
 
-        if (this.source instanceof XWikiCfgConfigurationSource) {
-            this.defaults = ((XWikiCfgConfigurationSource) this.source).getProperties();
+        if (this.source instanceof XWikiCfgConfigurationSource xwikiCfgConfigurationSource) {
+            this.defaults = xwikiCfgConfigurationSource.getProperties();
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/cache/rendering/DefaultRenderingCache.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/cache/rendering/DefaultRenderingCache.java
@@ -167,8 +167,8 @@ public class DefaultRenderingCache implements RenderingCache, Initializable
             for (String pluginName : pluginManager.getPlugins()) {
                 XWikiPluginInterface plugin = pluginManager.getPlugin(pluginName);
 
-                if (plugin instanceof RenderingCacheAware) {
-                    this.legacyRenderingCacheAware.add((RenderingCacheAware) plugin);
+                if (plugin instanceof RenderingCacheAware renderingCacheAware) {
+                    this.legacyRenderingCacheAware.add(renderingCacheAware);
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/converter/DocumentConverter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/converter/DocumentConverter.java
@@ -68,8 +68,8 @@ public class DocumentConverter extends AbstractConverter<Document>
     @Override
     public Document convertToType(Type targetType, Object sourceValue)
     {
-        if (sourceValue instanceof XWikiDocument) {
-            return ((XWikiDocument) sourceValue).newDocument(this.contextProvider.get());
+        if (sourceValue instanceof XWikiDocument document) {
+            return document.newDocument(this.contextProvider.get());
         } else {
             throw new ConversionException(String.format("Unsupported source type [%s]", sourceValue.getClass()));
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/converter/XWikiDocumentConverter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/converter/XWikiDocumentConverter.java
@@ -68,8 +68,8 @@ public class XWikiDocumentConverter extends AbstractConverter<XWikiDocument>
     @Override
     public XWikiDocument convertToType(Type targetType, Object sourceValue)
     {
-        if (sourceValue instanceof Document) {
-            return convertFromDocument((Document) sourceValue);
+        if (sourceValue instanceof Document document) {
+            return convertFromDocument(document);
         } else {
             throw new ConversionException(String.format("Unsupported source type [%s]", sourceValue.getClass()));
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/display/XWikiDocumentContentAsyncParser.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/display/XWikiDocumentContentAsyncParser.java
@@ -46,9 +46,7 @@ public class XWikiDocumentContentAsyncParser implements DocumentContentAsyncPars
     @Override
     public AsyncProperties getAsyncProperties(DocumentModelBridge document)
     {
-        if (document instanceof XWikiDocument) {
-            XWikiDocument xdocument = (XWikiDocument) document;
-
+        if (document instanceof XWikiDocument xdocument) {
             BaseObject asyncObject = xdocument.getXObject(DocumentAsyncClassDocumentInitializer.CLASS_REFERENCE);
             if (asyncObject != null) {
                 boolean asyncAllowed =

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/doc/ListAttachmentArchive.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/doc/ListAttachmentArchive.java
@@ -201,8 +201,8 @@ public class ListAttachmentArchive extends XWikiAttachmentArchive
         try {
             return this.toRCS(context).toByteArray();
         } catch (Exception e) {
-            if (e instanceof XWikiException) {
-                throw (XWikiException) e;
+            if (e instanceof XWikiException xwikiException) {
+                throw xwikiException;
             }
             Object[] args = {getAttachment().getFilename()};
             throw new XWikiException(XWikiException.MODULE_XWIKI_STORE,
@@ -221,8 +221,8 @@ public class ListAttachmentArchive extends XWikiAttachmentArchive
                 final Archive rcsArchive = new Archive(getAttachment().getFilename(), is);
                 super.setRCSArchive(rcsArchive);
             } catch (Exception e) {
-                if (e instanceof XWikiException) {
-                    throw (XWikiException) e;
+                if (e instanceof XWikiException xwikiException) {
+                    throw xwikiException;
                 }
                 Object[] args = {getAttachment().getFilename()};
                 throw new XWikiException(XWikiException.MODULE_XWIKI_STORE,

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/AbstractEntityEvent.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/AbstractEntityEvent.java
@@ -64,7 +64,7 @@ public abstract class AbstractEntityEvent implements EntityEvent
             return true;
         }
 
-        return otherEvent instanceof EntityEvent && matchesReference(((EntityEvent) otherEvent).getReference());
+        return otherEvent instanceof EntityEvent entityEvent && matchesReference(entityEvent.getReference());
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/export/DocumentSelectionResolver.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/export/DocumentSelectionResolver.java
@@ -370,8 +370,8 @@ public class DocumentSelectionResolver
     {
         Set<DocumentReference> excludedDocumentReferences = new LinkedHashSet<>();
         exclusions.forEach(excludedEntityReference -> {
-            if (excludedEntityReference instanceof DocumentReference) {
-                excludedDocumentReferences.add((DocumentReference) excludedEntityReference);
+            if (excludedEntityReference instanceof DocumentReference documentReference) {
+                excludedDocumentReferences.add(documentReference);
             }
         });
         return excludedDocumentReferences;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/AbstractEntityOutputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/AbstractEntityOutputFilterStream.java
@@ -315,8 +315,8 @@ public abstract class AbstractEntityOutputFilterStream<E> implements EntityOutpu
         Object reference = get(Object.class, key, parameters, def, false, false);
 
         if (reference != null && !(reference instanceof UserReference)) {
-            if (reference instanceof DocumentReference) {
-                userReference = this.userDocumentResolver.resolve((DocumentReference) reference);
+            if (reference instanceof DocumentReference documentReference) {
+                userReference = this.userDocumentResolver.resolve(documentReference);
             } else {
                 userReference = this.userDocumentResolver.resolve(toUserDocumentReference(reference));
             }
@@ -343,9 +343,9 @@ public abstract class AbstractEntityOutputFilterStream<E> implements EntityOutpu
     {
         DocumentReference userDocumentReference;
 
-        if (reference instanceof EntityReference) {
+        if (reference instanceof EntityReference entityReference) {
             userDocumentReference =
-                this.userEntityResolver.resolve((EntityReference) reference, this.currentEntityReference != null
+                this.userEntityResolver.resolve(entityReference, this.currentEntityReference != null
                     ? this.currentEntityReference.extractReference(EntityType.WIKI) : null);
         } else {
             userDocumentReference =

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/XWikiAttachmentOutputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/XWikiAttachmentOutputFilterStream.java
@@ -171,8 +171,8 @@ public class XWikiAttachmentOutputFilterStream extends AbstractEntityOutputFilte
         throws FilterException
     {
         if (source != null) {
-            if (source instanceof InputStreamInputSource) {
-                try (InputStreamInputSource streamSource = (InputStreamInputSource) source) {
+            if (source instanceof InputStreamInputSource streamSource) {
+                try (streamSource) {
                     attachment.setContent(streamSource.getInputStream());
                 } catch (IOException e) {
                     throw new FilterException("Failed to set attachment content", e);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/model/reference/AbstractCompleteEntityReferenceConverter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/model/reference/AbstractCompleteEntityReferenceConverter.java
@@ -69,8 +69,8 @@ public abstract class AbstractCompleteEntityReferenceConverter<R extends EntityR
 
         EntityReference result;
 
-        if (value instanceof EntityReference) {
-            result = this.referenceResolver.resolve((EntityReference) value, this.type);
+        if (value instanceof EntityReference entityReference) {
+            result = this.referenceResolver.resolve(entityReference, this.type);
         } else {
             result = this.stringResolver.resolve(value.toString(), this.type);
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/model/reference/CompactStringEntityReferenceSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/model/reference/CompactStringEntityReferenceSerializer.java
@@ -140,9 +140,8 @@ public class CompactStringEntityReferenceSerializer extends DefaultStringEntityR
     protected EntityReference resolveDefaultReference(EntityType type, Object... parameters)
     {
         EntityReference resolvedDefaultReference = null;
-        if (parameters.length > 0 && parameters[0] instanceof EntityReference) {
+        if (parameters.length > 0 && parameters[0] instanceof EntityReference referenceParameter) {
             // Try to extract the type from the passed parameter.
-            EntityReference referenceParameter = (EntityReference) parameters[0];
             EntityReference extractedReference = referenceParameter.extractReference(type);
             if (extractedReference != null) {
                 resolvedDefaultReference = extractedReference;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/model/reference/CurrentMixedReferenceDocumentReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/model/reference/CurrentMixedReferenceDocumentReferenceResolver.java
@@ -51,8 +51,8 @@ public class CurrentMixedReferenceDocumentReferenceResolver implements DocumentR
     @Override
     public DocumentReference resolve(EntityReference documentReferenceRepresentation, Object... parameters)
     {
-        if (documentReferenceRepresentation instanceof DocumentReference) {
-            return (DocumentReference) documentReferenceRepresentation;
+        if (documentReferenceRepresentation instanceof DocumentReference documentReference) {
+            return documentReference;
         }
 
         return new DocumentReference(this.entityReferenceResolver.resolve(documentReferenceRepresentation,

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/model/reference/CurrentReferenceDocumentReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/model/reference/CurrentReferenceDocumentReferenceResolver.java
@@ -51,8 +51,8 @@ public class CurrentReferenceDocumentReferenceResolver implements DocumentRefere
     @Override
     public DocumentReference resolve(EntityReference documentReferenceRepresentation, Object... parameters)
     {
-        if (documentReferenceRepresentation instanceof DocumentReference) {
-            return (DocumentReference) documentReferenceRepresentation;
+        if (documentReferenceRepresentation instanceof DocumentReference documentReference) {
+            return documentReference;
         }
 
         return new DocumentReference(this.entityReferenceResolver.resolve(documentReferenceRepresentation,

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/model/reference/CurrentReferencePageReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/model/reference/CurrentReferencePageReferenceResolver.java
@@ -51,8 +51,8 @@ public class CurrentReferencePageReferenceResolver implements PageReferenceResol
     @Override
     public PageReference resolve(EntityReference pageReferenceRepresentation, Object... parameters)
     {
-        if (pageReferenceRepresentation instanceof PageReference) {
-            return (PageReference) pageReferenceRepresentation;
+        if (pageReferenceRepresentation instanceof PageReference pageReference) {
+            return pageReference;
         }
 
         return new PageReference(

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/model/reference/CurrentWikiReferenceProvider.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/model/reference/CurrentWikiReferenceProvider.java
@@ -50,7 +50,6 @@ public class CurrentWikiReferenceProvider implements Provider<WikiReference>
     {
         EntityReference wikiReference = this.provider.getDefaultReference(EntityType.WIKI);
 
-        return wikiReference instanceof WikiReference ? (WikiReference) wikiReference
-            : new WikiReference(wikiReference);
+        return wikiReference instanceof WikiReference wikiRef ? wikiRef : new WikiReference(wikiReference);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/model/reference/DocumentReferenceConverter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/model/reference/DocumentReferenceConverter.java
@@ -70,8 +70,8 @@ public class DocumentReferenceConverter extends AbstractConverter<DocumentRefere
         DocumentReference result;
         if (value == null) {
             result = null;
-        } else if (value instanceof EntityReference) {
-            result = this.referenceResolver.resolve((EntityReference) value);
+        } else if (value instanceof EntityReference entityReference) {
+            result = this.referenceResolver.resolve(entityReference);
         } else {
             Converter<Object> converter = this.converterManager.getConverter(value.getClass());
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/model/reference/XClassRelativeStringEntityReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/model/reference/XClassRelativeStringEntityReferenceResolver.java
@@ -64,9 +64,8 @@ public class XClassRelativeStringEntityReferenceResolver extends AbstractStringE
         // We allow to pass a page reference in parameter. If the passed representation doesn't contain a page then the
         // page from the parameter will be used.
         EntityReference explicitReference = new EntityReference("XWiki", EntityType.SPACE);
-        if (parameters.length > 0 && (parameters[0] instanceof EntityReference)) {
-            EntityReference extractedPageReference =
-                ((EntityReference) parameters[0]).extractReference(EntityType.DOCUMENT);
+        if (parameters.length > 0 && parameters[0] instanceof EntityReference entityReference) {
+            EntityReference extractedPageReference = entityReference.extractReference(EntityType.DOCUMENT);
             if (extractedPageReference != null) {
                 explicitReference =
                     new EntityReference(extractedPageReference.getName(), EntityType.DOCUMENT, explicitReference);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/ImplicitlyAllowedValuesDBListQueryBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/ImplicitlyAllowedValuesDBListQueryBuilder.java
@@ -137,7 +137,7 @@ public class ImplicitlyAllowedValuesDBListQueryBuilder implements QueryBuilder<D
         spec.idField = StringUtils.defaultString(dbListClass.getIdField());
         spec.valueField = StringUtils.defaultString(dbListClass.getValueField());
         spec.parentField =
-            dbListClass instanceof DBTreeListClass ? ((DBTreeListClass) dbListClass).getParentField() : "";
+            dbListClass instanceof DBTreeListClass dbTreeListClass ? dbTreeListClass.getParentField() : "";
 
         spec.hasClassName = !StringUtils.isBlank(spec.className);
         spec.hasIdField = !StringUtils.isBlank(spec.idField);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/observation/remote/converter/AbstractXWikiEventConverter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/observation/remote/converter/AbstractXWikiEventConverter.java
@@ -192,9 +192,9 @@ public abstract class AbstractXWikiEventConverter extends AbstractEventConverter
         XWikiDocument origDoc = new XWikiDocument(docReference, origLocale);
 
         // Force invalidating the cache to be sure it returns (and keep) the right document
-        if (xcontext.getWiki().getStore() instanceof XWikiCacheStore) {
-            ((XWikiCacheStore) xcontext.getWiki().getStore()).invalidate(document);
-            ((XWikiCacheStore) xcontext.getWiki().getStore()).invalidate(origDoc);
+        if (xcontext.getWiki().getStore() instanceof XWikiCacheStore cacheStore) {
+            cacheStore.invalidate(document);
+            cacheStore.invalidate(origDoc);
         }
 
         String version = (String) remoteDataMap.get(DOC_VERSION);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/observation/remote/converter/DocumentEventConverter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/observation/remote/converter/DocumentEventConverter.java
@@ -142,8 +142,8 @@ public class DocumentEventConverter extends AbstractXWikiEventConverter
         doc.setOriginalDocument(origDoc);
 
         // Force invalidating the cache to be sure it return (and keep) the right document
-        if (xcontext.getWiki().getStore() instanceof XWikiCacheStore) {
-            ((XWikiCacheStore) xcontext.getWiki().getStore()).invalidate(doc);
+        if (xcontext.getWiki().getStore() instanceof XWikiCacheStore cacheStore) {
+            cacheStore.invalidate(doc);
         }
 
         return doc;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/pdf/FOPXSLFORenderer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/pdf/FOPXSLFORenderer.java
@@ -199,8 +199,8 @@ public class FOPXSLFORenderer implements XSLFORenderer, Initializable
                 }
             }
 
-            if (writableConfiguration instanceof DefaultConfiguration) {
-                extendConfiguration((DefaultConfiguration) writableConfiguration);
+            if (writableConfiguration instanceof DefaultConfiguration defaultConfiguration) {
+                extendConfiguration(defaultConfiguration);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/skin/WikiSkinUtils.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/skin/WikiSkinUtils.java
@@ -180,7 +180,7 @@ public class WikiSkinUtils
 
             if (resourceProperty != null) {
                 Object value = resourceProperty.getValue();
-                if (value instanceof String && StringUtils.isNotEmpty((String) value)) {
+                if (value instanceof String stringValue && StringUtils.isNotEmpty(stringValue)) {
                     return resourceProperty;
                 }
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/template/TemplateAsyncRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/template/TemplateAsyncRenderer.java
@@ -194,7 +194,7 @@ public class TemplateAsyncRenderer extends AbstractBlockAsyncRenderer
     private void transform(Block block) throws TransformationException
     {
         TransformationContext transformationContext =
-            new TransformationContext(block instanceof XDOM ? (XDOM) block : new XDOM(Arrays.asList(block)),
+            new TransformationContext(block instanceof XDOM xdom ? xdom : new XDOM(Arrays.asList(block)),
                 this.renderingContext.getDefaultSyntax(), this.renderingContext.isRestricted());
 
         // Use the Transformation id as the name passed to the Velocity Engine. This name is used internally

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/template/TemplateListener.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/template/TemplateListener.java
@@ -74,8 +74,8 @@ public class TemplateListener extends AbstractEventListener
 
         // Is this a skin document
         if (document.getXObject(WikiSkinUtils.SKINCLASS_REFERENCE) != null) {
-            if (event instanceof AbstractAttachmentEvent) {
-                AttachmentReference attachment = new AttachmentReference(((AbstractAttachmentEvent) event).getName(),
+            if (event instanceof AbstractAttachmentEvent attachmentEvent) {
+                AttachmentReference attachment = new AttachmentReference(attachmentEvent.getName(),
                     document.getDocumentReference());
                 String id = this.referenceSerializer.serialize(attachment);
                 if (event instanceof AttachmentDeletedEvent) {
@@ -83,8 +83,8 @@ public class TemplateListener extends AbstractEventListener
                 } else if (event instanceof AttachmentUpdatedEvent) {
                     this.observation.notify(new TemplateUpdatedEvent(id), this);
                 }
-            } else if (event instanceof XObjectPropertyEvent) {
-                String id = this.referenceSerializer.serialize(((XObjectPropertyEvent) event).getReference());
+            } else if (event instanceof XObjectPropertyEvent propertyEvent) {
+                String id = this.referenceSerializer.serialize(propertyEvent.getReference());
                 if (event instanceof XObjectPropertyDeletedEvent) {
                     this.observation.notify(new TemplateDeletedEvent(id), this);
                 } else if (event instanceof XObjectPropertyUpdatedEvent) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/template/VelocityTemplateEvaluator.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/template/VelocityTemplateEvaluator.java
@@ -86,9 +86,9 @@ public class VelocityTemplateEvaluator
         if (namespace == null) {
             namespace = template.getId() != null ? template.getId() : "unknown namespace";
 
-            if (this.renderingContext instanceof MutableRenderingContext) {
+            if (this.renderingContext instanceof MutableRenderingContext mutableRenderingContext) {
                 // Make the current velocity template id available
-                ((MutableRenderingContext) this.renderingContext).push(this.renderingContext.getTransformation(),
+                mutableRenderingContext.push(this.renderingContext.getTransformation(),
                     this.renderingContext.getXDOM(), this.renderingContext.getDefaultSyntax(), namespace,
                     this.renderingContext.isRestricted(), this.renderingContext.getTargetSyntax());
 
@@ -122,9 +122,7 @@ public class VelocityTemplateEvaluator
     private VelocityTemplate getVelocityTemplate(Template template, TemplateContent content)
         throws XWikiVelocityException
     {
-        if (content instanceof DefaultTemplateContent) {
-            DefaultTemplateContent templateContent = (DefaultTemplateContent) content;
-
+        if (content instanceof DefaultTemplateContent templateContent) {
             // Check if the content already been compiled
             if (!(templateContent.compiledContent instanceof VelocityTemplate)) {
                 // Velocity is not a fan of null template name

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/velocity/DefaultVelocityEvaluator.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/velocity/DefaultVelocityEvaluator.java
@@ -66,9 +66,9 @@ public class DefaultVelocityEvaluator implements VelocityEvaluator
             // Switch current namespace if needed
             String currentNamespace = renderingContext.getTransformationId();
             if (namespace != null && !Strings.CS.equals(namespace, currentNamespace)
-                && renderingContext instanceof MutableRenderingContext) {
+                && renderingContext instanceof MutableRenderingContext mutableRenderingContext) {
                 // Make the current velocity template id available
-                ((MutableRenderingContext) renderingContext).push(renderingContext.getTransformation(),
+                mutableRenderingContext.push(renderingContext.getTransformation(),
                     renderingContext.getXDOM(), renderingContext.getDefaultSyntax(), namespace,
                     renderingContext.isRestricted(), renderingContext.getTargetSyntax());
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseCollection.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseCollection.java
@@ -272,8 +272,8 @@ public abstract class BaseCollection<R extends EntityReference> extends BaseElem
     public void safeput(String name, PropertyInterface property)
     {
         addField(name, property);
-        if (property instanceof BaseProperty) {
-            ((BaseProperty) property).setName(name);
+        if (property instanceof BaseProperty baseProperty) {
+            baseProperty.setName(name);
         }
     }
 
@@ -1011,8 +1011,8 @@ public abstract class BaseCollection<R extends EntityReference> extends BaseElem
 
             for (String propertyName : getPropertyList()) {
                 PropertyInterface property = getField(propertyName);
-                if (property instanceof BaseElement) {
-                    ((BaseElement) property).setOwnerDocument(ownerDocument);
+                if (property instanceof BaseElement baseElement) {
+                    baseElement.setOwnerDocument(ownerDocument);
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseObject.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseObject.java
@@ -507,8 +507,8 @@ public class BaseObject extends BaseCollection<BaseObjectReference> implements O
         PropertyClass pclass = (PropertyClass) bclass.get(fieldname);
         BaseProperty prop = (BaseProperty) safeget(fieldname);
         boolean createProp = false;
-        if ((value instanceof String) && (pclass != null)) {
-            BaseProperty newProp = pclass.fromString((String) value);
+        if ((value instanceof String stringValue) && (pclass != null)) {
+            BaseProperty newProp = pclass.fromString(stringValue);
             if (prop == null) {
                 prop = newProp;
                 createProp = true;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseObjectReference.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseObjectReference.java
@@ -176,8 +176,8 @@ public class BaseObjectReference extends ObjectReference
 
     private DocumentReference resolveClassReference(EntityReference classReference)
     {
-        if (classReference instanceof DocumentReference) {
-            return (DocumentReference) classReference;
+        if (classReference instanceof DocumentReference documentReference) {
+            return documentReference;
         }
 
         return Utils.<DocumentReferenceResolver<EntityReference>>getComponent(DocumentReferenceResolver.TYPE_REFERENCE)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseStringProperty.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseStringProperty.java
@@ -67,8 +67,8 @@ public class BaseStringProperty extends BaseProperty
     {
         // Convert the value to a String, whatever its type.
         String stringValue;
-        if (value instanceof String) {
-            stringValue = (String) value;
+        if (value instanceof String string) {
+            stringValue = string;
         } else {
             stringValue = getConverterManager().convert(String.class, value);
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
@@ -412,8 +412,8 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
             Object formvalues = map.get(name);
             if (formvalues != null) {
                 BaseProperty objprop;
-                if (formvalues instanceof String[]) {
-                    objprop = property.fromStringArray(((String[]) formvalues));
+                if (formvalues instanceof String[] stringArray) {
+                    objprop = property.fromStringArray(stringArray);
                 } else if (formvalues instanceof String) {
                     objprop = property.fromString(formvalues.toString());
                 } else {
@@ -811,8 +811,8 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
 
         TextAreaClass textAreaClass;
         PropertyInterface field = get(fieldName);
-        if (field instanceof TextAreaClass) {
-            textAreaClass = (TextAreaClass) field;
+        if (field instanceof TextAreaClass existingTextAreaClass) {
+            textAreaClass = existingTextAreaClass;
         } else {
             // Remove the field if it already exist
             if (field != null) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/MetaClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/MetaClass.java
@@ -82,9 +82,9 @@ public class MetaClass extends BaseClass
     public void safeput(String name, PropertyInterface property)
     {
         addField(PROPERTY_NAME_PREFIX + name, property);
-        if (property instanceof PropertyClass) {
-            ((PropertyClass) property).setObject(this);
-            ((PropertyClass) property).setName(name);
+        if (property instanceof PropertyClass propertyClass) {
+            propertyClass.setObject(this);
+            propertyClass.setName(name);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/PropertyMetaClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/PropertyMetaClass.java
@@ -185,7 +185,7 @@ public class PropertyMetaClass extends BaseClass implements PropertyMetaClassInt
         } catch (Exception e) {
             // Fail silently.
         }
-        return instance != null && instance instanceof BaseCollection ? (BaseCollection) instance : super
+        return instance != null && instance instanceof BaseCollection baseCollection ? baseCollection : super
             .newObject(context);
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
@@ -326,8 +326,8 @@ public class Package
 
     public void addDocumentFilter(Object filter) throws PackageException
     {
-        if (filter instanceof DocumentFilter) {
-            this.documentFilters.add((DocumentFilter) filter);
+        if (filter instanceof DocumentFilter documentFilter) {
+            this.documentFilters.add(documentFilter);
         } else {
             throw new PackageException(PackageException.ERROR_PACKAGE_INVALID_FILTER, "Invalid Document Filter");
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/DatabaseProduct.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/DatabaseProduct.java
@@ -132,8 +132,7 @@ public final class DatabaseProduct
     public boolean equals(Object object)
     {
         boolean result = false;
-        if (object instanceof DatabaseProduct) {
-            DatabaseProduct product = (DatabaseProduct) object;
+        if (object instanceof DatabaseProduct product) {
             if (product.getProductName().equals(getProductName())) {
                 result = true;
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/query/HqlQueryExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/query/HqlQueryExecutor.java
@@ -168,8 +168,8 @@ public class HqlQueryExecutor extends AbstractQueryExecutor implements Initializ
     protected void checkAllowed(final Query query) throws QueryException
     {
         // Check if the query needs to be validated according to the current author
-        if (query instanceof SecureQuery) {
-            checkAllowed((SecureQuery) query);
+        if (query instanceof SecureQuery secureQuery) {
+            checkAllowed(secureQuery);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/HibernateDataMigrationManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/HibernateDataMigrationManager.java
@@ -230,8 +230,8 @@ public class HibernateDataMigrationManager extends AbstractDataMigrationManager
         // Execute migrations
         if (migrations != null) {
             for (XWikiMigration migration : migrations) {
-                if (migration.dataMigration instanceof HibernateDataMigration) {
-                    liquibaseUpdate((HibernateDataMigration) migration.dataMigration, preHibernate, database);
+                if (migration.dataMigration instanceof HibernateDataMigration hibernateDataMigration) {
+                    liquibaseUpdate(hibernateDataMigration, preHibernate, database);
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R1008010XWIKI10092DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R1008010XWIKI10092DataMigration.java
@@ -91,8 +91,8 @@ public class R1008010XWIKI10092DataMigration extends AbstractHibernateDataMigrat
         // Clean the document cache to make sure the new properties we just added directly to the database are not lost
         // during next save before a version of the document without those properties was already in the cache
         XWikiStoreInterface store = xcontext.getWiki().getStore();
-        if (store instanceof XWikiCacheStoreInterface) {
-            ((XWikiCacheStoreInterface) store).flushCache();
+        if (store instanceof XWikiCacheStoreInterface cacheStore) {
+            cacheStore.flushCache();
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R40000XWIKI6990DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R40000XWIKI6990DataMigration.java
@@ -714,8 +714,8 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
                     fillObjectIdConversion(session, objs);
 
                     // Retrieve custom mapped classes
-                    if (getStore() instanceof XWikiHibernateStore) {
-                        fillCustomMappingMap((XWikiHibernateStore) getStore(), getXWikiContext());
+                    if (getStore() instanceof XWikiHibernateStore xwikiHibernateStore) {
+                        fillCustomMappingMap(xwikiHibernateStore, getXWikiContext());
                     }
 
                     // Retrieve statistics ID conversion

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R72001XWIKI12228DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R72001XWIKI12228DataMigration.java
@@ -120,9 +120,9 @@ public class R72001XWIKI12228DataMigration extends AbstractHibernateDataMigratio
         // Resolve nested spaces
         Set<SpaceReference> spaces = new HashSet<>(databaseSpaces);
         for (SpaceReference space : databaseSpaces) {
-            for (EntityReference parent = space.getParent(); parent instanceof SpaceReference; parent =
+            for (EntityReference parent = space.getParent(); parent instanceof SpaceReference spaceReference; parent =
                 parent.getParent()) {
-                spaces.add((SpaceReference) parent);
+                spaces.add(spaceReference);
             }
         }
 
@@ -141,10 +141,10 @@ public class R72001XWIKI12228DataMigration extends AbstractHibernateDataMigratio
         // Resolve nested spaces
         Set<SpaceReference> spaces = new HashSet<>(databaseSpaces);
         for (SpaceReference space : databaseSpaces) {
-            for (EntityReference parent = space.getParent(); parent instanceof SpaceReference; parent =
+            for (EntityReference parent = space.getParent(); parent instanceof SpaceReference spaceReference; parent =
                 parent.getParent()) {
                 if (!visibleSpaces.contains(parent)) {
-                    spaces.add((SpaceReference) parent);
+                    spaces.add(spaceReference);
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/api/XWikiUser.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/api/XWikiUser.java
@@ -459,9 +459,7 @@ public class XWikiUser
         }
 
         boolean equals;
-        if (obj instanceof XWikiUser) {
-            XWikiUser otherUser = (XWikiUser) obj;
-
+        if (obj instanceof XWikiUser otherUser) {
             equals = otherUser.main == this.main && Objects.equals(getUserReference(), otherUser.getUserReference());
         } else {
             equals = false;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/UploadAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/UploadAction.java
@@ -81,8 +81,7 @@ public class UploadAction extends XWikiAction
         Object exception = context.get("exception");
         boolean ajax = ((Boolean) context.get("ajax")).booleanValue();
         // check Exception File upload is large
-        if (exception != null && exception instanceof AttachmentValidationException) {
-            AttachmentValidationException exp = (AttachmentValidationException) exception;
+        if (exception != null && exception instanceof AttachmentValidationException exp) {
             response.setStatus(exp.getHttpStatus());
             getCurrentScriptContext().setAttribute(MESSAGE, exp.getTranslationKey(), ENGINE_SCOPE);
             getCurrentScriptContext().setAttribute("parameters", exp.getTranslationParameters(), ENGINE_SCOPE);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiAction.java
@@ -807,7 +807,7 @@ public abstract class XWikiAction implements LegacyAction
     {
         RenderingContext renderingContext = Utils.getComponent(RenderingContext.class);
         MutableRenderingContext mutableRenderingContext =
-            renderingContext instanceof MutableRenderingContext ? (MutableRenderingContext) renderingContext : null;
+            renderingContext instanceof MutableRenderingContext mutableContext ? mutableContext : null;
 
         if (mutableRenderingContext != null) {
             mutableRenderingContext.push(renderingContext.getTransformation(), renderingContext.getXDOM(),
@@ -1320,8 +1320,8 @@ public abstract class XWikiAction implements LegacyAction
                 LOGGER.error(logMessage, exception);
             }
         } else {
-            if (exception instanceof XWikiException) {
-                throw (XWikiException) exception;
+            if (exception instanceof XWikiException xwikiException) {
+                throw xwikiException;
             } else {
                 throw new XWikiException(XWikiException.MODULE_XWIKI_APP, XWikiException.ERROR_XWIKI_UNKNOWN,
                     "Uncaught exception", exception);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/internal/velocity/XWikiVelocityManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/internal/velocity/XWikiVelocityManager.java
@@ -118,9 +118,7 @@ public class XWikiVelocityManager extends DefaultVelocityManager implements Init
             @Override
             public void onEvent(Event event, Object source, Object data)
             {
-                if (event instanceof TemplateEvent) {
-                    TemplateEvent templateEvent = (TemplateEvent) event;
-
+                if (event instanceof TemplateEvent templateEvent) {
                     XWikiVelocityManager.this.velocityEngines.remove(templateEvent.getId());
                 }
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/model/internal/document/SafeDocumentAuthors.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/model/internal/document/SafeDocumentAuthors.java
@@ -103,8 +103,8 @@ public class SafeDocumentAuthors extends AbstractWrappingObject<DocumentAuthors>
     @Override
     public boolean equals(Object obj)
     {
-        if (obj instanceof SafeDocumentAuthors) {
-            return Objects.equals(this.getWrapped(), ((SafeDocumentAuthors) obj).getWrapped());
+        if (obj instanceof SafeDocumentAuthors safeDocumentAuthors) {
+            return Objects.equals(this.getWrapped(), safeDocumentAuthors.getWrapped());
         }
         return super.equals(obj);
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/internal/AuthServiceConfigurationInvalidator.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/internal/AuthServiceConfigurationInvalidator.java
@@ -72,8 +72,8 @@ public class AuthServiceConfigurationInvalidator extends AbstractEventListener
     @Override
     public void onEvent(Event event, Object source, Object data)
     {
-        if (event instanceof WikiDeletedEvent) {
-            this.configuration.invalidate(((WikiDeletedEvent) event).getWikiId());
+        if (event instanceof WikiDeletedEvent wikiDeletedEvent) {
+            this.configuration.invalidate(wikiDeletedEvent.getWikiId());
         } else {
             this.configuration
                 .invalidate(((EntityEvent) event).getReference().extractReference(EntityType.WIKI).getName());


### PR DESCRIPTION
## Summary

Fixes 90 occurrences of SonarCloud rule [java:S6201 — "Replace this instanceof check and cast with 'instanceof ... pattern'"](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&resolved=false&rules=java:S6201) in the `xwiki-platform-oldcore` module.

Each fix binds a pattern variable in the `instanceof` check and removes the now-redundant cast, e.g.:

```java
// before
if (value instanceof BaseProperty) {
    ((BaseProperty) value).setName(name);
}
// after
if (value instanceof BaseProperty baseProperty) {
    baseProperty.setName(name);
}
```

This is a purely mechanical, behaviour-preserving change (positive guards, negated early-exit guards, compound `&&`/`||`, ternary and return shapes). No public API changes.

52 files changed across the module.

## Test plan

- [x] `mvn clean install -Plegacy,snapshot` on `xwiki-platform-oldcore` — **BUILD SUCCESS** (Checkstyle + Spoon + the module's full unit-test suite run and pass).

---
_Generated by Claude Code._

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXasMJ6U6LsRXriChck9JK)_