### PR TITLE
XWIKI-23719: The tree finder uses a hard-coded icon

### DIFF
--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/AllDocsPage.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/AllDocsPage.java
@@ -49,7 +49,7 @@ public class AllDocsPage extends ViewPage
 
     @FindBy(xpath = "//li[@id='xwikideletedAttachments']/a")
     private WebElement deletedAttachmentsTab;
-    
+
     @FindBy(xpath = "//div[contains(@class, 'xwikitabpanescontainer')]/div[contains(@class, 'jstree')]")
     private WebElement treeElement;
 

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/AllDocsPage.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/AllDocsPage.java
@@ -49,9 +49,7 @@ public class AllDocsPage extends ViewPage
 
     @FindBy(xpath = "//li[@id='xwikideletedAttachments']/a")
     private WebElement deletedAttachmentsTab;
-
-    // We can't simply match any direct child div of the tab panes container because the tree finder also inserts a
-    // sibling div (the search input and its icon) right before the tree root, which would otherwise also match.
+    
     @FindBy(xpath = "//div[contains(@class, 'xwikitabpanescontainer')]/div[contains(@class, 'jstree')]")
     private WebElement treeElement;
 

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/AllDocsPage.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/AllDocsPage.java
@@ -50,7 +50,9 @@ public class AllDocsPage extends ViewPage
     @FindBy(xpath = "//li[@id='xwikideletedAttachments']/a")
     private WebElement deletedAttachmentsTab;
 
-    @FindBy(xpath = "//div[contains(@class, 'xwikitabpanescontainer')]/div")
+    // We can't simply match any direct child div of the tab panes container because the tree finder also inserts a
+    // sibling div (the search input and its icon) right before the tree root, which would otherwise also match.
+    @FindBy(xpath = "//div[contains(@class, 'xwikitabpanescontainer')]/div[contains(@class, 'jstree')]")
     private WebElement treeElement;
 
     public static AllDocsPage gotoPage()

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/finder.js
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/finder.js
@@ -21,7 +21,8 @@ define('xwiki-tree-finder-icons', [], {
   icons: ['search']
 });
 
-define(['jquery', 'jsTree', 'xwiki-events-bridge'], function($) {
+define(['jquery', 'xwiki-icon!xwiki-tree-finder-icons', 'jsTree', 'xwiki-events-bridge'],
+    function($, icons) {
   'use strict';
 
   // jsTree uses the underscore notation for its API, instead of camel case.
@@ -44,10 +45,7 @@ define(['jquery', 'jsTree', 'xwiki-events-bridge'], function($) {
   var createSuggestInput = function(options) {
     let container = document.createElement('div');
     container.classList.add('xtree-finder-container');
-    // Load the search icon asynchronously, after the finder input is already in the page.
-    require(['xwiki-icon!xwiki-tree-finder-icons'], function(icons) {
-      container.insertBefore(icons.search.render(), container.firstChild);
-    });
+    container.appendChild(icons.search.render());
     let input = document.createElement('input');
     input.type = 'text';
     input.className = 'xtree-finder';

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/finder.js
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/finder.js
@@ -21,8 +21,7 @@ define('xwiki-tree-finder-icons', [], {
   icons: ['search']
 });
 
-define(['jquery', 'xwiki-icon!xwiki-tree-finder-icons', 'jsTree', 'xwiki-events-bridge'],
-    function($, icons) {
+define(['jquery', 'jsTree', 'xwiki-events-bridge'], function($) {
   'use strict';
 
   // jsTree uses the underscore notation for its API, instead of camel case.
@@ -45,7 +44,10 @@ define(['jquery', 'xwiki-icon!xwiki-tree-finder-icons', 'jsTree', 'xwiki-events-
   var createSuggestInput = function(options) {
     let container = document.createElement('div');
     container.classList.add('xtree-finder-container');
-    container.appendChild(icons.search.render());
+    // Load the search icon asynchronously, after the finder input is already in the page.
+    require(['xwiki-icon!xwiki-tree-finder-icons'], function(icons) {
+      container.insertBefore(icons.search.render(), container.firstChild);
+    });
     let input = document.createElement('input');
     input.type = 'text';
     input.className = 'xtree-finder';


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-23719

Patch for the regression at https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/stable-18.6.x/4/testReport//org.xwiki.index.test.ui.docker/AllIT$NestedAllDocsIT/MySQL_latest__Tomcat_11_jdk25__Filesystem__Chrome___Docker_tests__6_for_xwiki_platform_image_style__xwiki_platform_index__xwiki_platform_instance__xwiki_platform_invitation___Build_for_MySQL_latest__Tomcat_11_jdk25__Filesystem__Chrome___Docker_tests__6_for_xwiki_platform_image_style__xwiki_platform_index__xwiki_platform_instance__xwiki_platform_invitation___treeViewTab_TestUtils__TestReference_/

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Updated the AllDocsPage treeElement XPath to work properly.
* Reduced the scope of the icon require so that we can avoid the finder load waiting for the icon.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The regression happenned because of the DOM change in the finder.
* The change in finder.js is a small performance improvement (the finder doesn't have to wait for the search icon anymore before being displayed).


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None. Code architecture for test correctness only. We could probably see a small change in the looks of the component while loading but it's anecdotal and capturing this would be a pain.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Built the changes with `mvn clean install -f xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar -Pquality` and `mvn clean install -f xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-test-pageobjects -Dxwiki.checkstyle.skip=true -Dxwiki.revapi.skip=true -DskipTests`.

I then ran one of the two tests that were failing on CI, in the same conditions as CI: 
```
mvn verify -pl xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-docker \
    -Pdocker,legacy,integration-tests \
    -Dtest='AllIT$NestedAllDocsIT#treeViewTab+treeViewTabWithSpecialCharactersInEntityNames' \
    -Dxwiki.checkstyle.skip=true -Dxwiki.surefire.captureconsole.skip=true -Dxwiki.revapi.skip=true \
    -Dxwiki.spoon.skip=true -Dxwiki.enforcer.skip=true \
    -Dxwiki.test.ui.database=mysql -Dxwiki.test.ui.databaseTag=latest -Dxwiki.test.ui.jdbcVersion=pom \
    -Dxwiki.test.ui.servletEngine=tomcat -Dxwiki.test.ui.servletEngineTag=11-jdk25 \
    -Dxwiki.test.ui.browser=chrome -Dxwiki.test.ui.blobStore=filesystem
```
After the patch, these passed consistently. The other failing test has exactly the same underlying issue so I didn't check it again.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 18.6.X
  * 18.4.X
  * 17.10.X
Like its cause.