### PR TITLE
[Misc] Replace instanceof checks and casts with pattern matching (SonarCloud java:S6201)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-configuration/xwiki-platform-configuration-default/src/main/java/org/xwiki/configuration/internal/AbstractSpacesConfigurationSource.java
+++ b/xwiki-platform-core/xwiki-platform-configuration/xwiki-platform-configuration-default/src/main/java/org/xwiki/configuration/internal/AbstractSpacesConfigurationSource.java
@@ -69,8 +69,8 @@ public abstract class AbstractSpacesConfigurationSource extends AbstractComposit
 
             SpaceReference next = this.reference;
             // Move reference to parent
-            if (this.reference.getParent() instanceof SpaceReference) {
-                this.reference = (SpaceReference) this.reference.getParent();
+            if (this.reference.getParent() instanceof SpaceReference spaceReference) {
+                this.reference = spaceReference;
             } else {
                 this.reference = null;
             }

--- a/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-script/src/main/java/org/xwiki/crypto/script/AbstractScriptingStore.java
+++ b/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-script/src/main/java/org/xwiki/crypto/script/AbstractScriptingStore.java
@@ -55,8 +55,8 @@ public abstract class AbstractScriptingStore
 
     protected void checkAccess(Right right) throws AccessDeniedException
     {
-        if (storeReference instanceof WikiStoreReference) {
-            contextualAuthorizationManager.checkAccess(right, ((WikiStoreReference) storeReference).getReference());
+        if (storeReference instanceof WikiStoreReference wikiStoreReference) {
+            contextualAuthorizationManager.checkAccess(right, wikiStoreReference.getReference());
         } else {
             contextualAuthorizationManager.checkAccess(Right.PROGRAM);
         }

--- a/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-store/xwiki-platform-crypto-store-wiki/src/main/java/org/xwiki/crypto/store/wiki/internal/AbstractX509WikiStore.java
+++ b/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-store/xwiki-platform-crypto-store-wiki/src/main/java/org/xwiki/crypto/store/wiki/internal/AbstractX509WikiStore.java
@@ -308,8 +308,8 @@ public abstract class AbstractX509WikiStore
 
     private EntityReference getStoreReference(StoreReference store)
     {
-        if (store instanceof WikiStoreReference) {
-            return ((WikiStoreReference) store).getReference();
+        if (store instanceof WikiStoreReference wikiStoreReference) {
+            return wikiStoreReference.getReference();
         }
         throw new IllegalArgumentException("Unsupported store reference [" + store.getClass().getName()
             + "] for this implementation.");

--- a/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/SyndEntryDocumentSource.java
+++ b/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/SyndEntryDocumentSource.java
@@ -408,8 +408,8 @@ public class SyndEntryDocumentSource implements SyndEntrySource
 
         List<SyndCategory> result = new ArrayList<>();
         for (Object category : categories) {
-            if (category instanceof SyndCategory) {
-                result.add((SyndCategory) category);
+            if (category instanceof SyndCategory syndCategory) {
+                result.add(syndCategory);
             } else if (category != null) {
                 SyndCategory scat = new SyndCategoryImpl();
                 scat.setName(category.toString());
@@ -496,8 +496,8 @@ public class SyndEntryDocumentSource implements SyndEntrySource
 
         List<String> contributors = new ArrayList<>();
         for (Object rawContributor : rawContributors) {
-            if (rawContributor instanceof String) {
-                contributors.add((String) rawContributor);
+            if (rawContributor instanceof String contributor) {
+                contributors.add(contributor);
             } else {
                 contributors.add(rawContributor.toString());
             }
@@ -765,12 +765,12 @@ public class SyndEntryDocumentSource implements SyndEntrySource
      */
     protected Document castDocument(Object obj, XWikiContext context) throws XWikiException
     {
-        if (obj instanceof Document) {
-            return (Document) obj;
-        } else if (obj instanceof XWikiDocument) {
-            return ((XWikiDocument) obj).newDocument(context);
-        } else if (obj instanceof String) {
-            return context.getWiki().getDocument((String) obj, context).newDocument(context);
+        if (obj instanceof Document document) {
+            return document;
+        } else if (obj instanceof XWikiDocument xwikiDocument) {
+            return xwikiDocument.newDocument(context);
+        } else if (obj instanceof String string) {
+            return context.getWiki().getDocument(string, context).newDocument(context);
         } else {
             throw new XWikiException(XWikiException.MODULE_XWIKI_PLUGINS, XWikiException.ERROR_XWIKI_DOES_NOT_EXIST, "");
         }

--- a/xwiki-platform-core/xwiki-platform-job/xwiki-platform-job-handler/src/main/java/org/xwiki/job/handler/internal/question/QuestionJobResourceReferenceHandler.java
+++ b/xwiki-platform-core/xwiki-platform-job/xwiki-platform-job-handler/src/main/java/org/xwiki/job/handler/internal/question/QuestionJobResourceReferenceHandler.java
@@ -116,8 +116,8 @@ public class QuestionJobResourceReferenceHandler extends AbstractTemplateJobReso
         String contentType = "text/html; charset=utf-8";
 
         // POST request means answer
-        if (request instanceof ServletRequest) {
-            HttpServletRequest httpRequest = ((ServletRequest) request).getHttpServletRequest();
+        if (request instanceof ServletRequest servletRequest) {
+            HttpServletRequest httpRequest = servletRequest.getHttpServletRequest();
 
             if ("POST".equals(httpRequest.getMethod())) {
                 String token = httpRequest.getParameter("form_token");
@@ -170,9 +170,9 @@ public class QuestionJobResourceReferenceHandler extends AbstractTemplateJobReso
         }
 
         // Cancel if supported
-        if (job.getStatus() instanceof CancelableJobStatus
+        if (job.getStatus() instanceof CancelableJobStatus cancelableJobStatus
             && Boolean.parseBoolean(request.getParameter(CANCEL))) {
-            ((CancelableJobStatus) job.getStatus()).cancel();
+            cancelableJobStatus.cancel();
         }
 
         // Answer question

--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-api/src/main/java/org/xwiki/localization/internal/AbstractURLResourceTranslationBundle.java
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-api/src/main/java/org/xwiki/localization/internal/AbstractURLResourceTranslationBundle.java
@@ -155,9 +155,7 @@ public abstract class AbstractURLResourceTranslationBundle extends AbstractCache
         TranslationMessageParser parser = getTranslationMessageParser();
 
         for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-            if (entry.getKey() instanceof String && entry.getValue() instanceof String) {
-                String key = (String) entry.getKey();
-                String message = (String) entry.getValue();
+            if (entry.getKey() instanceof String key && entry.getValue() instanceof String message) {
 
                 TranslationMessage translationMessage = parser.parse(message);
 

--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-api/src/main/java/org/xwiki/localization/internal/message/ParameterTranslationMessageElement.java
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-api/src/main/java/org/xwiki/localization/internal/message/ParameterTranslationMessageElement.java
@@ -72,8 +72,8 @@ public class ParameterTranslationMessageElement implements TranslationMessageEle
         Object parameter = parameters[index];
 
         Block block;
-        if (parameter instanceof Block) {
-            block = (Block) parameter;
+        if (parameter instanceof Block parameterBlock) {
+            block = parameterBlock;
         } else if (parameter != null) {
             try {
                 XDOM xdom = this.plainParser.parse(new StringReader(parameter.toString()));

--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-jar/src/main/java/org/xwiki/localization/jar/internal/RootClassLoaderTranslationBundle.java
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-jar/src/main/java/org/xwiki/localization/jar/internal/RootClassLoaderTranslationBundle.java
@@ -80,9 +80,7 @@ public class RootClassLoaderTranslationBundle extends AbstractCachedTranslationB
         DefaultLocalizedTranslationBundle localeBundle = new DefaultLocalizedTranslationBundle(this, locale);
 
         for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-            if (entry.getKey() instanceof String && entry.getValue() instanceof String) {
-                String key = (String) entry.getKey();
-                String message = (String) entry.getValue();
+            if (entry.getKey() instanceof String key && entry.getValue() instanceof String message) {
 
                 TranslationMessage translationMessage = this.parser.parse(message);
 

--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-wiki/src/main/java/org/xwiki/localization/wiki/internal/AbstractDocumentTranslationBundle.java
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-wiki/src/main/java/org/xwiki/localization/wiki/internal/AbstractDocumentTranslationBundle.java
@@ -194,9 +194,7 @@ public abstract class AbstractDocumentTranslationBundle extends AbstractCachedTr
         TranslationMessageParser parser = getTranslationMessageParser();
 
         for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-            if (entry.getKey() instanceof String && entry.getValue() instanceof String) {
-                String key = (String) entry.getKey();
-                String message = (String) entry.getValue();
+            if (entry.getKey() instanceof String key && entry.getValue() instanceof String message) {
 
                 TranslationMessage translationMessage = parser.parse(message);
 

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-api/src/main/java/org/xwiki/mail/ExtendedMimeMessage.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-api/src/main/java/org/xwiki/mail/ExtendedMimeMessage.java
@@ -96,8 +96,8 @@ public class ExtendedMimeMessage extends MimeMessage
      */
     public static ExtendedMimeMessage wrap(MimeMessage message)
     {
-        if (message instanceof ExtendedMimeMessage) {
-            return (ExtendedMimeMessage) message;
+        if (message instanceof ExtendedMimeMessage extendedMimeMessage) {
+            return extendedMimeMessage;
         } else {
             try {
                 return new ExtendedMimeMessage(message);

--- a/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/main/java/org/xwiki/observation/remote/internal/converter/SerializableEventConverter.java
+++ b/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/main/java/org/xwiki/observation/remote/internal/converter/SerializableEventConverter.java
@@ -51,8 +51,8 @@ public class SerializableEventConverter extends AbstractEventConverter
     @Override
     public boolean fromRemote(RemoteEventData remoteEvent, LocalEventData localEvent)
     {
-        if (remoteEvent.getEvent() instanceof Event) {
-            localEvent.setEvent((Event) remoteEvent.getEvent());
+        if (remoteEvent.getEvent() instanceof Event event) {
+            localEvent.setEvent(event);
 
             if (remoteEvent.getSource() != null) {
                 localEvent.setSource(remoteEvent.getSource());

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-viewer/src/main/java/org/xwiki/office/viewer/internal/DefaultOfficeResourceViewer.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-viewer/src/main/java/org/xwiki/office/viewer/internal/DefaultOfficeResourceViewer.java
@@ -269,7 +269,7 @@ public class DefaultOfficeResourceViewer implements OfficeResourceViewer, Initia
             block.getFirstBlock(new ClassBlockMatcher(ExpandedMacroBlock.class), Block.Axes.ANCESTOR_OR_SELF);
         if (expandedMacro != null) {
             Block parent = expandedMacro.getParent();
-            if (!(parent instanceof MetaDataBlock) || !((MetaDataBlock) parent).getMetaData().contains(MODULE_NAME)) {
+            if (!(parent instanceof MetaDataBlock metaBlock) || !metaBlock.getMetaData().contains(MODULE_NAME)) {
                 MetaDataBlock metaData = new MetaDataBlock(Collections.emptyList());
                 // Use a syntax that supports relative path resource references (we use relative paths to include the
                 // temporary files).

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-api/src/main/java/org/xwiki/panels/internal/AbstractPanelsUIExtensionManager.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-api/src/main/java/org/xwiki/panels/internal/AbstractPanelsUIExtensionManager.java
@@ -121,8 +121,7 @@ public abstract class AbstractPanelsUIExtensionManager implements UIExtensionMan
                     //
                     // - For other implementations, we only support instance that have their id containing a document
                     // reference.
-                    if (extension instanceof WikiComponent) {
-                        WikiComponent wikiComponent = (WikiComponent) extension;
+                    if (extension instanceof WikiComponent wikiComponent) {
                         extensionId = wikiComponent.getDocumentReference();
                     } else {
                         extensionId = resolver.resolve(extension.getId());

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroRenderer.java
@@ -189,12 +189,12 @@ public class DefaultWikiMacroRenderer extends AbstractBlockAsyncRenderer
      */
     private static final BlockMatcher MACRO_MARKER_MATCHER = MacroMarkerBlock.class::isInstance;
 
-    private static final BlockMatcher PLACEHOLDERS_BLOCKMATCHER = testedBlock -> ((testedBlock instanceof RawBlock
-        && (((RawBlock) testedBlock).getSyntax().getType().equals(SyntaxType.XHTML)
-            || ((RawBlock) testedBlock).getSyntax().getType().equals(SyntaxType.HTML)))
+    private static final BlockMatcher PLACEHOLDERS_BLOCKMATCHER = testedBlock -> (testedBlock instanceof RawBlock raw
+        && (raw.getSyntax().getType().equals(SyntaxType.XHTML)
+            || raw.getSyntax().getType().equals(SyntaxType.HTML)))
         || (testedBlock instanceof MacroMarkerBlock macroBlock
             && (macroBlock.getId().equals(WikiMacroContentMacro.ID)
-                || macroBlock.getId().equals(WikiMacroParameterMacro.ID))));
+                || macroBlock.getId().equals(WikiMacroParameterMacro.ID)));
 
     /**
      * Match all the metadata blocks that contains wikimacrocontent=true.

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/internal/util/XWikiErrorBlockGenerator.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/internal/util/XWikiErrorBlockGenerator.java
@@ -134,9 +134,10 @@ public class XWikiErrorBlockGenerator extends DefaultErrorBlockGenerator
             scriptContext.setAttribute(CONTEXT_ATTRIBUTE, renderingerror, ScriptContext.GLOBAL_SCOPE);
 
             // Disable restricted context if set as the error generator template generally needs scripting
-            if (this.renderingContext.isRestricted() && this.renderingContext instanceof MutableRenderingContext) {
+            if (this.renderingContext.isRestricted()
+                && this.renderingContext instanceof MutableRenderingContext mutableRenderingContext) {
                 // Make the current velocity template id available
-                ((MutableRenderingContext) this.renderingContext).push(this.renderingContext.getTransformation(),
+                mutableRenderingContext.push(this.renderingContext.getTransformation(),
                     this.renderingContext.getXDOM(), this.renderingContext.getDefaultSyntax(),
                     this.renderingContext.getTransformationId(), false, this.renderingContext.getTargetSyntax());
 

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/SearchRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/SearchRESTResource.java
@@ -112,9 +112,9 @@ public class SearchRESTResource extends AbstractExtensionRESTResource
         // Rights
         // /////////////////
 
-        if (query instanceof SecureQuery) {
+        if (query instanceof SecureQuery secureQuery) {
             // Show only what the current user has the right to see
-            ((SecureQuery) query).checkCurrentUser(true);
+            secureQuery.checkCurrentUser(true);
         }
 
         // /////////////////

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-default/src/main/java/org/xwiki/store/merge/internal/DefaultMergeManager.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-default/src/main/java/org/xwiki/store/merge/internal/DefaultMergeManager.java
@@ -236,13 +236,9 @@ public class DefaultMergeManager implements MergeManager
     {
         MergeDocumentResult mergeResult = new MergeDocumentResult(currentDocument, previousDocument, newDocument);
         
-        if (previousDocument instanceof XWikiDocument 
-            && newDocument instanceof XWikiDocument 
-            && currentDocument instanceof XWikiDocument) {
-            
-            XWikiDocument previousDoc = (XWikiDocument) previousDocument;
-            XWikiDocument newDoc = (XWikiDocument) newDocument;
-            XWikiDocument currentDoc = (XWikiDocument) currentDocument;
+        if (previousDocument instanceof XWikiDocument previousDoc
+            && newDocument instanceof XWikiDocument newDoc
+            && currentDocument instanceof XWikiDocument currentDoc) {
 
             XWikiDocument mergedDocument;
 

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/main/java/org/xwiki/store/TransactionException.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/main/java/org/xwiki/store/TransactionException.java
@@ -100,9 +100,7 @@ public class TransactionException extends Exception
 
         int total = 0;
         for (Throwable cause : this.causes) {
-            if (cause instanceof TransactionException) {
-                final TransactionException teCause = (TransactionException) cause;
-
+            if (cause instanceof TransactionException teCause) {
                 total += teCause.exceptionCount();
                 if (teCause.isNonRecoverable()) {
                     nonRecoverable = true;

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/selector/ExhaustiveCheckTagsSelector.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/selector/ExhaustiveCheckTagsSelector.java
@@ -155,8 +155,8 @@ public class ExhaustiveCheckTagsSelector extends AbstractTagsSelector
                 .createQuery(hql, Query.HQL)
                 .addFilter(this.hiddenDocumentQueryFilter);
             if (parameters != null) {
-                if (parameters instanceof Map) {
-                    query.bindValues((Map) parameters);
+                if (parameters instanceof Map map) {
+                    query.bindValues(map);
                 } else {
                     query.bindValues((List) parameters);
                 }

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/selector/UnsafeTagsSelector.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/selector/UnsafeTagsSelector.java
@@ -119,8 +119,8 @@ public class UnsafeTagsSelector extends AbstractTagsSelector
         try {
             Query query = this.contextProvider.get().getWiki().getStore().getQueryManager().createQuery(hql, Query.HQL);
             if (parameters != null) {
-                if (parameters instanceof Map) {
-                    query.bindValues((Map) parameters);
+                if (parameters instanceof Map map) {
+                    query.bindValues(map);
                 } else {
                     query.bindValues((List) parameters);
                 }

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-api/src/main/java/org/xwiki/tree/AbstractTreeNode.java
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-api/src/main/java/org/xwiki/tree/AbstractTreeNode.java
@@ -126,11 +126,11 @@ public abstract class AbstractTreeNode implements TreeNode
 
     private TreeFilter getFilter(Object filter)
     {
-        if (filter instanceof TreeFilter) {
-            return (TreeFilter) filter;
-        } else if (filter instanceof String) {
+        if (filter instanceof TreeFilter treeFilter) {
+            return treeFilter;
+        } else if (filter instanceof String string) {
             try {
-                return this.contextComponentManagerProvider.get().getInstance(TreeFilter.class, (String) filter);
+                return this.contextComponentManagerProvider.get().getInstance(TreeFilter.class, string);
             } catch (ComponentLookupException e) {
                 this.logger.warn("Skipping tree filter [{}]. Root cause is [{}].", filter,
                     ExceptionUtils.getRootCauseMessage(e));

--- a/xwiki-platform-core/xwiki-platform-uiextension/xwiki-platform-uiextension-default/src/main/java/org/xwiki/uiextension/internal/AbstractWikiUIExtension.java
+++ b/xwiki-platform-core/xwiki-platform-uiextension/xwiki-platform-uiextension-default/src/main/java/org/xwiki/uiextension/internal/AbstractWikiUIExtension.java
@@ -137,8 +137,8 @@ public abstract class AbstractWikiUIExtension extends AbstractAsyncContentBaseOb
         executorConfiguration.setTargetSyntax(this.renderingContext.getTargetSyntax());
 
         // Add decorator
-        if (this instanceof BlockAsyncRendererDecorator) {
-            executorConfiguration.setDecorator((BlockAsyncRendererDecorator) this);
+        if (this instanceof BlockAsyncRendererDecorator decorator) {
+            executorConfiguration.setDecorator(decorator);
         }
 
         // Indicate if asynchronous execution is enabled for this UI extension

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/main/java/org/xwiki/url/internal/XWikiServerClassListener.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/main/java/org/xwiki/url/internal/XWikiServerClassListener.java
@@ -77,8 +77,8 @@ public class XWikiServerClassListener extends AbstractEventListener
     @Override
     public void onEvent(Event event, Object source, Object data)
     {
-        if (this.securityManager instanceof DefaultURLSecurityManager) {
-            ((DefaultURLSecurityManager) this.securityManager).invalidateCache();
+        if (this.securityManager instanceof DefaultURLSecurityManager defaultSecurityManager) {
+            defaultSecurityManager.invalidateCache();
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-schemes/xwiki-platform-url-scheme-standard/src/main/java/org/xwiki/url/internal/standard/StandardURLStringEntityReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-schemes/xwiki-platform-url-scheme-standard/src/main/java/org/xwiki/url/internal/standard/StandardURLStringEntityReferenceResolver.java
@@ -86,8 +86,8 @@ public class StandardURLStringEntityReferenceResolver extends DefaultStringEntit
             ResourceType resourceType = this.typeResolver.resolve(extendedURL, Collections.emptyMap());
             ResourceReference reference =
                 this.resourceResolver.resolve(extendedURL, resourceType, Collections.emptyMap());
-            if (reference instanceof EntityResourceReference) {
-                return ((EntityResourceReference) reference).getEntityReference();
+            if (reference instanceof EntityResourceReference entityResourceReference) {
+                return entityResourceReference.getEntityReference();
             }
         } catch (CreateResourceReferenceException | UnsupportedResourceReferenceException | CreateResourceTypeException
             | MalformedURLException e) {

--- a/xwiki-platform-core/xwiki-platform-velocity/xwiki-platform-velocity-webapp/src/main/java/org/xwiki/velocity/XWikiWebappResourceLoader.java
+++ b/xwiki-platform-core/xwiki-platform-velocity/xwiki-platform-velocity-webapp/src/main/java/org/xwiki/velocity/XWikiWebappResourceLoader.java
@@ -79,8 +79,8 @@ public class XWikiWebappResourceLoader extends ResourceLoader
         }
 
         // Find root path
-        if (this.environment instanceof ServletEnvironment) {
-            this.rootPath = ((ServletEnvironment) this.environment).getServletContext().getRealPath(SLASH);
+        if (this.environment instanceof ServletEnvironment servletEnvironment) {
+            this.rootPath = servletEnvironment.getServletContext().getRealPath(SLASH);
         } else {
             URL root = this.environment.getResource(SLASH);
             if (root != null && "file".equals(root.getProtocol())) {

--- a/xwiki-platform-core/xwiki-platform-whatsnew/xwiki-platform-whatsnew-api/src/main/java/org/xwiki/whatsnew/internal/CategoriesConverter.java
+++ b/xwiki-platform-core/xwiki-platform-whatsnew/xwiki-platform-whatsnew-api/src/main/java/org/xwiki/whatsnew/internal/CategoriesConverter.java
@@ -49,8 +49,8 @@ public class CategoriesConverter extends AbstractConverter<Set<NewsCategory>>
             return Collections.emptySet();
         }
 
-        if (value instanceof Set) {
-            return (Set) value;
+        if (value instanceof Set set) {
+            return set;
         }
 
         Set<NewsCategory> categories = new LinkedHashSet<>();

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-creationjob/src/main/java/org/xwiki/platform/wiki/creationjob/WikiCreationException.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-creationjob/src/main/java/org/xwiki/platform/wiki/creationjob/WikiCreationException.java
@@ -55,8 +55,7 @@ public class WikiCreationException extends Exception
     @Override
     public boolean equals(Object o)
     {
-        if (o instanceof WikiCreationException) {
-            WikiCreationException other = (WikiCreationException) o;
+        if (o instanceof WikiCreationException other) {
             return new EqualsBuilder().append(getMessage(), other.getMessage()).append(getCause(), other.getCause())
                     .isEquals();
         }

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/descriptor/document/XWikiServerXwikiDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/descriptor/document/XWikiServerXwikiDocumentInitializer.java
@@ -108,8 +108,7 @@ public class XWikiServerXwikiDocumentInitializer extends AbstractMandatoryDocume
 
                 // Initialize the alias and the protocol with the input URL
                 Request request = this.container.getRequest();
-                if (request instanceof ServletRequest) {
-                    ServletRequest servletRequest = (ServletRequest) request;
+                if (request instanceof ServletRequest servletRequest) {
                     URL sourceURL = HttpServletUtils.getSourceBaseURL(servletRequest.getHttpServletRequest());
                     xobject.setStringValue(XWikiServerClassDocumentInitializer.FIELD_SERVER, sourceURL.getHost());
                     if ("https".equals(sourceURL.getProtocol())) {

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/internal/converter/DefaultHTMLConverter.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/internal/converter/DefaultHTMLConverter.java
@@ -252,10 +252,10 @@ public class DefaultHTMLConverter implements HTMLConverter
 
     private boolean maybeSetRenderingContextSyntax(Syntax syntax)
     {
-        if (this.renderingContext instanceof MutableRenderingContext) {
+        if (this.renderingContext instanceof MutableRenderingContext mutableRenderingContext) {
             // Make sure we set the default syntax and the target syntax on the rendering context. This is needed
             // for instance when the content of a macro that was edited in-line is converted to wiki syntax.
-            ((MutableRenderingContext) this.renderingContext).push(this.renderingContext.getTransformation(),
+            mutableRenderingContext.push(this.renderingContext.getTransformation(),
                 this.renderingContext.getXDOM(), syntax, this.renderingContext.getTransformationId(),
                 this.renderingContext.isRestricted(), syntax);
             return true;
@@ -276,8 +276,8 @@ public class DefaultHTMLConverter implements HTMLConverter
         // in the first one...
         txContext.setId(TRANSFORMATION_ID);
 
-        if (this.renderingContext instanceof MutableRenderingContext) {
-            ((MutableRenderingContext) this.renderingContext).transformInContext(this.macroTransformation, txContext,
+        if (this.renderingContext instanceof MutableRenderingContext mutableRenderingContext) {
+            mutableRenderingContext.transformInContext(this.macroTransformation, txContext,
                 xdom);
         }
     }

--- a/xwiki-platform-tools/xwiki-platform-tool-packager-plugin/src/main/java/com/xpn/xwiki/tool/backup/DataMojo.java
+++ b/xwiki-platform-tools/xwiki-platform-tool-packager-plugin/src/main/java/com/xpn/xwiki/tool/backup/DataMojo.java
@@ -97,8 +97,8 @@ public class DataMojo extends AbstractOldCoreMojo
             // Manually starts the consumer thread as it is not automatically started in the packaging setup.
             // This is also convenient as we can be sure that the tasks are all queued before being consumed.
             TaskManager taskManager = componentManager.getInstance(TaskManager.class);
-            if (taskManager instanceof DefaultTasksManager) {
-                ((DefaultTasksManager) taskManager).startThread();
+            if (taskManager instanceof DefaultTasksManager defaultTasksManager) {
+                defaultTasksManager.startThread();
             }
 
             getLog().info(

--- a/xwiki-platform-tools/xwiki-platform-tool-standards-validator/src/main/java/org/xwiki/validator/RSSValidator.java
+++ b/xwiki-platform-tools/xwiki-platform-tool-standards-validator/src/main/java/org/xwiki/validator/RSSValidator.java
@@ -50,8 +50,7 @@ public class RSSValidator extends AbstractXMLValidator
         } catch (IllegalArgumentException e) {
             throw new RuntimeException(e);
         } catch (FeedException e) {
-            if (e instanceof ParsingFeedException) {
-                ParsingFeedException pfe = (ParsingFeedException) e;
+            if (e instanceof ParsingFeedException pfe) {
                 addError(Type.ERROR, pfe.getLineNumber(), pfe.getColumnNumber(), e.getMessage());
             } else {
                 addError(Type.ERROR, -1, -1, e.getMessage());


### PR DESCRIPTION
## Summary

Fixes a batch of **40** SonarCloud [`java:S6201`](https://rules.sonarsource.com/java/RSPEC-6201/) issues ("Replace this instanceof check and cast with 'instanceof Foo foo'") across **29 modules**, by binding a pattern variable in the `instanceof` and removing the now-redundant explicit cast(s).

Example:
```java
// before
if (parameter instanceof Block) {
    block = (Block) parameter;
}
// after
if (parameter instanceof Block parameterBlock) {
    block = parameterBlock;
}
```

All changes are behaviour-neutral (Java 16+ pattern matching, the codebase is on Java 17). Casts that fall outside the pattern variable's flow scope, or to a different type, were left untouched as separate sites.

## SonarCloud issues

``[The 40 issues fixed by this PR](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AYyD4ucxj2dtqk6dnyLy,AYyD4s2Fj2dtqk6dnyKV,AYyD4s29j2dtqk6dnyKW,AYyD4q2hj2dtqk6dnyHJ,AYyD4wPmj2dtqk6dnyNZ,AYyD4wPmj2dtqk6dnyNa,AYyD4wPmj2dtqk6dnyNb,AYyD4wPmj2dtqk6dnyNc,AYyD4wPmj2dtqk6dnyNd,AYyD4w2lj2dtqk6dnyNx,AYyD4w2lj2dtqk6dnyNy,AYyD4rqlj2dtqk6dnyIZ,AYyD4rpqj2dtqk6dnyIY,AYyD4roYj2dtqk6dnyIX,AYyD4rnQj2dtqk6dnyIW,AYyD4oAIj2dtqk6dnyCv,AYyD4wtYj2dtqk6dnyNr,AYyD4tAbj2dtqk6dnyKb,AYyD4wHBj2dtqk6dnyNR,AYyD4nkuj2dtqk6dnyCd,AYyD4nkuj2dtqk6dnyCe,AYyD4naJj2dtqk6dnyCJ,AYyD4w65j2dtqk6dnyNz,AYyD4v9cj2dtqk6dnyNN,AYyD4v7hj2dtqk6dnyNM,AYyD4wI-j2dtqk6dnyNT,AYyD4wImj2dtqk6dnyNS,AYyD4wglj2dtqk6dnyNj,AYyD4wglj2dtqk6dnyNk,AYyD4qm7j2dtqk6dnyG3,AYyD4u74j2dtqk6dnyL_,AYyD4u5wj2dtqk6dnyL-,AYyD4xBQj2dtqk6dnyN5,AYyD4wwOj2dtqk6dnyNt,AYyD4vgLj2dtqk6dnyMb,AYyD4vabj2dtqk6dnyMa,AYyD4vMqj2dtqk6dnyMN,AYyD4vMqj2dtqk6dnyMO,AYyD4xJZj2dtqk6dnyN7,AYyD4xNsj2dtqk6dnyN8&open=AYyD4ucxj2dtqk6dnyLy)``

## Test plan

- `mvn clean install -Plegacy,quality` on all 29 affected modules — passes (compilation, Checkstyle, Revapi, JaCoCo and the modules' unit tests all green).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0147DQVNLPa49u5NG3N8RVXX)_