### PR TITLE
[Misc] Fix various SonarCloud issues (merge nested ifs, remove unused code, simplify)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/QueryExpressionGenerator.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/QueryExpressionGenerator.java
@@ -30,7 +30,6 @@ import javax.inject.Singleton;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.eventstream.EventStreamException;
 import org.xwiki.model.reference.DocumentReference;
-import org.xwiki.model.reference.LocalDocumentReference;
 import org.xwiki.notifications.filters.NotificationFilter;
 import org.xwiki.notifications.filters.NotificationFilterManager;
 import org.xwiki.notifications.filters.NotificationFilterType;
@@ -69,8 +68,6 @@ import static org.xwiki.notifications.filters.expression.generics.ExpressionBuil
 @Singleton
 public class QueryExpressionGenerator
 {
-    private static final LocalDocumentReference USER_CLASS = new LocalDocumentReference("XWiki", "XWikiUsers");
-
     @Inject
     private WikiDescriptorManager wikiDescriptorManager;
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/ViewableAllowedDBListValueFilter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/ViewableAllowedDBListValueFilter.java
@@ -69,14 +69,13 @@ public class ViewableAllowedDBListValueFilter implements QueryFilter
                 if (this.authorization.hasAccess(Right.VIEW, documentReference)) {
                     filteredResults.add(result);
                 }
-            } else if (result instanceof Object[] row) {
-                if (row.length > 0 && row[0] instanceof String documentFullName) {
-                    DocumentReference documentReference = this.documentReferenceResolver.resolve(documentFullName);
-                    if (this.authorization.hasAccess(Right.VIEW, documentReference)) {
-                        // The document full name column was added just to be able to check view right. We can discard
-                        // it now and return only the relevant columns.
-                        filteredResults.add(row.length > 1 ? Arrays.copyOfRange(row, 1, row.length) : row);
-                    }
+            } else if (result instanceof Object[] row && row.length > 0
+                && row[0] instanceof String documentFullName) {
+                DocumentReference documentReference = this.documentReferenceResolver.resolve(documentFullName);
+                if (this.authorization.hasAccess(Right.VIEW, documentReference)) {
+                    // The document full name column was added just to be able to check view right. We can discard
+                    // it now and return only the relevant columns.
+                    filteredResults.add(row.length > 1 ? Arrays.copyOfRange(row, 1, row.length) : row);
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
@@ -1813,10 +1813,8 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
                     session.load(property, (Serializable) property);
                     // In Oracle, empty string are converted to NULL. Since an undefined property is not found at all,
                     // it is safe to assume that a retrieved NULL value should actually be an empty string.
-                    if (property instanceof BaseStringProperty stringProperty) {
-                        if (stringProperty.getValue() == null) {
-                            stringProperty.setValue("");
-                        }
+                    if (property instanceof BaseStringProperty stringProperty && stringProperty.getValue() == null) {
+                        stringProperty.setValue("");
                     }
                     ((BaseProperty) property).setDirty(false);
                 } catch (ObjectNotFoundException e) {

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractEntityJobWithChecks.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractEntityJobWithChecks.java
@@ -174,11 +174,10 @@ public abstract class AbstractEntityJobWithChecks<R extends EntityRequest, S ext
     protected EntitySelection getConcernedEntitiesEntitySelection(EntityReference reference)
     {
         EntitySelection entitySelection = this.concernedEntities.get(reference);
-        if (entitySelection == null && reference instanceof DocumentReference documentReference) {
-            if (Locale.ROOT.equals(documentReference.getLocale())) {
-                entitySelection = this.concernedEntities.get(
-                    new DocumentReference(documentReference.withoutLocale(), (Locale) null));
-            }
+        if (entitySelection == null && reference instanceof DocumentReference documentReference
+            && Locale.ROOT.equals(documentReference.getLocale())) {
+            entitySelection = this.concernedEntities.get(
+                new DocumentReference(documentReference.withoutLocale(), (Locale) null));
         }
         return entitySelection;
     }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/job/MoveJobTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/job/MoveJobTest.java
@@ -39,7 +39,6 @@ import org.xwiki.refactoring.event.DocumentRenamedEvent;
 import org.xwiki.refactoring.event.DocumentRenamingEvent;
 import org.xwiki.refactoring.event.EntitiesRenamedEvent;
 import org.xwiki.refactoring.event.EntitiesRenamingEvent;
-import org.xwiki.refactoring.job.EntityJobStatus;
 import org.xwiki.refactoring.job.MoveRequest;
 import org.xwiki.refactoring.job.OverwriteQuestion;
 import org.xwiki.refactoring.job.RefactoringJobs;

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
@@ -241,11 +241,8 @@ public class IncludeMacro extends AbstractIncludeMacro<IncludeMacroParameters>
         Block parentBlock = currentBlock.getParent();
 
         if (parentBlock != null) {
-            if (parentBlock instanceof MacroMarkerBlock parentMacro) {
-
-                if (isRecursive(parentMacro, reference)) {
-                    throw new MacroExecutionException("Found recursive inclusion of document [" + reference + "]");
-                }
+            if (parentBlock instanceof MacroMarkerBlock parentMacro && isRecursive(parentMacro, reference)) {
+                throw new MacroExecutionException("Found recursive inclusion of document [" + reference + "]");
             }
 
             checkRecursion(parentBlock, reference);

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/RangeIterable.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/RangeIterable.java
@@ -100,11 +100,7 @@ public class RangeIterable<T> implements Iterable<T>
             @Override
             public boolean hasNext()
             {
-                if (i < number && i + start < list.size()) {
-                    return true;
-                }
-
-                return false;
+                return i < number && i + start < list.size();
             }
 
             @Override


### PR DESCRIPTION
## Summary

Fixes a set of safe, behaviour-preserving [SonarCloud issues](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&sinceLeakPeriod=true&id=org.xwiki.platform%3Axwiki-platform) reported on new code. Only mechanical, low-risk changes were made.

### Fixed

- **`java:S1066`** — merge collapsible nested `if` statements:
  - [`ViewableAllowedDBListValueFilter`](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZ9q2aUvHKfHY7dxJX2H&open=AZ9q2aUvHKfHY7dxJX2H)
  - [`XWikiHibernateStore`](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZ9q2bMdHKfHY7dxJX2J&open=AZ9q2bMdHKfHY7dxJX2J)
  - [`IncludeMacro`](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZ9q2cMAHKfHY7dxJX2N&open=AZ9q2cMAHKfHY7dxJX2N)
  - [`AbstractEntityJobWithChecks`](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZ9mXz3g9v-7QKVTF1Xq&open=AZ9mXz3g9v-7QKVTF1Xq)
- **`java:S1068`** — remove an unused private field (`USER_CLASS`) and its now-orphaned import in [`QueryExpressionGenerator`](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZ9q2dPKHKfHY7dxJX2Q&open=AZ9q2dPKHKfHY7dxJX2Q)
- **`java:S1128`** — remove an unused import in [`MoveJobTest`](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZ9q2gKsHKfHY7dxJX2V&open=AZ9q2gKsHKfHY7dxJX2V)
- **`java:S1126`** — replace an if-then-else returning boolean literals by a single return in [`RangeIterable`](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZ9q2b91HKfHY7dxJX2K&open=AZ9q2b91HKfHY7dxJX2K)

### Notably not changed (unsafe / out of scope)

- **`java:S3415`** (assertion argument order) was intentionally **not** applied: the flagged tests deliberately depend on the operand order — `RegexEntityReferenceTest` relies on the asymmetric `RegexEntityReference.equals`, and the `assertNotEquals(obj, null)` cases exercise `obj.equals(null)`; swapping would change or break the tests.
- `java:S6880` (if/else → switch), `java:S1130` (remove `throws`), `java:S1845`, `java:S3776`, and the logging-related `java:S2629`/`java:S3457` were left out as not purely mechanical / higher-risk.

## Test plan

- `mvn clean install` on all 5 affected modules (oldcore, refactoring-api, rendering-macro-include, rest-server, notifications-sources) — **BUILD SUCCESS**, all tests pass (Checkstyle + Spoon included).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeZYDvcFbHP3APkuAo38Yg)_