### PR TITLE
[Misc] Replace Stream.collect(Collectors.toList()) with Stream.toList() (SonarQube java:S6204)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-api/src/main/java/org/xwiki/export/pdf/internal/script/SafePDFExportConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-api/src/main/java/org/xwiki/export/pdf/internal/script/SafePDFExportConfiguration.java
@@ -21,7 +21,6 @@ package org.xwiki.export.pdf.internal.script;
 
 import java.net.URI;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.xwiki.export.pdf.PDFExportConfiguration;
 import org.xwiki.model.reference.DocumentReference;
@@ -103,7 +102,7 @@ public class SafePDFExportConfiguration extends AbstractSafeObject<PDFExportConf
     {
         return getWrapped().getTemplates().stream()
             .filter(templateReference -> this.authorization.hasAccess(Right.VIEW, templateReference))
-            .collect(Collectors.toList());
+            .toList();
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-default/src/main/java/org/xwiki/export/pdf/internal/DefaultPDFExportConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-default/src/main/java/org/xwiki/export/pdf/internal/DefaultPDFExportConfiguration.java
@@ -23,7 +23,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -140,7 +139,7 @@ public class DefaultPDFExportConfiguration implements PDFExportConfiguration
         List<String> templates = this.configDocument.getProperty("templates", List.class,
             Collections.singletonList("XWiki.PDFExport.Template"));
         return templates.stream().filter(StringUtils::isNotBlank)
-            .map(template -> this.documentReferenceResolver.resolve(template)).collect(Collectors.toList());
+            .map(template -> this.documentReferenceResolver.resolve(template)).toList();
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/ExtensionIndexSolrUtil.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/ExtensionIndexSolrUtil.java
@@ -22,7 +22,6 @@ package org.xwiki.extension.index.internal;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -78,7 +77,7 @@ public class ExtensionIndexSolrUtil
                 installedNamespaces = Collections.singletonList(toStoredNamespace((String) null));
             } else {
                 installedNamespaces = installedExtension.getNamespaces().stream().map(this::toStoredNamespace)
-                    .collect(Collectors.toList());
+                    .toList();
             }
             this.utils.setAtomic(ATOMIC_UPDATE_MODIFIER_SET, FIELD_INSTALLED_NAMESPACES,
                 installedNamespaces, document);
@@ -135,7 +134,7 @@ public class ExtensionIndexSolrUtil
 
         return solrNamespaces.stream()
             .map(this::fromStoredNamespace)
-            .collect(Collectors.toList());
+            .toList();
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/ExtensionIndexStore.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/ExtensionIndexStore.java
@@ -373,15 +373,15 @@ public class ExtensionIndexStore implements Initializable, Disposable
         }
         Stream<String> cveIds =
             result.getSecurityVulnerabilities().stream().map(SecurityVulnerabilityDescriptor::getId);
-        this.utils.setAtomic(SolrUtils.ATOMIC_UPDATE_MODIFIER_SET, SECURITY_CVE_ID, cveIds.collect(Collectors.toList()),
+        this.utils.setAtomic(SolrUtils.ATOMIC_UPDATE_MODIFIER_SET, SECURITY_CVE_ID, cveIds.toList(),
             doc);
         this.utils.setAtomic(SolrUtils.ATOMIC_UPDATE_MODIFIER_SET, SECURITY_CVE_LINK,
             result.getSecurityVulnerabilities().stream().map(SecurityVulnerabilityDescriptor::getURL)
-                .collect(Collectors.toList()),
+                .toList(),
             doc);
         this.utils.setAtomic(SolrUtils.ATOMIC_UPDATE_MODIFIER_SET, SECURITY_CVE_CVSS,
             result.getSecurityVulnerabilities().stream().map(SecurityVulnerabilityDescriptor::getScore)
-                .collect(Collectors.toList()),
+                .toList(),
             doc);
         String fixVersion =
             result.getSecurityVulnerabilities().stream().map(SecurityVulnerabilityDescriptor::getFixVersion)
@@ -392,10 +392,10 @@ public class ExtensionIndexStore implements Initializable, Disposable
             result.getSecurityVulnerabilities().size(), doc);
         this.utils.setAtomic(SolrUtils.ATOMIC_UPDATE_MODIFIER_SET, IS_CORE_EXTENSION, result.isCoreExtension(), doc);
         List<Boolean> safeMapping = result.getSecurityVulnerabilities().stream()
-            .map(SecurityVulnerabilityDescriptor::isSafe).collect(Collectors.toList());
+            .map(SecurityVulnerabilityDescriptor::isSafe).toList();
         this.utils.setAtomic(SolrUtils.ATOMIC_UPDATE_MODIFIER_SET, IS_REVIEWED_SAFE, safeMapping, doc);
         List<String> reviewExplanations = result.getSecurityVulnerabilities().stream()
-            .map(SecurityVulnerabilityDescriptor::getReviews).collect(Collectors.toList());
+            .map(SecurityVulnerabilityDescriptor::getReviews).toList();
         this.utils.setAtomic(SolrUtils.ATOMIC_UPDATE_MODIFIER_SET, IS_SAFE_EXPLANATIONS, reviewExplanations, doc);
 
         add(doc);
@@ -599,7 +599,7 @@ public class ExtensionIndexStore implements Initializable, Disposable
 
         this.utils.setString(Extension.FIELD_AUTHORS, extension.getAuthors(), ExtensionAuthor.class, document);
         this.utils.set(ExtensionIndexSolrCoreInitializer.SOLR_FIELD_AUTHORS_INDEX,
-            extension.getAuthors().stream().map(ExtensionAuthor::getName).collect(Collectors.toList()), document);
+            extension.getAuthors().stream().map(ExtensionAuthor::getName).toList(), document);
 
         this.utils.setString(Extension.FIELD_COMPONENTS, extension.getComponents(), ExtensionComponent.class, document);
         for (ExtensionComponent component : extension.getComponents()) {
@@ -1038,7 +1038,7 @@ public class ExtensionIndexStore implements Initializable, Disposable
         }
 
         return documents.stream().map(d -> this.utils.<Version>get(Extension.FIELD_VERSION, d, Version.class))
-            .collect(Collectors.toList());
+            .toList();
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-api/src/main/java/org/xwiki/extension/security/internal/SolrToLiveDataEntryMapper.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-api/src/main/java/org/xwiki/extension/security/internal/SolrToLiveDataEntryMapper.java
@@ -28,7 +28,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.IntPredicate;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import javax.inject.Inject;
@@ -160,7 +159,7 @@ public class SolrToLiveDataEntryMapper
         return Optional.ofNullable(doc.getFieldValues(IS_REVIEWED_SAFE))
             .map(values -> values.stream()
                 .map(it -> (boolean) it)
-                .collect(Collectors.toList()))
+                .toList())
             .orElse(List.of());
     }
 
@@ -170,7 +169,7 @@ public class SolrToLiveDataEntryMapper
         return IntStream.range(0, mapToStrings(doc, SECURITY_CVE_ID).size())
             .filter(((IntPredicate) safe::get).negate())
             .boxed()
-            .collect(Collectors.toList());
+            .toList();
     }
 
     private static List<Integer> getSafeCVEsIndex(SolrDocument doc, List<Boolean> safe)
@@ -178,7 +177,7 @@ public class SolrToLiveDataEntryMapper
         return IntStream.range(0, mapToStrings(doc, SECURITY_CVE_ID).size())
             .filter(safe::get)
             .boxed()
-            .collect(Collectors.toList());
+            .toList();
     }
 
     private static List<String> mapToStrings(SolrDocument doc, String name)
@@ -187,7 +186,7 @@ public class SolrToLiveDataEntryMapper
         if (fieldValues == null) {
             return List.of();
         }
-        return fieldValues.stream().map(String::valueOf).collect(Collectors.toList());
+        return fieldValues.stream().map(String::valueOf).toList();
     }
 
     private String buildAdvice(SolrDocument doc)

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-api/src/test/java/org/xwiki/extension/security/internal/ExtensionSecuritySolrClientTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-api/src/test/java/org/xwiki/extension/security/internal/ExtensionSecuritySolrClientTest.java
@@ -22,7 +22,6 @@ package org.xwiki.extension.security.internal;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.response.QueryResponse;
@@ -220,8 +219,8 @@ class ExtensionSecuritySolrClientTest
 
     private static boolean sameArraysNoOrder(String[] a1, String[] a2)
     {
-        List<String> sl1 = Arrays.stream(a1).sorted().collect(Collectors.toList());
-        List<String> sl2 = Arrays.stream(a2).sorted().collect(Collectors.toList());
+        List<String> sl1 = Arrays.stream(a1).sorted().toList();
+        List<String> sl2 = Arrays.stream(a2).sorted().toList();
         return Objects.equals(sl1, sl2);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-default/src/main/java/org/xwiki/index/internal/migration/R140300000XWIKI19614DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-default/src/main/java/org/xwiki/index/internal/migration/R140300000XWIKI19614DataMigration.java
@@ -21,7 +21,6 @@ package org.xwiki.index.internal.migration;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -102,7 +101,7 @@ public class R140300000XWIKI19614DataMigration extends AbstractDocumentsMigratio
                         String locale = Objects.toString(array[1], "");
                         return resolveDocumentReference(String.valueOf(array[0]), locale).stream();
                     })
-                    .collect(Collectors.toList());
+                    .toList();
             } catch (QueryException e) {
                 throw new DataMigrationException(
                     String.format("Failed retrieve the list of all the documents for wiki [%s].", wiki.getName()), e);

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/java/org/xwiki/index/tree/internal/AbstractEntityTreeNode.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/java/org/xwiki/index/tree/internal/AbstractEntityTreeNode.java
@@ -95,7 +95,7 @@ public abstract class AbstractEntityTreeNode extends AbstractTreeNode implements
 
     protected <E extends EntityReference> List<String> serialize(List<E> entityReferences)
     {
-        return entityReferences.stream().map(this::serialize).collect(Collectors.toList());
+        return entityReferences.stream().map(this::serialize).toList();
     }
 
     protected boolean areHiddenEntitiesShown()

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/java/org/xwiki/index/tree/internal/FarmTreeNode.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/java/org/xwiki/index/tree/internal/FarmTreeNode.java
@@ -81,7 +81,7 @@ public class FarmTreeNode extends AbstractEntityTreeNode
         try {
             return this.wikiDescriptorManager.getAll().stream()
                 .filter(wikiDescriptor -> !getExcludedWikis().contains(wikiDescriptor.getId()))
-                .collect(Collectors.toList());
+                .toList();
         } catch (WikiManagerException e) {
             this.logger.warn("Failed to retrieve the list of wikis. Root cause [{}].",
                 ExceptionUtils.getRootCauseMessage(e));

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-messagestream/xwiki-platform-legacy-messagestream-api/src/main/java/org/xwiki/messagestream/internal/DefaultMessageStream.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-messagestream/xwiki-platform-legacy-messagestream-api/src/main/java/org/xwiki/messagestream/internal/DefaultMessageStream.java
@@ -22,7 +22,6 @@ package org.xwiki.messagestream.internal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -189,7 +188,7 @@ public class DefaultMessageStream implements MessageStream
             SimpleEventQuery query = createEventQuery(PersonalMessageDescriptor.EVENT_TYPE, limit, offset);
             query.eq(Event.FIELD_USER, author);
 
-            result = this.eventStore.search(query).stream().collect(Collectors.toList());
+            result = this.eventStore.search(query).stream().toList();
         } catch (EventStreamException ex) {
             this.logger.warn("Failed to search personal messages: {}", ex.getMessage());
         }
@@ -210,7 +209,7 @@ public class DefaultMessageStream implements MessageStream
             SimpleEventQuery query = createEventQuery(DirectMessageDescriptor.EVENT_TYPE, limit, offset);
             query.eq(Event.FIELD_STREAM, this.bridge.getCurrentUserReference());
 
-            result = this.eventStore.search(query).stream().collect(Collectors.toList());
+            result = this.eventStore.search(query).stream().toList();
         } catch (EventStreamException ex) {
             this.logger.warn("Failed to search direct messages: {}", ex.getMessage());
         }
@@ -231,7 +230,7 @@ public class DefaultMessageStream implements MessageStream
             SimpleEventQuery query = createEventQuery(GroupMessageDescriptor.EVENT_TYPE, limit, offset);
             query.eq(Event.FIELD_STREAM, group);
 
-            result = this.eventStore.search(query).stream().collect(Collectors.toList());
+            result = this.eventStore.search(query).stream().toList();
         } catch (EventStreamException ex) {
             this.logger.warn("Failed to search group messages: {}", ex.getMessage());
         }


### PR DESCRIPTION
## Summary

Fixes 23 SonarCloud [`java:S6204`](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS6204&rule_key=java%3AS6204) issues by replacing `Stream.collect(Collectors.toList())` with `Stream.toList()` (Java 16+) and removing the now-unused `Collectors` imports.

Each conversion was checked so the resulting list stays confined (returned as a freshly-built list, iterated, or passed to a read-only consumer such as a Solr atomic-update / `assertEquals`). Sites where the collected list would escape into a public API able to mutate it (e.g. stored in a field exposed by a public getter, or passed to a setter that stores it by reference on a public model class) were intentionally **left unchanged**.

## Modules touched

- `xwiki-platform-extension-security-api` — `SolrToLiveDataEntryMapper`, `ExtensionSecuritySolrClientTest`
- `xwiki-platform-extension-index` — `ExtensionIndexStore`, `ExtensionIndexSolrUtil`
- `xwiki-platform-index-tree-api` — `FarmTreeNode`, `AbstractEntityTreeNode`
- `xwiki-platform-index-default` — `R140300000XWIKI19614DataMigration`
- `xwiki-platform-export-pdf-api` — `SafePDFExportConfiguration`
- `xwiki-platform-export-pdf-default` — `DefaultPDFExportConfiguration`
- `xwiki-platform-legacy-messagestream-api` — `DefaultMessageStream`

## SonarCloud

``[All 23 issues](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issues=AZGaGx9PPhpr_P5DN48A%2CAZGaGx9PPhpr_P5DN48B%2CAZGaGx9PPhpr_P5DN48C%2CAZGaGx9PPhpr_P5DN48D%2CAY-b40IQuDZgbKZWNlDp%2CAYyD4q2Qj2dtqk6dnyHI%2CAYyD4q0Ij2dtqk6dnyHE%2CAYyD4rlBj2dtqk6dnyIT%2CAYyD4rlBj2dtqk6dnyIU%2CAYyD4rkwj2dtqk6dnyIL%2CAYyD4rkwj2dtqk6dnyIP%2CAYyD4rkwj2dtqk6dnyIS%2CAYyD4rRkj2dtqk6dnyHr%2CAYyD4rRkj2dtqk6dnyHs%2CAYyD4rRkj2dtqk6dnyHt%2CAYyD4rRkj2dtqk6dnyHu%2CAYyD4uitj2dtqk6dnyL4%2CAYyD4uj0j2dtqk6dnyL6%2CAYyD4wylj2dtqk6dnyNu%2CAYyD4wylj2dtqk6dnyNv%2CAYyD4wylj2dtqk6dnyNw%2CAY974mkHKZk1650DhyHO%2CAY974mkHKZk1650DhyHP)``

## Test plan

- `mvn clean install` on the 7 affected modules (with `-Plegacy,snapshot`) — BUILD SUCCESS, Checkstyle clean, all unit tests pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YQ9GjUTf6Yf1BE9mBpQkrb)_