### PR TITLE
XWIKI-18921: Panel Navigation: duplicated IDs

### DIFF
--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/NavigationPanelIT.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/NavigationPanelIT.java
@@ -40,7 +40,6 @@ import org.xwiki.test.ui.TestUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verify the Navigation Panel.
@@ -111,7 +110,8 @@ class NavigationPanelIT
 
     /**
      * Show the Navigation Panel in both columns so the same document nodes end up rendered by two independent trees.
-     * Verify this doesn't produce duplicate DOM ids.
+     * Verify this doesn't produce duplicate anchor DOM ids (the {@code <li>} itself intentionally keeps its
+     * original, potentially shared id - see tree.js).
      */
     @Test
     void noDuplicateIds(TestUtils setup, TestReference testReference)
@@ -120,7 +120,11 @@ class NavigationPanelIT
         setup.setWikiPreference("showLeftPanels", "1");
         setup.setWikiPreference("leftPanels", "Panels.Navigation");
 
-        setup.gotoPage(testReference);
+        // Use a flat (single-level space) page rather than testReference directly: testReference is nested (it uses
+        // the test class and method names as space names) and the Navigation Panel's automatic open-to-current-doc
+        // doesn't reliably expand more than one level deep (a pre-existing limitation, unrelated to this test).
+        String[] documentPath = {testReference.getLastSpaceReference().getName() + "NoDuplicateIds", "WebHome"};
+        setup.createPage(new LocalDocumentReference(documentPath[0], documentPath[1]), "Some content");
 
         NavigationTreeElement leftTree = new NavigationTreeElement(
             setup.getDriver().findElement(By.cssSelector("#leftPanels .panel.Navigation .xtree")));
@@ -129,32 +133,24 @@ class NavigationPanelIT
             setup.getDriver().findElement(By.cssSelector("#rightPanels .panel.Navigation .xtree")));
         rightTree.waitForIt();
 
+        // The panel opens to the current document asynchronously, which can still be in progress after waitForIt()
+        // returns (that only waits for the tree's own initial load). Wait for the document itself to appear, with a
+        // longer timeout than the default, since this involves an extra round-trip beyond the tree's initial load.
         // Sanity check: both trees actually render the current document (i.e. we're really exercising the
         // duplicate-id scenario and not just looking at two empty trees).
-        String spaceName = testReference.getLastSpaceReference().getName();
-        String documentName = testReference.getName();
-        assertTrue(leftTree.hasDocument(spaceName, documentName),
-            "The left Navigation panel doesn't show the current document");
-        assertTrue(rightTree.hasDocument(spaceName, documentName),
-            "The right Navigation panel doesn't show the current document");
+        setup.getDriver().waitUntilCondition(driver -> leftTree.hasDocument(documentPath), 30);
+        setup.getDriver().waitUntilCondition(driver -> rightTree.hasDocument(documentPath), 30);
 
-        // The two trees show the same document, so its rendered DOM id must have been disambiguated between the two
-        // occurrences.
-        String leftNodeId = leftTree.getDocumentNode(spaceName, documentName).getId();
-        String rightNodeId = rightTree.getDocumentNode(spaceName, documentName).getId();
-        assertEquals(leftNodeId, rightNodeId,
-            "The two trees should expose the same logical node id for the current document");
-
-        assertEquals(List.of(), getDuplicateDOMIds(setup), "Found duplicate DOM ids on the page");
+        assertEquals(List.of(), getDuplicateAnchorDOMIds(setup), "Found duplicate anchor DOM ids on the page");
     }
 
-    private List<String> getDuplicateDOMIds(TestUtils setup)
+    private List<String> getDuplicateAnchorDOMIds(TestUtils setup)
     {
-        // Scoped to the tree nodes (li) and their anchors (a)
-        Map<String, Long> idCounts =
-            setup.getDriver().findElements(By.cssSelector(".xtree li[id], .xtree a[id]")).stream()
-                .map(element -> element.getAttribute("id"))
-                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+        // Scoped to the tree nodes' anchors (a); the <li> itself intentionally still shares its id with other trees
+        // showing the same entity (see tree.js), so it's excluded here.
+        Map<String, Long> idCounts = setup.getDriver().findElements(By.cssSelector(".xtree a[id]")).stream()
+            .map(element -> element.getAttribute("id"))
+            .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
         return idCounts.entrySet().stream()
             .filter(entry -> entry.getValue() > 1)
             .map(Map.Entry::getKey)

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/NavigationPanelIT.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/NavigationPanelIT.java
@@ -110,8 +110,6 @@ class NavigationPanelIT
 
     /**
      * Show the Navigation Panel in both columns so the same document nodes end up rendered by two independent trees.
-     * Verify this doesn't produce duplicate anchor DOM ids (the {@code <li>} itself intentionally keeps its
-     * original, potentially shared id - see tree.js).
      */
     @Test
     void noDuplicateIds(TestUtils setup, TestReference testReference)
@@ -120,9 +118,6 @@ class NavigationPanelIT
         setup.setWikiPreference("showLeftPanels", "1");
         setup.setWikiPreference("leftPanels", "Panels.Navigation");
 
-        // Use a flat (single-level space) page rather than testReference directly: testReference is nested (it uses
-        // the test class and method names as space names) and the Navigation Panel's automatic open-to-current-doc
-        // doesn't reliably expand more than one level deep (a pre-existing limitation, unrelated to this test).
         String[] documentPath = {testReference.getLastSpaceReference().getName() + "NoDuplicateIds", "WebHome"};
         setup.createPage(new LocalDocumentReference(documentPath[0], documentPath[1]), "Some content");
 
@@ -132,12 +127,7 @@ class NavigationPanelIT
         NavigationTreeElement rightTree = new NavigationTreeElement(
             setup.getDriver().findElement(By.cssSelector("#rightPanels .panel.Navigation .xtree")));
         rightTree.waitForIt();
-
-        // The panel opens to the current document asynchronously, which can still be in progress after waitForIt()
-        // returns (that only waits for the tree's own initial load). Wait for the document itself to appear, with a
-        // longer timeout than the default, since this involves an extra round-trip beyond the tree's initial load.
-        // Sanity check: both trees actually render the current document (i.e. we're really exercising the
-        // duplicate-id scenario and not just looking at two empty trees).
+        
         setup.getDriver().waitUntilCondition(driver -> leftTree.hasDocument(documentPath), 30);
         setup.getDriver().waitUntilCondition(driver -> rightTree.hasDocument(documentPath), 30);
 
@@ -146,8 +136,7 @@ class NavigationPanelIT
 
     private List<String> getDuplicateAnchorDOMIds(TestUtils setup)
     {
-        // Scoped to the tree nodes' anchors (a); the <li> itself intentionally still shares its id with other trees
-        // showing the same entity (see tree.js), so it's excluded here.
+        // Scoped to the tree nodes' anchors
         Map<String, Long> idCounts = setup.getDriver().findElements(By.cssSelector(".xtree a[id]")).stream()
             .map(element -> element.getAttribute("id"))
             .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/NavigationPanelIT.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/NavigationPanelIT.java
@@ -19,19 +19,28 @@
  */
 package org.xwiki.panels.test.ui.docker;
 
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
 import org.xwiki.appwithinminutes.test.po.AppWithinMinutesHomePage;
 import org.xwiki.appwithinminutes.test.po.ApplicationCreatePage;
 import org.xwiki.appwithinminutes.test.po.ApplicationHomePage;
 import org.xwiki.model.reference.LocalDocumentReference;
 import org.xwiki.panels.test.po.NavigationPanel;
 import org.xwiki.panels.test.po.NavigationPanelAdministrationPage;
+import org.xwiki.panels.test.po.NavigationTreeElement;
 import org.xwiki.test.docker.junit5.TestReference;
 import org.xwiki.test.docker.junit5.UITest;
 import org.xwiki.test.ui.TestUtils;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verify the Navigation Panel.
@@ -98,5 +107,57 @@ class NavigationPanelIT
         ApplicationCreatePage appCreatePage = AppWithinMinutesHomePage.gotoPage().clickCreateApplication();
         appCreatePage.setApplicationName(appName);
         return appCreatePage.clickNextStep().clickNextStep().clickNextStep().clickFinish();
+    }
+
+    /**
+     * Show the Navigation Panel in both columns so the same document nodes end up rendered by two independent trees.
+     * Verify this doesn't produce duplicate DOM ids.
+     */
+    @Test
+    void noDuplicateIds(TestUtils setup, TestReference testReference)
+        throws Exception
+    {
+        setup.setWikiPreference("showLeftPanels", "1");
+        setup.setWikiPreference("leftPanels", "Panels.Navigation");
+
+        setup.gotoPage(testReference);
+
+        NavigationTreeElement leftTree = new NavigationTreeElement(
+            setup.getDriver().findElement(By.cssSelector("#leftPanels .panel.Navigation .xtree")));
+        leftTree.waitForIt();
+        NavigationTreeElement rightTree = new NavigationTreeElement(
+            setup.getDriver().findElement(By.cssSelector("#rightPanels .panel.Navigation .xtree")));
+        rightTree.waitForIt();
+
+        // Sanity check: both trees actually render the current document (i.e. we're really exercising the
+        // duplicate-id scenario and not just looking at two empty trees).
+        String spaceName = testReference.getLastSpaceReference().getName();
+        String documentName = testReference.getName();
+        assertTrue(leftTree.hasDocument(spaceName, documentName),
+            "The left Navigation panel doesn't show the current document");
+        assertTrue(rightTree.hasDocument(spaceName, documentName),
+            "The right Navigation panel doesn't show the current document");
+
+        // The two trees show the same document, so its rendered DOM id must have been disambiguated between the two
+        // occurrences.
+        String leftNodeId = leftTree.getDocumentNode(spaceName, documentName).getId();
+        String rightNodeId = rightTree.getDocumentNode(spaceName, documentName).getId();
+        assertEquals(leftNodeId, rightNodeId,
+            "The two trees should expose the same logical node id for the current document");
+
+        assertEquals(List.of(), getDuplicateDOMIds(setup), "Found duplicate DOM ids on the page");
+    }
+
+    private List<String> getDuplicateDOMIds(TestUtils setup)
+    {
+        // Scoped to the tree nodes (li) and their anchors (a)
+        Map<String, Long> idCounts =
+            setup.getDriver().findElements(By.cssSelector(".xtree li[id], .xtree a[id]")).stream()
+                .map(element -> element.getAttribute("id"))
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+        return idCounts.entrySet().stream()
+            .filter(entry -> entry.getValue() > 1)
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toList());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/NavigationPanelIT.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/NavigationPanelIT.java
@@ -19,17 +19,19 @@
  */
 package org.xwiki.panels.test.ui.docker;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
 import org.xwiki.appwithinminutes.test.po.AppWithinMinutesHomePage;
 import org.xwiki.appwithinminutes.test.po.ApplicationCreatePage;
 import org.xwiki.appwithinminutes.test.po.ApplicationHomePage;
+import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.LocalDocumentReference;
 import org.xwiki.panels.test.po.NavigationPanel;
 import org.xwiki.panels.test.po.NavigationPanelAdministrationPage;
@@ -112,37 +114,33 @@ class NavigationPanelIT
      * Show the Navigation Panel in both columns so the same document nodes end up rendered by two independent trees.
      */
     @Test
-    void noDuplicateIds(TestUtils setup, TestReference testReference)
+    void noDuplicateAnchorIds(TestUtils setup, TestReference testReference)
         throws Exception
     {
         setup.setWikiPreference("showLeftPanels", "1");
         setup.setWikiPreference("leftPanels", "Panels.Navigation");
 
-        String[] documentPath = {testReference.getLastSpaceReference().getName() + "NoDuplicateIds", "WebHome"};
-        setup.createPage(new LocalDocumentReference(documentPath[0], documentPath[1]), "Some content");
+        setup.createPage(testReference, "Some content");
+        String[] documentPath = Stream
+            .concat(testReference.getSpaceReferences().stream().map(EntityReference::getName),
+                Stream.of(testReference.getName()))
+            .toArray(String[]::new);
 
-        NavigationTreeElement leftTree = new NavigationTreeElement(
-            setup.getDriver().findElement(By.cssSelector("#leftPanels .panel.Navigation .xtree")));
-        leftTree.waitForIt();
-        NavigationTreeElement rightTree = new NavigationTreeElement(
-            setup.getDriver().findElement(By.cssSelector("#rightPanels .panel.Navigation .xtree")));
-        rightTree.waitForIt();
-        
-        setup.getDriver().waitUntilCondition(driver -> leftTree.hasDocument(documentPath), 30);
-        setup.getDriver().waitUntilCondition(driver -> rightTree.hasDocument(documentPath), 30);
+        // The created page is the current one, so both trees open to it and thus render the same nodes twice.
+        List<String> labelIds = new ArrayList<>();
+        for (boolean leftColumn : List.of(true, false)) {
+            NavigationTreeElement tree = new NavigationPanel(leftColumn).getNavigationTree();
+            tree.waitForDocumentSelected(documentPath);
+            labelIds.addAll(tree.getNodeLabelIds());
+        }
 
-        assertEquals(List.of(), getDuplicateAnchorDOMIds(setup), "Found duplicate anchor DOM ids on the page");
+        assertEquals(List.of(), getDuplicates(labelIds), "Found duplicate node label ids on the page");
     }
 
-    private List<String> getDuplicateAnchorDOMIds(TestUtils setup)
+    private List<String> getDuplicates(List<String> values)
     {
-        // Scoped to the tree nodes' anchors
-        Map<String, Long> idCounts = setup.getDriver().findElements(By.cssSelector(".xtree a[id]")).stream()
-            .map(element -> element.getAttribute("id"))
-            .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
-        return idCounts.entrySet().stream()
-            .filter(entry -> entry.getValue() > 1)
-            .map(Map.Entry::getKey)
-            .collect(Collectors.toList());
+        Map<String, Long> counts =
+            values.stream().collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+        return counts.entrySet().stream().filter(entry -> entry.getValue() > 1).map(Map.Entry::getKey).toList();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/NavigationPanelIT.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/NavigationPanelIT.java
@@ -134,6 +134,10 @@ class NavigationPanelIT
             labelIds.addAll(tree.getNodeLabelIds());
         }
 
+        // A node label without an id would otherwise be reported below as a duplicate of the other missing ids,
+        // which is not the problem this test is about.
+        assertFalse(labelIds.stream().anyMatch(id -> id == null || id.isEmpty()),
+            "Found a node label without an id in " + labelIds);
         assertEquals(List.of(), getDuplicates(labelIds), "Found duplicate node label ids on the page");
     }
 

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-pageobjects/src/main/java/org/xwiki/panels/test/po/NavigationPanel.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-pageobjects/src/main/java/org/xwiki/panels/test/po/NavigationPanel.java
@@ -30,6 +30,29 @@ import org.xwiki.test.ui.po.ViewPage;
  */
 public class NavigationPanel extends ViewPage
 {
+    private final String columnSelector;
+
+    /**
+     * Creates a page object that looks for the Navigation Panel in any of the two panel columns.
+     */
+    public NavigationPanel()
+    {
+        this.columnSelector = ".panels";
+    }
+
+    /**
+     * Creates a page object that looks for the Navigation Panel in a specific panel column. This is needed when the
+     * panel is displayed in both columns at the same time.
+     *
+     * @param leftColumn {@code true} to target the panel displayed in the left column, {@code false} for the one
+     *     displayed in the right column
+     * @since 18.8.0RC1
+     */
+    public NavigationPanel(boolean leftColumn)
+    {
+        this.columnSelector = leftColumn ? "#leftPanels" : "#rightPanels";
+    }
+
     /**
      * @return the page representing the Navigation Panel
      */
@@ -46,8 +69,8 @@ public class NavigationPanel extends ViewPage
 
     public NavigationTreeElement getNavigationTree()
     {
-        String panelContainer =
-            "Panels.Navigation".equals(getMetaDataValue("data-xwiki-document")) ? "#xwikicontent" : ".panels";
+        String panelContainer = "Panels.Navigation".equals(getMetaDataValue("data-xwiki-document")) ? "#xwikicontent"
+            : this.columnSelector;
         return (NavigationTreeElement) new NavigationTreeElement(
             getDriver().findElementWithoutWaiting(By.cssSelector(panelContainer + " .panel.Navigation .xtree")))
                 .waitForIt();

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-test-pageobjects/src/main/java/org/xwiki/tree/test/po/TreeElement.java
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-test-pageobjects/src/main/java/org/xwiki/tree/test/po/TreeElement.java
@@ -53,12 +53,26 @@ public class TreeElement extends BaseElement
     }
 
     /**
+     * The rendered DOM id of a node is prefixed with the tree's own id, to keep it unique when the same entity is
+     * shown by more than one tree on the same page (see tree.js). This reconstructs that rendered id from the node
+     * id.
+     *
+     * @param nodeId the node identifier
+     * @return the corresponding DOM id
+     */
+    private String getRenderedNodeId(String nodeId)
+    {
+        String prefix = this.element.getAttribute("id");
+        return (prefix == null || prefix.isEmpty()) ? nodeId : (prefix + "-" + nodeId);
+    }
+
+    /**
      * @param nodeId the node identifier
      * @return the node with the specified identifier
      */
     public TreeNodeElement getNode(String nodeId)
     {
-        return new TreeNodeElement(this.element, By.id(nodeId));
+        return new TreeNodeElement(this.element, By.id(getRenderedNodeId(nodeId)));
     }
 
     /**
@@ -72,7 +86,7 @@ public class TreeElement extends BaseElement
         // be). Such an element id is technically invalid but the browsers are handling it fine.
         // See https://code.google.com/p/selenium/issues/detail?id=8173
         return !getDriver().findElementsWithoutWaiting(this.element,
-            By.xpath(".//*[@id = '" + nodeId + "']")).isEmpty();
+            By.xpath(".//*[@id = '" + getRenderedNodeId(nodeId) + "']")).isEmpty();
     }
 
     /**
@@ -133,7 +147,8 @@ public class TreeElement extends BaseElement
     public TreeElement waitForNodeSelected(String nodeId)
     {
         String selectedNodeXPath =
-            String.format(".//*[@id = '%s_anchor' and contains(@class, 'jstree-clicked')]", nodeId);
+            String.format(".//*[@id = '%s_anchor' and contains(@class, 'jstree-clicked')]",
+                getRenderedNodeId(nodeId));
         getDriver().waitUntilElementIsVisible(this.element, By.xpath(selectedNodeXPath));
         return this;
     }

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-test-pageobjects/src/main/java/org/xwiki/tree/test/po/TreeElement.java
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-test-pageobjects/src/main/java/org/xwiki/tree/test/po/TreeElement.java
@@ -38,6 +38,11 @@ import org.xwiki.test.ui.po.BaseElement;
 public class TreeElement extends BaseElement
 {
     /**
+     * The id HTML attribute.
+     */
+    private static final String ID = "id";
+
+    /**
      * The element that represents the tree.
      */
     private WebElement element;
@@ -53,17 +58,19 @@ public class TreeElement extends BaseElement
     }
 
     /**
-     * The rendered DOM id of a node is prefixed with the tree's own id, to keep it unique when the same entity is
-     * shown by more than one tree on the same page (see tree.js). This reconstructs that rendered id from the node
-     * id.
+     * The rendered DOM id of a node's anchor is prefixed with the tree's own id, to keep it unique when the same
+     * entity is shown by more than one tree on the same page (see tree.js). The node's own {@code <li>} keeps its
+     * plain, unprefixed id (jsTree doesn't allow us to safely change that one - see tree.js). This reconstructs the
+     * anchor's rendered id from the node id.
      *
      * @param nodeId the node identifier
-     * @return the corresponding DOM id
+     * @return the corresponding anchor DOM id
      */
-    private String getRenderedNodeId(String nodeId)
+    private String getRenderedAnchorId(String nodeId)
     {
-        String prefix = this.element.getAttribute("id");
-        return (prefix == null || prefix.isEmpty()) ? nodeId : (prefix + "-" + nodeId);
+        String prefix = this.element.getAttribute(ID);
+        String anchorId = nodeId + "_anchor";
+        return (prefix == null || prefix.isEmpty()) ? anchorId : (prefix + "-" + anchorId);
     }
 
     /**
@@ -72,7 +79,7 @@ public class TreeElement extends BaseElement
      */
     public TreeNodeElement getNode(String nodeId)
     {
-        return new TreeNodeElement(this.element, By.id(getRenderedNodeId(nodeId)));
+        return new TreeNodeElement(this.element, By.id(nodeId));
     }
 
     /**
@@ -86,7 +93,7 @@ public class TreeElement extends BaseElement
         // be). Such an element id is technically invalid but the browsers are handling it fine.
         // See https://code.google.com/p/selenium/issues/detail?id=8173
         return !getDriver().findElementsWithoutWaiting(this.element,
-            By.xpath(".//*[@id = '" + getRenderedNodeId(nodeId) + "']")).isEmpty();
+            By.xpath(".//*[@id = '" + nodeId + "']")).isEmpty();
     }
 
     /**
@@ -147,8 +154,7 @@ public class TreeElement extends BaseElement
     public TreeElement waitForNodeSelected(String nodeId)
     {
         String selectedNodeXPath =
-            String.format(".//*[@id = '%s_anchor' and contains(@class, 'jstree-clicked')]",
-                getRenderedNodeId(nodeId));
+            String.format(".//*[@id = '%s' and contains(@class, 'jstree-clicked')]", getRenderedAnchorId(nodeId));
         getDriver().waitUntilElementIsVisible(this.element, By.xpath(selectedNodeXPath));
         return this;
     }
@@ -212,7 +218,7 @@ public class TreeElement extends BaseElement
         return getDriver()
             .findElementsWithoutWaiting(this.element,
                 By.cssSelector(".jstree-container-ul > .jstree-node:not(.jstree-hidden)"))
-            .stream().map(nodeElement -> By.id(nodeElement.getAttribute("id")))
+            .stream().map(nodeElement -> By.id(nodeElement.getAttribute(ID)))
             .map(nodeLocator -> new TreeNodeElement(this.element, nodeLocator)).toList();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-test-pageobjects/src/main/java/org/xwiki/tree/test/po/TreeElement.java
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-test-pageobjects/src/main/java/org/xwiki/tree/test/po/TreeElement.java
@@ -58,10 +58,7 @@ public class TreeElement extends BaseElement
     }
 
     /**
-     * The rendered DOM id of a node's anchor is prefixed with the tree's own id, to keep it unique when the same
-     * entity is shown by more than one tree on the same page (see tree.js). The node's own {@code <li>} keeps its
-     * plain, unprefixed id (jsTree doesn't allow us to safely change that one - see tree.js). This reconstructs the
-     * anchor's rendered id from the node id.
+     * Reconstructs an anchor's rendered id from its node id.
      *
      * @param nodeId the node identifier
      * @return the corresponding anchor DOM id

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-test-pageobjects/src/main/java/org/xwiki/tree/test/po/TreeElement.java
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-test-pageobjects/src/main/java/org/xwiki/tree/test/po/TreeElement.java
@@ -38,11 +38,6 @@ import org.xwiki.test.ui.po.BaseElement;
 public class TreeElement extends BaseElement
 {
     /**
-     * The id HTML attribute.
-     */
-    private static final String ID = "id";
-
-    /**
      * The element that represents the tree.
      */
     private WebElement element;
@@ -65,7 +60,7 @@ public class TreeElement extends BaseElement
      */
     private String getRenderedAnchorId(String nodeId)
     {
-        String prefix = this.element.getAttribute(ID);
+        String prefix = this.element.getAttribute(ATTRIBUTE_ID);
         String anchorId = nodeId + "_anchor";
         return (prefix == null || prefix.isEmpty()) ? anchorId : (prefix + "-" + anchorId);
     }
@@ -208,6 +203,16 @@ public class TreeElement extends BaseElement
     }
 
     /**
+     * @return the DOM ids of the labels of the loaded nodes, in document order
+     * @since 18.8.0RC1
+     */
+    public List<String> getNodeLabelIds()
+    {
+        return getDriver().findElementsWithoutWaiting(this.element, By.cssSelector(".jstree-anchor")).stream()
+            .map(label -> label.getAttribute(ATTRIBUTE_ID)).toList();
+    }
+
+    /**
      * @return the list of top level nodes
      */
     public List<TreeNodeElement> getTopLevelNodes()
@@ -215,7 +220,7 @@ public class TreeElement extends BaseElement
         return getDriver()
             .findElementsWithoutWaiting(this.element,
                 By.cssSelector(".jstree-container-ul > .jstree-node:not(.jstree-hidden)"))
-            .stream().map(nodeElement -> By.id(nodeElement.getAttribute(ID)))
+            .stream().map(nodeElement -> By.id(nodeElement.getAttribute(ATTRIBUTE_ID)))
             .map(nodeLocator -> new TreeNodeElement(this.element, nodeLocator)).toList();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-test-pageobjects/src/main/java/org/xwiki/tree/test/po/TreeNodeElement.java
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-test-pageobjects/src/main/java/org/xwiki/tree/test/po/TreeNodeElement.java
@@ -47,6 +47,11 @@ public class TreeNodeElement extends BaseElement
     private static final String ID = "id";
 
     /**
+     * The XPath locator of the node's anchor, relative to the node.
+     */
+    private static final String ANCHOR_XPATH = "./a";
+
+    /**
      * The tree that contains this node.
      */
     private WebElement treeElement;
@@ -83,14 +88,7 @@ public class TreeNodeElement extends BaseElement
      */
     public String getId()
     {
-        // The rendered id is prefixed with the tree's own id, to keep it unique when the same entity is shown by
-        // more than one tree on the same page (see tree.js). Strip it back off to get the actual node id.
-        String renderedId = getElement().getAttribute(ID);
-        String prefix = this.treeElement.getAttribute(ID);
-        if (prefix != null && !prefix.isEmpty() && renderedId != null && renderedId.startsWith(prefix + "-")) {
-            return renderedId.substring(prefix.length() + 1);
-        }
-        return renderedId;
+        return getElement().getAttribute(ID);
     }
 
     /**
@@ -107,7 +105,7 @@ public class TreeNodeElement extends BaseElement
      */
     public WebElement getLabelElement()
     {
-        return getElement().findElement(By.xpath("./a"));
+        return getElement().findElement(By.xpath(ANCHOR_XPATH));
     }
 
     /**
@@ -216,7 +214,7 @@ public class TreeNodeElement extends BaseElement
             try {
                 // The aria-busy attribute is not directly on the li element, but it's on the element located as a
                 // child of the li in the DOM.
-                WebElement anchor = getDriver().findElementWithoutWaiting(getElement(), By.xpath("./a"));
+                WebElement anchor = getDriver().findElementWithoutWaiting(getElement(), By.xpath(ANCHOR_XPATH));
                 return !Boolean.parseBoolean(anchor.getAttribute("aria-busy"));
             } catch (StaleElementReferenceException e) {
                 // The element has just been replaced. Try again.

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-test-pageobjects/src/main/java/org/xwiki/tree/test/po/TreeNodeElement.java
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-test-pageobjects/src/main/java/org/xwiki/tree/test/po/TreeNodeElement.java
@@ -83,7 +83,14 @@ public class TreeNodeElement extends BaseElement
      */
     public String getId()
     {
-        return getElement().getAttribute(ID);
+        // The rendered id is prefixed with the tree's own id, to keep it unique when the same entity is shown by
+        // more than one tree on the same page (see tree.js). Strip it back off to get the actual node id.
+        String renderedId = getElement().getAttribute(ID);
+        String prefix = this.treeElement.getAttribute(ID);
+        if (prefix != null && !prefix.isEmpty() && renderedId != null && renderedId.startsWith(prefix + "-")) {
+            return renderedId.substring(prefix.length() + 1);
+        }
+        return renderedId;
     }
 
     /**
@@ -209,8 +216,7 @@ public class TreeNodeElement extends BaseElement
             try {
                 // The aria-busy attribute is not directly on the li element, but it's on the element located as a
                 // child of the li in the DOM.
-                WebElement anchor = getDriver().findElementWithoutWaiting(getElement(), By.id(String.format("%s_anchor",
-                    getId())));
+                WebElement anchor = getDriver().findElementWithoutWaiting(getElement(), By.xpath("./a"));
                 return !Boolean.parseBoolean(anchor.getAttribute("aria-busy"));
             } catch (StaleElementReferenceException e) {
                 // The element has just been replaced. Try again.

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
@@ -87,9 +87,40 @@ define([
     return $.post(new URL('?', url), $.param($.extend(urlParams, data), true));
   };
 
+  // jsTree renders the node id as-is as the DOM id (li and anchor), which causes duplicate DOM ids when the same
+  // entity is shown by more than one tree on the same page. We prefix the rendered id with the tree's own (unique)
+  // container id.
+  var treeCounter = 0;
+
+  var getTreePrefix = function(tree) {
+    var prefix = tree.element.attr('id');
+    if (!prefix) {
+      prefix = 'xtree-' + (treeCounter++);
+      tree.element.attr('id', prefix);
+    }
+    return prefix;
+  };
+
+  var namespaceNodeAttributes = function(node, tree) {
+    if (node && typeof node.id !== 'undefined') {
+      var prefix = getTreePrefix(tree);
+      node.li_attr = $.extend({}, node.li_attr, {id: prefix + '-' + node.id});
+      node.a_attr = $.extend({}, node.a_attr, {id: prefix + '-' + node.id + '_anchor'});
+    }
+    return node;
+  };
+
   var getChildren = function(node, callback, parameters) {
     // 'this' is the tree instance.
-    callback = callback.bind(this);
+    var tree = this;
+    var boundCallback = callback.bind(this);
+    // Wrap the callback from jsTree so that every fetched child gets a page-wide unique rendered id.
+    callback = function(children) {
+      (children || []).forEach(function(child) {
+        namespaceNodeAttributes(child, tree);
+      });
+      boundCallback(children);
+    };
     if (node.id === $.jstree.root && !node.data) {
       // Take the root node data from the tree container element.
       node.data = this.get_container().data('root') || {};

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
@@ -87,20 +87,8 @@ define([
     return $.post(new URL('?', url), $.param($.extend(urlParams, data), true));
   };
 
-  // jsTree renders the node id as-is as the DOM id of the node's anchor (appending '_anchor'), which causes
-  // duplicate DOM ids when the same entity is shown by more than one tree on the same page. We prefix the rendered
-  // anchor id with the tree's own (unique) container id.
-  //
-  // Note this only fixes the anchor, not the <li> itself: jsTree hard-codes the <li>'s DOM id to the node's raw
-  // internal id (li_attr.id is explicitly ignored when rendering) and separately relies on being able to
-  // re-locate a node's own <li> (and its parent's) by that same raw id via live DOM '#id' queries whenever it
-  // redraws a node - e.g. to find where to insert a child. Overriding the <li>'s rendered id after the fact (which
-  // we tried) breaks that lookup for any node whose ancestor has already been relabeled, silently aborting the
-  // redraw of deeper nodes. Properly deduplicating the <li> id would require changing jsTree's own internal id for
-  // the node (used by get_node/select_node/openTo/drag-and-drop), cascading through every caller that currently
-  // passes a raw entity id into those APIs - out of scope here. The <li> keeps its original, potentially
-  // page-wide-duplicated id.
-  var treeCounter = 0;
+  // Prefix each node's rendered anchor id with the tree's own container id, to avoid duplicate DOM ids when the same
+  // entity is shown by more than one tree on the same page.
 
   var getTreePrefix = function(tree) {
     var prefix = tree.element.attr('id');

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
@@ -99,7 +99,7 @@ define([
     return prefix;
   };
 
-  var namespaceAnchorAttributes = function(node, tree) {
+  var prefixAnchorAttributes = function(node, tree) {
     if (node && typeof node.id !== 'undefined') {
       var prefix = getTreePrefix(tree);
       node.a_attr = $.extend({}, node.a_attr, {id: prefix + '-' + node.id + '_anchor'});
@@ -114,7 +114,7 @@ define([
     // Wrap the callback from jsTree so that every fetched child's anchor gets a page-wide unique rendered id.
     callback = function(children) {
       (children || []).forEach(function(child) {
-        namespaceAnchorAttributes(child, tree);
+        prefixAnchorAttributes(child, tree);
       });
       boundCallback(children);
     };

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
@@ -87,9 +87,19 @@ define([
     return $.post(new URL('?', url), $.param($.extend(urlParams, data), true));
   };
 
-  // jsTree renders the node id as-is as the DOM id (li and anchor), which causes duplicate DOM ids when the same
-  // entity is shown by more than one tree on the same page. We prefix the rendered id with the tree's own (unique)
-  // container id.
+  // jsTree renders the node id as-is as the DOM id of the node's anchor (appending '_anchor'), which causes
+  // duplicate DOM ids when the same entity is shown by more than one tree on the same page. We prefix the rendered
+  // anchor id with the tree's own (unique) container id.
+  //
+  // Note this only fixes the anchor, not the <li> itself: jsTree hard-codes the <li>'s DOM id to the node's raw
+  // internal id (li_attr.id is explicitly ignored when rendering) and separately relies on being able to
+  // re-locate a node's own <li> (and its parent's) by that same raw id via live DOM '#id' queries whenever it
+  // redraws a node - e.g. to find where to insert a child. Overriding the <li>'s rendered id after the fact (which
+  // we tried) breaks that lookup for any node whose ancestor has already been relabeled, silently aborting the
+  // redraw of deeper nodes. Properly deduplicating the <li> id would require changing jsTree's own internal id for
+  // the node (used by get_node/select_node/openTo/drag-and-drop), cascading through every caller that currently
+  // passes a raw entity id into those APIs - out of scope here. The <li> keeps its original, potentially
+  // page-wide-duplicated id.
   var treeCounter = 0;
 
   var getTreePrefix = function(tree) {
@@ -101,10 +111,9 @@ define([
     return prefix;
   };
 
-  var namespaceNodeAttributes = function(node, tree) {
+  var namespaceAnchorAttributes = function(node, tree) {
     if (node && typeof node.id !== 'undefined') {
       var prefix = getTreePrefix(tree);
-      node.li_attr = $.extend({}, node.li_attr, {id: prefix + '-' + node.id});
       node.a_attr = $.extend({}, node.a_attr, {id: prefix + '-' + node.id + '_anchor'});
     }
     return node;
@@ -114,10 +123,10 @@ define([
     // 'this' is the tree instance.
     var tree = this;
     var boundCallback = callback.bind(this);
-    // Wrap the callback from jsTree so that every fetched child gets a page-wide unique rendered id.
+    // Wrap the callback from jsTree so that every fetched child's anchor gets a page-wide unique rendered id.
     callback = function(children) {
       (children || []).forEach(function(child) {
-        namespaceNodeAttributes(child, tree);
+        namespaceAnchorAttributes(child, tree);
       });
       boundCallback(children);
     };

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
@@ -89,34 +89,35 @@ define([
 
   // Prefix each node's rendered anchor id with the tree's own container id, to avoid duplicate DOM ids when the same
   // entity is shown by more than one tree on the same page.
+  let treeCounter = 0;
 
-  var getTreePrefix = function(tree) {
-    var prefix = tree.element.attr('id');
-    if (!prefix) {
-      prefix = 'xtree-' + (treeCounter++);
-      tree.element.attr('id', prefix);
+  function getOrGenerateTreeId(tree) {
+    let id = tree.element.attr('id');
+    if (!id) {
+      id = 'xtree-' + (treeCounter++);
+      tree.element.attr('id', id);
     }
-    return prefix;
-  };
+    return id;
+  }
 
-  var prefixAnchorAttributes = function(node, tree) {
+  function prefixAnchorIdAttribute(node, tree) {
     if (node && typeof node.id !== 'undefined') {
-      var prefix = getTreePrefix(tree);
-      node.a_attr = $.extend({}, node.a_attr, {id: prefix + '-' + node.id + '_anchor'});
+      const treeId = getOrGenerateTreeId(tree);
+      node.a_attr = $.extend({}, node.a_attr, {id: treeId + '-' + node.id + '_anchor'});
     }
     return node;
-  };
+  }
 
   var getChildren = function(node, callback, parameters) {
     // 'this' is the tree instance.
-    var tree = this;
-    var boundCallback = callback.bind(this);
+    const tree = this;
+    const boundCallback = callback.bind(this);
     // Wrap the callback from jsTree so that every fetched child's anchor gets a page-wide unique rendered id.
-    callback = function(children) {
+    callback = function(children, ...args) {
       (children || []).forEach(function(child) {
-        prefixAnchorAttributes(child, tree);
+        prefixAnchorIdAttribute(child, tree);
       });
-      boundCallback(children);
+      return boundCallback(children, ...args);
     };
     if (node.id === $.jstree.root && !node.data) {
       // Take the root node data from the tree container element.

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
@@ -414,7 +414,8 @@ define([
         // the rest of the siblings (i.e. all the next pages) until we find the node that corresponds to the given path
         // element, so we simply add the node to the parent. Don't worry, the node won't be duplicated when the
         // pagination is triggered.
-        this.create_node(parent, nodeSpec, siblings.length - 1, resolve);
+        // This node doesn't go through the children callback, so its anchor id is prefixed here instead.
+        this.create_node(parent, prefixAnchorIdAttribute(nodeSpec, this), siblings.length - 1, resolve);
       } else {
         // The specified node can't be created.
         reject();


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-18921

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added a prefix on anchor IDs.
* Wrote a test to check that these IDs end up unique.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* See latest comment on https://jira.xwiki.org/browse/XWIKI-18921 , this does not fix the li ID duplication but this is the only safe change to make.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No visual difference, this is a minor DOM only change.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Built the change with `mvn clean install -pl xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar`.
Checked the new test with `mvn clean verify -pl xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker -Dit.test=NavigationPanelIT#noDuplicateIds`.
Passed additional tests :
* `mvn clean verify -pl xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker -Dit.test=NavigationPanelIT#verifyPanelCaching`
* `mvn clean verify -pl xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker -Dit.test=LinkIT#createLinkForNotExistingPage`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None.