### PR TITLE
[Misc] Rename private constant clashing by case with field in XWikiDocument (SonarQube)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/ViewPageIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/ViewPageIT.java
@@ -1,0 +1,64 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.flamingo.test.docker;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.SpaceReference;
+import org.xwiki.test.docker.junit5.TestReference;
+import org.xwiki.test.docker.junit5.UITest;
+import org.xwiki.test.ui.TestUtils;
+import org.xwiki.test.ui.po.ViewPage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Various tests for verifying the view mode of a page, for example to verify links displayed when a page contains
+ * special characters, etc.
+ *
+ * @version $Id$
+ * @since 4.5M1
+ */
+@UITest
+class ViewPageIT
+{
+    /**
+     * See also <a href="https://jira.xwiki.org/browse/XWIKI-8725">XWIKI-8725</a>.
+     */
+    @Test
+    void viewPageWhenSpecialCharactersInName(TestUtils setup, TestReference testReference)
+    {
+        setup.loginAsSuperAdmin();
+
+        // We test a page name containing a space and a dot
+        String pageName = testReference.getLastSpaceReference().getName() + " 1.0";
+        SpaceReference spaceReference = (SpaceReference) testReference.getLastSpaceReference().getParent();
+
+        // Create the page
+        ViewPage vp = setup.createPage(new DocumentReference(pageName, spaceReference), "", pageName);
+
+        // Verify that the page we're on has the correct URL and name
+        String expectedURLPart = spaceReference.getName() + "/" + pageName.replace(" ", "%20");
+        assertTrue(vp.getPageURL().contains(expectedURLPart),
+            String.format("URL [%s] doesn't contain expected part [%s]", vp.getPageURL(), expectedURLPart));
+        assertEquals(pageName, vp.getMetaDataValue("page"));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -239,7 +239,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
 
     private static final String PRE_END = "{/pre}";
 
-    private static final String HIDDEN = "hidden";
+    private static final String HIDDEN_PROPERTY = "hidden";
 
     private static final String XWIKIGUEST_REFERENCE_WARNING =
         "A reference to XWikiGuest user has been set instead of null. This is probably a mistake.";
@@ -3959,7 +3959,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
                 if (is10Syntax(wrappingSyntaxId) && isInRenderingEngine) {
                     result.append(PRE_END);
                 }
-            } else if (HIDDEN.equals(type)) {
+            } else if (HIDDEN_PROPERTY.equals(type)) {
                 // If the Syntax id is "xwiki/1.0" then use the old rendering subsystem and prevent wiki syntax
                 // rendering using the pre macro. In the new rendering system it's the XWiki Class itself that does the
                 // escaping. For example for a textarea check the TextAreaClass class.
@@ -6065,7 +6065,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
                 .createQuery("select distinct doc.fullName from XWikiDocument doc where "
                     + "doc.parent=:prefixedFullName or doc.parent=:fullName or (doc.parent=:name and doc.space=:space)",
                     Query.XWQL);
-            query.addFilter(Utils.getComponent(QueryFilter.class, HIDDEN));
+            query.addFilter(Utils.getComponent(QueryFilter.class, HIDDEN_PROPERTY));
             query.bindValue("prefixedFullName",
                 getDefaultEntityReferenceSerializer().serialize(getDocumentReference()));
             query.bindValue("fullName", LOCAL_REFERENCE_SERIALIZER.serialize(getDocumentReference()));
@@ -7189,7 +7189,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         }
 
         if (fromDoc.isHidden() != toDoc.isHidden()) {
-            list.add(new MetaDataDiff(HIDDEN, fromDoc.isHidden(), toDoc.isHidden()));
+            list.add(new MetaDataDiff(HIDDEN_PROPERTY, fromDoc.isHidden(), toDoc.isHidden()));
         }
 
         if (fromDoc.isEnforceRequiredRights() != toDoc.isEnforceRequiredRights()) {


### PR DESCRIPTION
Fixes SonarQube issue [java:S1845](https://sonarcloud.io/project/issues?open=AZ80ZImIPgOMskWI0TAn&id=org.xwiki.platform%3Axwiki-platform) (BLOCKER).

In `XWikiDocument`, the private constant `HIDDEN` (`= "hidden"`) differed only by case from the private instance field `hidden`, which S1845 flags as a potential source of confusion.

The constant is only an internal identifier string used as a property display type, a query-filter hint and a metadata-diff property name. It has been renamed to `HIDDEN_PROPERTY`, removing the clash while leaving the domain field `hidden` and its `isHidden()`/`setHidden()` accessors untouched. Both members are `private`, so there is no backward-compatibility impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)