### PR TITLE
[Misc] Fix various mechanical SonarCloud issues

### DIFF
--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/handler/XarExtensionJobFinishedListener.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/handler/XarExtensionJobFinishedListener.java
@@ -256,7 +256,6 @@ public class XarExtensionJobFinishedListener implements EventListener
                     this.logger.error("Failed to load attachments", e);
                     // Lets be safe and skip removing that page
                     pages.put(reference, false);
-                    continue;
                 }
             }
 

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/repository/XarInstalledExtensionRepository.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/repository/XarInstalledExtensionRepository.java
@@ -217,8 +217,6 @@ public class XarInstalledExtensionRepository extends AbstractInstalledExtensionR
                     }
                 } catch (Exception e) {
                     this.logger.error("Failed to parse extension [{}]", localExtension.getId(), e);
-
-                    continue;
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/handler/WikiEventListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/handler/WikiEventListenerTest.java
@@ -61,8 +61,6 @@ class WikiEventListenerTest
 
     private InstalledExtensionRepository installedExtensionRepository;
 
-    private WikiDescriptorManager wikiDescriptorManager;
-
     private ObservationManager observation;
 
     private LocalExtension localExtension1;
@@ -72,7 +70,7 @@ class WikiEventListenerTest
     @AfterComponent
     void afterComponent() throws Exception
     {
-        this.wikiDescriptorManager = this.componentManager.registerMockComponent(WikiDescriptorManager.class);
+        this.componentManager.registerMockComponent(WikiDescriptorManager.class);
     }
 
     @AfterComponent

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/ExtensionIndexInitializerListener.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/ExtensionIndexInitializerListener.java
@@ -63,8 +63,8 @@ public class ExtensionIndexInitializerListener extends AbstractEventListener
     {
         if (event instanceof ApplicationReadyEvent) {
             this.scheduler.start();
-        } else if (event instanceof WikiReadyEvent) {
-            this.scheduler.initialize(new WikiNamespace(((WikiReadyEvent) event).getWikiId()));
+        } else if (event instanceof WikiReadyEvent wikiReadyEvent) {
+            this.scheduler.initialize(new WikiNamespace(wikiReadyEvent.getWikiId()));
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/ExtensionIndexStore.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/ExtensionIndexStore.java
@@ -333,9 +333,7 @@ public class ExtensionIndexStore implements Initializable, Disposable
         this.utils.setAtomic(SolrUtils.ATOMIC_UPDATE_MODIFIER_SET, RemoteExtension.FIELD_RECOMMENDED,
             remoteExtension.isRecommended(), document);
 
-        if (remoteExtension instanceof RatingExtension) {
-            RatingExtension ratingExtension = (RatingExtension) remoteExtension;
-
+        if (remoteExtension instanceof RatingExtension ratingExtension) {
             this.utils.setAtomic(SolrUtils.ATOMIC_UPDATE_MODIFIER_SET, RatingExtension.FIELD_TOTAL_VOTES,
                 ratingExtension.getRating().getTotalVotes(), document);
             this.utils.setAtomic(SolrUtils.ATOMIC_UPDATE_MODIFIER_SET, RatingExtension.FIELD_AVERAGE_VOTE,
@@ -869,9 +867,7 @@ public class ExtensionIndexStore implements Initializable, Disposable
         }
 
         // Indexed
-        if (query instanceof IndexedExtensionQuery) {
-            IndexedExtensionQuery indexedQuery = (IndexedExtensionQuery) query;
-
+        if (query instanceof IndexedExtensionQuery indexedQuery) {
             // Compatible
             if (indexedQuery.getCompatible() != null) {
                 StringBuilder builder = new StringBuilder();

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/job/ExtensionIndexJob.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/job/ExtensionIndexJob.java
@@ -576,17 +576,16 @@ public class ExtensionIndexJob extends AbstractJob<ExtensionIndexRequest, Defaul
 
         // Add the extensions
         for (Extension extension : extensions) {
-            if (!this.invalidFlavors.contains(extension.getId().getId())) {
-                // TODO: support beta and snapshots versions too ?
-                if (extension.getId().getVersion().getType() == Type.STABLE
-                    && !this.indexStore.exists(extension.getId(), true)) {
-                    this.indexStore.add(extension, true);
+            // TODO: support beta and snapshots versions too ?
+            if (!this.invalidFlavors.contains(extension.getId().getId())
+                && extension.getId().getVersion().getType() == Type.STABLE
+                && !this.indexStore.exists(extension.getId(), true)) {
+                this.indexStore.add(extension, true);
 
-                    updated = true;
-                    getStatus().setExtensionAdded(true);
+                updated = true;
+                getStatus().setExtensionAdded(true);
 
-                    add(extension.getId(), indexedExtensions);
-                }
+                add(extension.getId(), indexedExtensions);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/VulnerabilityIndexer.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/VulnerabilityIndexer.java
@@ -97,8 +97,8 @@ public class VulnerabilityIndexer
 
             analysis.setCoreExtension(extension instanceof CoreExtension);
             if (!securityVulnerabilities.isEmpty()) {
-                if (extension instanceof CoreExtension) {
-                    if (isFromEnvironment((CoreExtension) extension)) {
+                if (extension instanceof CoreExtension coreExtension) {
+                    if (isFromEnvironment(coreExtension)) {
                         analysis.setAdvice(UPGRADE_ENVIRONMENT_ADVICE.getTranslationId());
                     } else {
                         analysis.setAdvice(UPGRADE_XWIKI_ADVICE.getTranslationId());
@@ -141,8 +141,8 @@ public class VulnerabilityIndexer
      */
     private static boolean isDirectDependency(Extension extension)
     {
-        return extension instanceof InstalledExtension
-            && ((InstalledExtension) extension).isDependency(null);
+        return extension instanceof InstalledExtension installedExtension
+            && installedExtension.isDependency(null);
     }
 
     private static String formatReviews(List<Review> reviews)

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/listener/ExtensionSecurityInitializerListener.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/listener/ExtensionSecurityInitializerListener.java
@@ -67,8 +67,8 @@ public class ExtensionSecurityInitializerListener extends AbstractLocalEventList
     {
         // Clustering related note: since the JobFinishedEvent is only sent by node, the scheduler will also be stared 
         // on a single node. Therefore 
-        if (event instanceof JobFinishedEvent
-            && Objects.equals(((JobFinishedEvent) event).getJobType(), JOB_TYPE))
+        if (event instanceof JobFinishedEvent jobFinishedEvent
+            && Objects.equals(jobFinishedEvent.getJobType(), JOB_TYPE))
         {
             this.schedulerProvider.get().start();
         }

--- a/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
@@ -847,8 +847,8 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
             Constructor< ? extends SyndEntrySource> ctor = null;
             if (params != null) {
                 try {
-                    ctor = sesc.getConstructor(new Class[] {Map.class});
-                    return ctor.newInstance(new Object[] {params});
+                    ctor = sesc.getConstructor(Map.class);
+                    return ctor.newInstance(params);
                 } catch (Throwable t) {
                 }
             }

--- a/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/SyndEntryDocumentSource.java
+++ b/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/SyndEntryDocumentSource.java
@@ -357,7 +357,7 @@ public class SyndEntryDocumentSource implements SyndEntrySource
         String author = xwiki.getUserName(doc.getAuthor(), null, false, context);
         // the description format should be taken from a resource bundle, and thus localized
         String descFormat = "Version %1$s edited by %2$s on %3$s";
-        return String.format(descFormat, new Object[] {doc.getVersion(), author, doc.getDate()});
+        return String.format(descFormat, doc.getVersion(), author, doc.getDate());
     }
 
     protected SyndContent getDescription(Document doc, Map<String, Object> params, XWikiContext context)

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-default/src/main/java/org/xwiki/index/internal/TaskApplicationReadyListener.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-default/src/main/java/org/xwiki/index/internal/TaskApplicationReadyListener.java
@@ -66,8 +66,8 @@ public class TaskApplicationReadyListener extends AbstractEventListener implemen
     public void onEvent(Event event, Object source, Object data)
     {
         // In case of ApplicationReadyEvent (when the wiki starts) and the implementation of type DefaultTasksManager.
-        if (this.taskManager instanceof DefaultTasksManager) {
-            ((DefaultTasksManager) this.taskManager).startThread();
+        if (this.taskManager instanceof DefaultTasksManager tasksManager) {
+            tasksManager.startThread();
         }
     }
 
@@ -76,8 +76,8 @@ public class TaskApplicationReadyListener extends AbstractEventListener implemen
     {
         // If the application is already initialized we start the threads immediately (e.g. in case of extension
         // install) and the implementation of type DefaultTasksManager.
-        if (this.contextProvider.get() != null && this.taskManager instanceof DefaultTasksManager) {
-            ((DefaultTasksManager) this.taskManager).startThread();
+        if (this.contextProvider.get() != null && this.taskManager instanceof DefaultTasksManager tasksManager) {
+            tasksManager.startThread();
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/java/org/xwiki/index/tree/internal/nestedpages/query/DocumentReferenceResolverFilter.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/java/org/xwiki/index/tree/internal/nestedpages/query/DocumentReferenceResolverFilter.java
@@ -85,10 +85,10 @@ public class DocumentReferenceResolverFilter implements QueryFilter
 
     protected boolean toBoolean(Object value)
     {
-        if (value instanceof Boolean) {
-            return (Boolean) value;
-        } else if (value instanceof Number) {
-            return ((Number) value).intValue() != 0;
+        if (value instanceof Boolean booleanValue) {
+            return booleanValue;
+        } else if (value instanceof Number number) {
+            return number.intValue() != 0;
         } else {
             return false;
         }

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/listeners/ColorThemeListener.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/listeners/ColorThemeListener.java
@@ -96,7 +96,6 @@ public class ColorThemeListener implements EventListener
         List<BaseObject> colorThemeObjects = document.getXObjects(COLOR_THEME_CLASS);
         if (colorThemeObjects != null && !colorThemeObjects.isEmpty()) {
             clearCacheFromColorTheme(document);
-            return;
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/listeners/SkinListener.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/listeners/SkinListener.java
@@ -89,7 +89,6 @@ public class SkinListener implements EventListener
         List<BaseObject> skinObjects = document.getXObjects(SKIN_CLASS);
         if (skinObjects != null && !skinObjects.isEmpty()) {
             clearCacheFromSkin(document);
-            return;
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/grouping/OneMailPerCompositeEmailGroupingStrategy.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/grouping/OneMailPerCompositeEmailGroupingStrategy.java
@@ -27,7 +27,6 @@ import org.xwiki.notifications.notifiers.email.NotificationEmailGroupingStrategy
 import javax.inject.Named;
 import javax.inject.Singleton;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * This component offers a strategy for sending one email per composite event to notify to the user.
@@ -48,6 +47,6 @@ public class OneMailPerCompositeEmailGroupingStrategy implements NotificationEma
     public List<List<CompositeEvent>> groupEventsPerMail(List<CompositeEvent> compositeEvents)
             throws NotificationException
     {
-        return compositeEvents.stream().map(List::of).collect(Collectors.toList());
+        return compositeEvents.stream().map(List::of).toList();
     }
 }


### PR DESCRIPTION
## Summary

A batch of mechanical, behaviour-preserving cleanups reported by [SonarCloud](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform), spanning several modules and rule types. 20 issues fixed:

| Rule | Count | Description |
|---|---|---|
| `java:S6201` | 11 | Use `instanceof` pattern matching (drop redundant casts) |
| `java:S3626` | 4 | Remove redundant jump statements |
| `java:S3878` | 3 | Remove arrays created for varargs |
| `java:S1066` | 1 | Merge collapsible nested `if` |
| `java:S1068` | 1 | Remove unused private field |
| `java:S6204` | 1 | `Stream.collect(Collectors.toList())` → `Stream.toList()` |

Modules touched: `extension-handler-xar`, `extension-index`, `extension-security-index`, `feed-api`, `index-default`, `index-tree-api`, `lesscss-default`, `notifications-notifiers-api`.

All changes are line-local and preserve behaviour. The `S6204` conversion was applied only where the resulting unmodifiable list stays confined to internal code; sites where the list escapes into a public/script API were intentionally left unchanged.

## Test plan

Built the 8 affected modules with `mvn clean install -Plegacy,quality` (includes tests, Checkstyle, Revapi, JaCoCo and Enforcer) — `BUILD SUCCESS`, all tests green.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ktagrpYDjRxNo77z3khR2)_