### PR TITLE
[Misc] Fix various SonarCloud issues

### DIFF
--- a/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-default/src/main/java/org/xwiki/export/pdf/internal/job/DefaultPDFExportJobRequestFactory.java
+++ b/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-default/src/main/java/org/xwiki/export/pdf/internal/job/DefaultPDFExportJobRequestFactory.java
@@ -25,7 +25,6 @@ import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -164,7 +163,7 @@ public class DefaultPDFExportJobRequestFactory implements PDFExportJobRequestFac
         request.setWithHeader(!"0".equals(httpRequest.get("pdfheader")));
         request.setWithFooter(!"0".equals(httpRequest.get("pdffooter")));
         request.setDocuments(this.documentSelectionResolver.getSelectedDocuments(true).stream()
-            .sorted(this.documentReferenceComparatorProvider.get()).collect(Collectors.toList()));
+            .sorted(this.documentReferenceComparatorProvider.get()).toList());
 
         request.setFileName(xcontext.getDoc().getRenderedTitle(Syntax.PLAIN_1_0, xcontext) + ".pdf");
     }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-cluster/src/main/java/org/xwiki/extension/cluster/internal/ExtensionJobEventConverter.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-cluster/src/main/java/org/xwiki/extension/cluster/internal/ExtensionJobEventConverter.java
@@ -57,14 +57,13 @@ public class ExtensionJobEventConverter extends AbstractEventConverter
     @Override
     public boolean toRemote(LocalEventData localEvent, RemoteEventData remoteEvent)
     {
-        if (localEvent.getEvent() instanceof JobStartedEvent jobStartedEvent) {
-            // Share only specific jobs
-            // Don't send back remote jobs
-            if (JOBS.contains(jobStartedEvent.getJobType()) && !jobStartedEvent.getRequest().isRemote()) {
-                remoteEvent.setEvent(jobStartedEvent);
+        // Share only specific jobs
+        // Don't send back remote jobs
+        if (localEvent.getEvent() instanceof JobStartedEvent jobStartedEvent
+            && JOBS.contains(jobStartedEvent.getJobType()) && !jobStartedEvent.getRequest().isRemote()) {
+            remoteEvent.setEvent(jobStartedEvent);
 
-                return true;
-            }
+            return true;
         }
 
         return false;

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/UUIDLiveTableNewRowNamingStrategyTest.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/UUIDLiveTableNewRowNamingStrategyTest.java
@@ -24,7 +24,6 @@ import java.util.UUID;
 
 import javax.inject.Named;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.xwiki.livedata.LiveDataException;

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroRenderer.java
@@ -281,7 +281,7 @@ public class DefaultWikiMacroRenderer extends AbstractBlockAsyncRenderer
 
         this.syncContext = syncContext;
 
-        this.id = createId("rendering", "wikimacro", wikimacro.getId(),
+        this.id = createId("rendering", MACRO_BINDING, wikimacro.getId(),
             wikimacro.getBlockId(syncContext.getCurrentMacroBlock()));
         try {
             this.parameters = convertParameters(parameters);

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroRenderer.java
@@ -115,6 +115,11 @@ public class DefaultWikiMacroRenderer extends AbstractBlockAsyncRenderer
     private static final String MACRO_BINDING = "wikimacro";
 
     /**
+     * The id component identifying a wiki macro rendering, whose value matches {@link #MACRO_BINDING}.
+     */
+    private static final String MACRO_ASYNC_ID = MACRO_BINDING;
+
+    /**
      * The name of the metadata flagging a block as containing wiki macro content.
      */
     private static final String WIKIMACROCONTENT = "wikimacrocontent";
@@ -281,7 +286,7 @@ public class DefaultWikiMacroRenderer extends AbstractBlockAsyncRenderer
 
         this.syncContext = syncContext;
 
-        this.id = createId("rendering", MACRO_BINDING, wikimacro.getId(),
+        this.id = createId("rendering", MACRO_ASYNC_ID, wikimacro.getId(),
             wikimacro.getBlockId(syncContext.getCurrentMacroBlock()));
         try {
             this.parameters = convertParameters(parameters);


### PR DESCRIPTION
Fixes a batch of open SonarCloud issues across several modules. All changes are mechanical and behaviour-preserving.

| Rule | Module | Change | SonarCloud issue |
|---|---|---|---|
| [java:S1128](https://rules.sonarsource.com/java/RSPEC-1128) | `xwiki-platform-livedata-livetable` | Remove an unused `BeforeEach` import in `UUIDLiveTableNewRowNamingStrategyTest` | [AZ-BFejeLc-jv7qMmBM6](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZ-BFejeLc-jv7qMmBM6&open=AZ-BFejeLc-jv7qMmBM6) |
| [java:S6204](https://rules.sonarsource.com/java/RSPEC-6204) | `xwiki-platform-export-pdf-default` | Use `Stream.toList()` instead of `collect(Collectors.toList())` in `DefaultPDFExportJobRequestFactory` (the list is only passed to `setDocuments`, whose getter's other branch already returns an unmodifiable list) | [AYyD4qzsj2dtqk6dnyHD](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AYyD4qzsj2dtqk6dnyHD&open=AYyD4qzsj2dtqk6dnyHD) |
| [java:S1066](https://rules.sonarsource.com/java/RSPEC-1066) | `xwiki-platform-extension-cluster` | Merge a collapsible nested `if` in `ExtensionJobEventConverter` | [AZ98rk5r7D0Q84qnpYl0](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZ98rk5r7D0Q84qnpYl0&open=AZ98rk5r7D0Q84qnpYl0) |
| [java:S1192](https://rules.sonarsource.com/java/RSPEC-1192) | `xwiki-platform-rendering-wikimacro-store` | Reuse the existing `MACRO_BINDING` constant instead of duplicating its value in `DefaultWikiMacroRenderer` | [AZX3NluzxsQvdBlSeTcr](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZX3NluzxsQvdBlSeTcr&open=AZX3NluzxsQvdBlSeTcr) |

Verified with `mvn clean install -Plegacy,quality` (including tests) on the four affected modules — BUILD SUCCESS.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCS2cZXQtz2djqvSqh5yom)_