### PR TITLE
[Misc] Add unit tests for RangeIterable

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/pom.xml
@@ -32,7 +32,7 @@
   <name>XWiki Platform - REST - Server</name>
   <description>Service for accessing XWiki through a RESTful API</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.36</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.37</xwiki.jacoco.instructionRatio>
   </properties>
   <dependencies>
     <dependency>

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/RangeIterableTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/RangeIterableTest.java
@@ -1,0 +1,97 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rest.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Validate {@link RangeIterable}.
+ *
+ * @version $Id$
+ */
+class RangeIterableTest
+{
+    private <T> List<T> collect(RangeIterable<T> range)
+    {
+        List<T> result = new ArrayList<>();
+        range.forEach(result::add);
+        return result;
+    }
+
+    @Test
+    void iterateWindowWithinBounds()
+    {
+        assertEquals(List.of("b", "c"),
+            collect(new RangeIterable<>(List.of("a", "b", "c", "d", "e"), 1, 2)));
+    }
+
+    @Test
+    void negativeStartClampedToZero()
+    {
+        assertEquals(List.of("a", "b"),
+            collect(new RangeIterable<>(List.of("a", "b", "c"), -5, 2)));
+    }
+
+    @Test
+    void startBeyondSizeYieldsEmpty()
+    {
+        assertEquals(List.of(),
+            collect(new RangeIterable<>(List.of("a", "b", "c"), 10, 2)));
+    }
+
+    @Test
+    void negativeNumberMeansRemainderFromStart()
+    {
+        assertEquals(List.of("b", "c"),
+            collect(new RangeIterable<>(List.of("a", "b", "c"), 1, -1)));
+    }
+
+    @Test
+    void numberOverflowClampedToSize()
+    {
+        assertEquals(List.of("c"),
+            collect(new RangeIterable<>(List.of("a", "b", "c"), 2, 10)));
+    }
+
+    @Test
+    void emptyListYieldsEmpty()
+    {
+        assertEquals(List.of(), collect(new RangeIterable<>(List.of(), 0, 5)));
+    }
+
+    @Test
+    void nextBeyondEndThrows()
+    {
+        // Documents current behaviour: next() is unguarded and relies on the caller checking
+        // hasNext(). Exhausting the iterator and calling next() again reaches list.get() out of
+        // range.
+        var it = new RangeIterable<>(List.of("a"), 0, 1).iterator();
+        it.next();
+        assertFalse(it.hasNext());
+        assertThrows(IndexOutOfBoundsException.class, it::next);
+    }
+}


### PR DESCRIPTION
RangeIterable had zero tests despite non-trivial bounds-clamping logic used on the REST pagination path. Add characterization tests pinning current behavior (start/number clamping, negative-number semantics, empty list, unguarded next() past end), and raise the module's xwiki.jacoco.instructionRatio from 0.36 to 0.37 to reflect the coverage gain.

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

*

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 