### PR TITLE
[Misc] Fix various mechanical SonarCloud issues

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/io/internal/migration/hibernate/R40001XWIKI7540DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/io/internal/migration/hibernate/R40001XWIKI7540DataMigration.java
@@ -456,16 +456,14 @@ public class R40001XWIKI7540DataMigration extends AbstractHibernateDataMigration
                 // If the deleted property was "annotation" (from AnnotationClass), then use the new
                 // property "comment" for (XWikiComments).
                 newProperty.setName("comment");
-            } else if ("replyto".equals(deletedProperty.getName())) {
+            } else if ("replyto".equals(deletedProperty.getName()) && deletedProperty.getValue() != null) {
                 // XWIKI-7745: We need to handle the fact that the "replyto" property needs to point to the new object
                 // number of the comment it was previously assigned to, since the comment can now have a new number
                 // assigned to it.
-                if (deletedProperty.getValue() != null) {
-                    int oldValue = (Integer) deletedProperty.getValue();
-                    int newValue = this.oldToNewCommentNumberMap.get(oldValue);
+                int oldValue = (Integer) deletedProperty.getValue();
+                int newValue = this.oldToNewCommentNumberMap.get(oldValue);
 
-                    newProperty.setValue(newValue);
-                }
+                newProperty.setValue(newValue);
             }
             return newProperty;
         }

--- a/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
@@ -852,8 +852,8 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
                 } catch (Throwable t) {
                 }
             }
-            ctor = sesc.getConstructor(new Class[] {});
-            return ctor.newInstance(new Object[] {});
+            ctor = sesc.getConstructor();
+            return ctor.newInstance();
         } catch (Throwable t) {
             throw new XWikiException(XWikiException.MODULE_XWIKI_PLUGINS, XWikiException.ERROR_XWIKI_UNKNOWN, "", t);
         }

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/DocumentLocaleReader.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/DocumentLocaleReader.java
@@ -533,13 +533,11 @@ public class DocumentLocaleReader extends AbstractReader
     {
         this.currentLegacyDocument = xmlReader.getElementText();
 
-        if (this.currentDocumentReference == null) {
-            // Its an old thing
-            if (this.currentLegacySpace != null) {
-                this.currentDocumentReference =
-                    new LocalDocumentReference(this.currentLegacySpace, this.currentLegacyDocument);
-                this.currentSpaceReference = this.currentDocumentReference.getParent();
-            }
+        // Its an old thing
+        if (this.currentDocumentReference == null && this.currentLegacySpace != null) {
+            this.currentDocumentReference =
+                new LocalDocumentReference(this.currentLegacySpace, this.currentLegacyDocument);
+            this.currentSpaceReference = this.currentDocumentReference.getParent();
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/org/xwiki/legacy/internal/oldcore/notification/LegacyNotificationDispatcher.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/org/xwiki/legacy/internal/oldcore/notification/LegacyNotificationDispatcher.java
@@ -124,10 +124,10 @@ public class LegacyNotificationDispatcher implements EventListener
             } else if (event instanceof DocumentDeletingEvent) {
                 manager.preverify(document, new XWikiDocument(document.getDocumentReference()),
                     XWikiDocChangeNotificationInterface.EVENT_DELETE, context);
-            } else if (event instanceof ActionExecutedEvent) {
-                manager.verify(document, ((ActionExecutedEvent) event).getActionName(), context);
-            } else if (event instanceof ActionExecutingEvent) {
-                manager.preverify(document, ((ActionExecutingEvent) event).getActionName(), context);
+            } else if (event instanceof ActionExecutedEvent actionExecutedEvent) {
+                manager.verify(document, actionExecutedEvent.getActionName(), context);
+            } else if (event instanceof ActionExecutingEvent actionExecutingEvent) {
+                manager.preverify(document, actionExecutingEvent.getActionName(), context);
             }
         } else {
             this.logger.error("Can't find old [XWikiNotificationManager] system");

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseCollection.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseCollection.java
@@ -245,13 +245,11 @@ public abstract class BaseCollection<R extends EntityReference> extends BaseElem
     public void setClassName(String name)
     {
         EntityReference xClassReference = null;
-        if (!StringUtils.isEmpty(name)) {
-            // Handle backward compatibility: In the past, for statistics objects we used to use a special class name
-            // of "internal". We now check for a null Class Reference instead wherever we were previously checking for
-            // "internal".
-            if (!"internal".equals(name)) {
-                xClassReference = getRelativeEntityReferenceResolver().resolve(name, EntityType.DOCUMENT);
-            }
+        // Handle backward compatibility: In the past, for statistics objects we used to use a special class name
+        // of "internal". We now check for a null Class Reference instead wherever we were previously checking for
+        // "internal".
+        if (!StringUtils.isEmpty(name) && !"internal".equals(name)) {
+            xClassReference = getRelativeEntityReferenceResolver().resolve(name, EntityType.DOCUMENT);
         }
         setXClassReference(xClassReference);
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiVersioningStoreInterface.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiVersioningStoreInterface.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.suigeneris.jrcs.rcs.Version;
 import org.xwiki.component.annotation.Role;
@@ -117,7 +116,7 @@ public interface XWikiVersioningStoreInterface
     {
         return filterVersions(getXWikiDocumentArchive(doc, context), criteria).stream()
             .map(Version::new)
-            .collect(Collectors.toList());
+            .toList();
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SkinAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SkinAction.java
@@ -171,14 +171,13 @@ public class SkinAction extends XWikiAction
                 }
 
                 // Try on the default base skin, if it wasn't already tested above.
+                // defaultbaseskin can only be on the filesystem, so don't try to use it as a
+                // skin document.
                 if (StringUtils.isNotEmpty(baseskin)
-                    && !(doc.getName().equals(defaultbaseskin) || baseskin.equals(defaultbaseskin))) {
-                    // defaultbaseskin can only be on the filesystem, so don't try to use it as a
-                    // skin document.
-                    if (renderSkinFileFromResource(defaultbaseskin, filename, context)) {
-                        found = true;
-                        break;
-                    }
+                    && !(doc.getName().equals(defaultbaseskin) || baseskin.equals(defaultbaseskin))
+                    && renderSkinFileFromResource(defaultbaseskin, filename, context)) {
+                    found = true;
+                    break;
                 }
 
                 // Try in the resources directory.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/query/hql/internal/StandardHQLCompleteStatementValidator.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/query/hql/internal/StandardHQLCompleteStatementValidator.java
@@ -298,11 +298,9 @@ public class StandardHQLCompleteStatementValidator implements HQLCompleteStateme
                 if (!isFunctionSafe(function)) {
                     return false;
                 }
-            } else if (value instanceof PlainSelect plainSelect) {
+            } else if (value instanceof PlainSelect plainSelect && !isPlainSelectSafe(plainSelect)) {
                 // Check if the select is safe
-                if (!isPlainSelectSafe(plainSelect)) {
-                    return false;
-                }
+                return false;
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroRenderer.java
@@ -659,14 +659,13 @@ public class DefaultWikiMacroRenderer extends AbstractBlockAsyncRenderer
             } else if (macroBlock.getId().equals(WikiMacroParameterMacro.ID)) {
                 return resolveMacroParameter(macroBlock);
             }
-        } else if (block instanceof RawBlock rawBlock) {
+        } else if (block instanceof RawBlock rawBlock
+            && (rawBlock.getSyntax().getType().equals(SyntaxType.XHTML)
+                || rawBlock.getSyntax().getType().equals(SyntaxType.HTML))) {
             // We need the wikimacro content and parameter to be executed in the right context so if any can be found in
             // an html raw block we need to refactor that raw block to be two raw blocks around a proper blocks to
             // execute later
-            if (rawBlock.getSyntax().getType().equals(SyntaxType.XHTML)
-                || rawBlock.getSyntax().getType().equals(SyntaxType.HTML)) {
-                return replaceHTMLPlaceHolder(rawBlock);
-            }
+            return replaceHTMLPlaceHolder(rawBlock);
         }
 
         return block;


### PR DESCRIPTION
Fixes a batch of mechanical [SonarCloud](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&resolved=false) issues across several modules. All changes are behaviour-preserving mechanical cleanups; the affected modules were built and tested with `-Plegacy,quality` (BUILD SUCCESS, all tests green).

## Changes

* **[java:S1066](https://rules.sonarsource.com/java/RSPEC-1066)** — merge collapsible nested `if` statements:
  * `BaseCollection`, `SkinAction`, `StandardHQLCompleteStatementValidator` (oldcore)
  * `DefaultWikiMacroRenderer` (rendering-wikimacro-store)
  * `R40001XWIKI7540DataMigration` (annotation-io)
  * `DocumentLocaleReader` (filter-stream-xar)
* **[java:S6201](https://rules.sonarsource.com/java/RSPEC-6201)** — use `instanceof` pattern matching instead of an explicit cast: `LegacyNotificationDispatcher` (legacy-oldcore)
* **[java:S6204](https://rules.sonarsource.com/java/RSPEC-6204)** — replace `Collectors.toList()` with `Stream.toList()` where the result stays confined and cannot escape to a mutating caller: `XWikiVersioningStoreInterface` (oldcore)
* **[java:S3878](https://rules.sonarsource.com/java/RSPEC-3878)** — remove redundant array creation for varargs calls: `FeedPlugin` (feed-api)

## Notes

Many candidate issues in this batch were intentionally left as-is because "fixing" them would change behaviour or break APIs (e.g. plugin-class super-call overrides needed for reflective dispatch, utility-class constructors on instantiated factories / abstract classes, Hibernate-mapped accessors, `Collectors.toList()` results that escape to mutating public/script callers, and `try`/`finally` blocks that restore shared state rather than close a resource).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWuw5EDQB6WX4n2uksaVo3)_