### PR TITLE
[Misc] Fix various mechanical SonarCloud issues

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/internal/renderer/AnnotationGeneratorChainingListener.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/internal/renderer/AnnotationGeneratorChainingListener.java
@@ -238,13 +238,11 @@ public class AnnotationGeneratorChainingListener extends QueueListener implement
                 } else {
                     // cannot find the events for the start and / or end of annotation, ignore it
                     // TODO: mark it somehow...
-                    continue;
                 }
             } else {
                 // cannot find the context of the annotation or the annotation selection cannot be found in the
                 // annotation context, ignore it
                 // TODO: mark it somehow...
-                continue;
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-reference/src/main/java/org/xwiki/annotation/reference/IndexedObjectReference.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-reference/src/main/java/org/xwiki/annotation/reference/IndexedObjectReference.java
@@ -135,7 +135,6 @@ public class IndexedObjectReference extends ObjectReference
             className = name.substring(0, openPosition);
         } catch (NumberFormatException e) {
             // number could not be parsed, which means className stays name, and object stays null
-            return;
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/SolrEventStore.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/SolrEventStore.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -435,7 +434,7 @@ public class SolrEventStore extends AbstractAsynchronousEventStore
         SolrQuery solrQuery = new SolrQuery();
 
         solrQuery.addFilterQuery(serializeInCondition(EventsSolrCoreInitializer.SOLR_FIELD_ID,
-            events.stream().map(Event::getId).collect(Collectors.toList())));
+            events.stream().map(Event::getId).toList()));
 
         solrQuery.addFilterQuery(serializeInCondition(EventsSolrCoreInitializer.SOLR_FIELD_READLISTENERS, entityIds)
             + SOLR_OR + serializeInCondition(EventsSolrCoreInitializer.SOLR_FIELD_UNREADLISTENERS, entityIds));

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/job/ExtensionIndexJob.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/job/ExtensionIndexJob.java
@@ -67,7 +67,6 @@ import org.xwiki.extension.repository.result.IterableResult;
 import org.xwiki.extension.repository.search.SearchException;
 import org.xwiki.extension.repository.search.Searchable;
 import org.xwiki.extension.version.Version;
-import org.xwiki.extension.version.Version.Type;
 import org.xwiki.extension.version.VersionConstraint;
 import org.xwiki.extension.version.internal.VersionUtils;
 import org.xwiki.job.AbstractJob;
@@ -565,33 +564,6 @@ public class ExtensionIndexJob extends AbstractJob<ExtensionIndexRequest, Defaul
         }
 
         this.progress.popLevelProgress(indexedExtensions);
-    }
-
-    private void addLocalExtensions(Map<String, SortedSet<Version>> indexedExtensions)
-        throws SearchException, SolrServerException, IOException
-    {
-        boolean updated = false;
-
-        IterableResult<Extension> extensions = this.localExtensions.search("", 0, -1);
-
-        // Add the extensions
-        for (Extension extension : extensions) {
-            // TODO: support beta and snapshots versions too ?
-            if (!this.invalidFlavors.contains(extension.getId().getId())
-                && extension.getId().getVersion().getType() == Type.STABLE
-                && !this.indexStore.exists(extension.getId(), true)) {
-                this.indexStore.add(extension, true);
-
-                updated = true;
-                getStatus().setExtensionAdded(true);
-
-                add(extension.getId(), indexedExtensions);
-            }
-        }
-
-        if (updated) {
-            this.indexStore.commit();
-        }
     }
 
     private void addRemoteExtensions(Map<String, SortedSet<Version>> indexedExtensions)

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/ExtensionRatingScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/ExtensionRatingScriptService.java
@@ -117,7 +117,6 @@ public class ExtensionRatingScriptService extends AbstractExtensionScriptService
                 } catch (ResolveException e) {
                     setError(e);
                     // Keep looking. Maybe there's another repository with the same extension.
-                    continue;
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/ReviewMapFilter.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/ReviewMapFilter.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -93,7 +92,7 @@ public class ReviewMapFilter
                         .anyMatch(it -> pattern.matcher(it).matches());
                 }
                 return match;
-            }).collect(Collectors.toList()));
+            }).toList());
         }
 
         // Replace the content with the filtered content.

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/WikiReader.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/WikiReader.java
@@ -142,7 +142,6 @@ public class WikiReader
             if (entry.isDirectory() || entry.getName().startsWith("META-INF")) {
                 // The entry is either a directory or is something inside of the META-INF dir.
                 // (we use that directory to put meta data such as LICENSE/NOTICE files.)
-                continue;
             } else if (entry.getName().equals(XarModel.PATH_PACKAGE)) {
                 readPackage(zis, entry);
             } else {

--- a/xwiki-platform-core/xwiki-platform-flavor/xwiki-platform-flavor-api/src/main/java/org/xwiki/platform/flavor/internal/DefaultFlavorManager.java
+++ b/xwiki-platform-core/xwiki-platform-flavor/xwiki-platform-flavor-api/src/main/java/org/xwiki/platform/flavor/internal/DefaultFlavorManager.java
@@ -103,23 +103,6 @@ public class DefaultFlavorManager implements FlavorManager
         return result;
     }
 
-    private Collection<ExtensionId> getFlavors(String property)
-    {
-        Collection<ExtensionId> flavors = new LinkedHashSet<>();
-
-        // Get flavors from environment extension
-        List<String> ids = getEnvironmentPropertyList(property);
-        if (!ids.isEmpty()) {
-            flavors.addAll(this.converter.convert(ExtensionId.TYPE_LIST, ids));
-        }
-
-        // TODO: Get flavors from configuration
-        // flavors.addAll(configurationSource.getProperty("extension.flavor.known",
-        // Collections.<String>emptyList()));
-
-        return flavors;
-    }
-
     private List<String> getEnvironmentPropertyList(String property)
     {
         // Get flavors from environment extension

--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-api/src/main/java/org/xwiki/localization/LocaleUtils.java
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-api/src/main/java/org/xwiki/localization/LocaleUtils.java
@@ -37,7 +37,7 @@ import org.apache.commons.lang3.StringUtils;
 public class LocaleUtils extends org.apache.commons.lang3.LocaleUtils
 {
     // class to avoid synchronization (Init on demand)
-    static class SyncAvoid
+    static final class SyncAvoid
     {
         /**
          * Unmodifiable list of available locales.
@@ -60,6 +60,11 @@ public class LocaleUtils extends org.apache.commons.lang3.LocaleUtils
             }
             AVAILABLE_LOCALE_LIST = Collections.unmodifiableList(list);
             AVAILABLE_LOCALE_SET = Collections.unmodifiableSet(new HashSet<>(list));
+        }
+
+        private SyncAvoid()
+        {
+            // Utility class, no instantiation.
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/EntityReferenceSetTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/EntityReferenceSetTest.java
@@ -147,11 +147,6 @@ class EntityReferenceSetTest
         excludes(reference, EntityType.SPACE);
     }
 
-    private void excludesDocument(String reference) throws Exception
-    {
-        excludes(reference, EntityType.DOCUMENT);
-    }
-
     // Tests
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/EscapeLikeParametersQuery.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/EscapeLikeParametersQuery.java
@@ -83,9 +83,9 @@ public class EscapeLikeParametersQuery extends WrappingQuery
             Map<T, Object> escapedMap = new LinkedHashMap<>();
             for (Map.Entry<T, Object> entry : parametersToEscape.entrySet()) {
                 // TODO: Also handle Arrays and collections in the future
-                if (modifiedParameters.contains(entry.getKey()) && entry.getValue() instanceof DefaultQueryParameter) {
+                if (modifiedParameters.contains(entry.getKey())
+                    && entry.getValue() instanceof DefaultQueryParameter queryParameter) {
                     // Join the parameter parts and escape the literal parts
-                    DefaultQueryParameter queryParameter = (DefaultQueryParameter) entry.getValue();
                     StringBuffer buffer = new StringBuffer();
                     for (ParameterPart part : queryParameter.getParts()) {
                         if (part instanceof LiteralParameterPart) {

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/XWikiRepositoryModel.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/XWikiRepositoryModel.java
@@ -42,7 +42,7 @@ import org.xwiki.model.reference.RegexEntityReference;
 
 import com.xpn.xwiki.objects.BaseObjectReference;
 
-public class XWikiRepositoryModel
+public final class XWikiRepositoryModel
 {
     // References
 
@@ -468,6 +468,11 @@ public class XWikiRepositoryModel
     }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(XWikiRepositoryModel.class);
+
+    private XWikiRepositoryModel()
+    {
+        // Utility class, no instantiation.
+    }
 
     public static String toExtensionClassSolrPropertyName(String propertyName)
     {

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/DomainObjectFactory.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/DomainObjectFactory.java
@@ -63,8 +63,13 @@ import com.xpn.xwiki.objects.BaseObject;
  * 
  * @version $Id$
  */
-public class DomainObjectFactory
+public final class DomainObjectFactory
 {
+    private DomainObjectFactory()
+    {
+        // Utility class, no instantiation.
+    }
+
     public static ModelFactory getModelFactory()
     {
         return com.xpn.xwiki.web.Utils.getComponent(ModelFactory.class);

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
@@ -35,8 +35,6 @@ import java.util.Vector;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.commons.lang3.StringUtils;
@@ -48,8 +46,6 @@ import org.xwiki.job.Request;
 import org.xwiki.logging.LogLevel;
 import org.xwiki.logging.event.LogEvent;
 import org.xwiki.logging.tail.LogTail;
-import org.xwiki.mail.EmailAddressObfuscator;
-import org.xwiki.mail.GeneralMailConfiguration;
 import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
@@ -172,14 +168,6 @@ public class ModelFactory
 
     @Inject
     private UserReferenceSerializer<String> userReferenceSerializer;
-
-    // Needs to be a provider because some dependencies are lacking an implementation of this component at compile time.
-    @Inject
-    private Provider<GeneralMailConfiguration> generalMailConfiguration;
-
-    // Needs to be a provider because some dependencies are lacking an implementation of this component at compile time.
-    @Inject
-    private Provider<EmailAddressObfuscator> emailAddressObfuscator;
 
     public ModelFactory()
     {
@@ -1305,30 +1293,5 @@ public class ModelFactory
         }
 
         return true;
-    }
-
-    private String cleanupBeforeMakingPublic(String type, PropertyInterface baseProperty)
-    {
-        String cleanedUpStringValue;
-        if (Objects.equals(type, PASSWORD_TYPE)) {
-            cleanedUpStringValue = null;
-        } else {
-            cleanedUpStringValue = serializePropertyValue(baseProperty);
-            // We obfuscate the email only if the obfuscation has been activated, and if the current user does not have
-            // the right to edit the document containing the base property.
-            // A user allowed to edit a document has to view the unescaped email to be able to edit it correctly.
-            if (Objects.equals(type, "Email") && this.generalMailConfiguration.get().shouldObfuscate()
-                && !this.authorizationManagerProvider.get().hasAccess(Right.EDIT, baseProperty.getReference())) {
-                try {
-                    cleanedUpStringValue =
-                        this.emailAddressObfuscator.get().obfuscate(InternetAddress.parse(cleanedUpStringValue)[0]);
-                } catch (AddressException e) {
-                    this.logger.warn("Failed to parse [{}] to an email address. Cause: [{}]", cleanedUpStringValue,
-                        getRootCauseMessage(e));
-                    cleanedUpStringValue = "";
-                }
-            }
-        }
-        return cleanedUpStringValue;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrUtils.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrUtils.java
@@ -258,15 +258,6 @@ public class DefaultSolrUtils implements SolrUtils
         return null;
     }
 
-    private static boolean isList(Class<?> clazz)
-    {
-        if (clazz != null && !CLASS_SUFFIX_MAPPING.containsKey(clazz)) {
-            return Iterable.class.isAssignableFrom(clazz) || clazz.isArray();
-        }
-
-        return false;
-    }
-
     private static String getTypeName(Type type)
     {
         if (type != null) {

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/AbstractSolrMetadataExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/AbstractSolrMetadataExtractor.java
@@ -308,10 +308,9 @@ public abstract class AbstractSolrMetadataExtractor implements SolrMetadataExtra
 
         for (Locale locale : availableLocales) {
             // Add locale only if there is no explicit translation for it
-            if (!documentLocales.contains(locale)) {
-                if (entityLocale == null || locale.toString().startsWith(entityLocaleString)) {
-                    locales.add(locale);
-                }
+            if (!documentLocales.contains(locale)
+                && (entityLocale == null || locale.toString().startsWith(entityLocaleString))) {
+                locales.add(locale);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-embedded/src/main/java/org/xwiki/search/solr/internal/EmbeddedSolr.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-embedded/src/main/java/org/xwiki/search/solr/internal/EmbeddedSolr.java
@@ -381,12 +381,9 @@ public class EmbeddedSolr extends AbstractSolr implements Disposable, Initializa
 
         // Check the version of the schema
         File schemaFile = this.solrSearchCorePath.resolve(SCHEMA_PATH).toFile();
-        if (!schemaFile.exists() || SEARCH_CORE_MAJOR_VERSION > getCoreVersion(schemaFile)) {
-            return false;
-        }
 
         // Everything seems to have as expected
-        return true;
+        return schemaFile.exists() && SEARCH_CORE_MAJOR_VERSION <= getCoreVersion(schemaFile);
     }
 
     private void recreateSearchCore() throws IOException

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-embedded/src/test/java/org/xwiki/search/solr/internal/EmbeddedSolrInitializationTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-embedded/src/test/java/org/xwiki/search/solr/internal/EmbeddedSolrInitializationTest.java
@@ -72,9 +72,9 @@ import org.xwiki.test.mockito.MockitoComponentManager;
 @ComponentTest
 class EmbeddedSolrInitializationTest
 {
-    private final static String SOLRHOME_PROPERTY = String.format("%s.%s.%s", "solr", EmbeddedSolr.TYPE, "home");
+    private static final String SOLRHOME_PROPERTY = String.format("%s.%s.%s", "solr", EmbeddedSolr.TYPE, "home");
 
-    private final static String SEARCH_SOLRCORE = SolrClientInstance.CORE_NAME + '_' + Version.LATEST.major;
+    private static final String SEARCH_SOLRCORE = SolrClientInstance.CORE_NAME + '_' + Version.LATEST.major;
 
     @XWikiTempDir
     private File permanentDirectory;

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-server/xwiki-platform-search-solr-server-plugin/src/main/java/org/xwiki/search/solr/internal/XWikiDismaxQParserPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-server/xwiki-platform-search-solr-server-plugin/src/main/java/org/xwiki/search/solr/internal/XWikiDismaxQParserPlugin.java
@@ -234,10 +234,8 @@ public class XWikiDismaxQParserPlugin extends ExtendedDismaxQParserPlugin
                 if (fieldName.startsWith(fieldNamePattern.substring(0, fieldNamePattern.length() - 1))) {
                     return true;
                 }
-            } else if (fieldNamePattern.startsWith(WILDCARD)) {
-                if (fieldName.endsWith(fieldNamePattern.substring(1))) {
-                    return true;
-                }
+            } else if (fieldNamePattern.startsWith(WILDCARD) && fieldName.endsWith(fieldNamePattern.substring(1))) {
+                return true;
             }
         }
         return false;

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/sx/SxDocumentSource.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/sx/SxDocumentSource.java
@@ -74,9 +74,6 @@ public class SxDocumentSource implements SxSource
     /** The document containing the extension. */
     private XWikiDocument document;
 
-    /** The current XWikiContext. */
-    private XWikiContext context;
-
     /** The type of Extension for getting the right kind of object from the document. */
     private Extension extension;
 
@@ -88,7 +85,6 @@ public class SxDocumentSource implements SxSource
      */
     public SxDocumentSource(XWikiContext context, Extension extension)
     {
-        this.context = context;
         this.document = context.getDoc();
         this.extension = extension;
     }

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/attach/AttachController.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/attach/AttachController.java
@@ -51,14 +51,11 @@ public class AttachController extends FsAbstractController
 {
     private static final BitField<Access> READ_ONLY = BitField.of(READ);
 
-    private final AttachDriver driver;
-
     private ComponentManager componentManager;
 
-    AttachController(AttachDriver driver, FsModel model, ComponentManager componentManager)
+    AttachController(FsModel model, ComponentManager componentManager)
     {
         super(model);
-        this.driver = driver;
         this.componentManager = componentManager;
     }
 

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/attach/AttachDriver.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/attach/AttachDriver.java
@@ -48,6 +48,6 @@ public class AttachDriver extends FsDriver
     @Override
     public FsController newController(FsManager manager, FsModel model, FsController parent)
     {
-        return new AttachController(this, model, this.componentManager);
+        return new AttachController(model, this.componentManager);
     }
 }


### PR DESCRIPTION
## Summary

Mechanical, behaviour-preserving cleanups reported by SonarCloud across several leaf modules. Each change is a single-line/single-block fix that preserves semantics; the affected modules were verified with `mvn install -Plegacy,quality` (Checkstyle + Spoon + Revapi + JaCoCo + unit tests).

Rules fixed:
* `java:S1066` — merge collapsible nested `if` statements
* `java:S1068` — remove unused private fields
* `java:S1118` — add a private constructor to hide the implicit public one (utility classes)
* `java:S1124` — reorder modifiers to comply with the JLS
* `java:S1126` — replace an if-then-else by a single return statement
* `java:S1144` — remove unused private methods (and the fields/imports they orphaned)
* `java:S3626` — remove redundant jump statements
* `java:S6201` — use `instanceof` pattern matching (drop redundant casts)
* `java:S6204` — replace `Stream.collect(Collectors.toList())` with `Stream.toList()` (only where the result cannot escape as a mutable list)

SonarCloud issues addressed: ``[filtered view](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issues=AW5-S-Cd1Yj5qvzeRot8%2CAW5-S-aW1Yj5qvzeRo2I%2CAW5-S-g71Yj5qvzeRo3q%2CAW5-S4eN1Yj5qvzeRmqj%2CAW5-S5Ch1Yj5qvzeRmw-%2CAW5-S5Ch1Yj5qvzeRmw9%2CAW5-S5Id1Yj5qvzeRmy5%2CAW5-S7-l1Yj5qvzeRoDB%2CAW5-S77M1Yj5qvzeRoB_%2CAW5-S7JS1Yj5qvzeRn4m%2CAW5-S8xM1Yj5qvzeRoO6%2CAY974oZ3KZk1650DhyOi%2CAYDYVrBMVBlv98NhNcQT%2CAYyD4r2xj2dtqk6dnyIi%2CAYyD4rOXj2dtqk6dnyHo%2CAYyD4si6j2dtqk6dnyJp%2CAZBvgSePcj_-G2g1uBsy%2CAZBvgSePcj_-G2g1uBsz%2CAZEyzR5yylklwX4lWOWY%2CAZGaGx8HPhpr_P5DN477%2CAZimiY5x04h2nrvpqYEA%2CAZzGqR_0XFD7Ud6sqSQx%2CAZzff0GdPhPIe6f1ng-L).``

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCGcH9vXHc3oQb8F8LHAhh)_