### PR TITLE
[Misc] Fix additional SonarQube-reported NPE risks blocking the quality gate

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -7686,6 +7686,10 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         com.xpn.xwiki.XWiki xwiki = context.getWiki();
         String language = "";
         XWikiDocument tdoc = (XWikiDocument) context.get(CKEY_TDOC);
+        // Fall back to this document when no translated document is set in the context.
+        if (tdoc == null) {
+            tdoc = this;
+        }
         String realLang = tdoc.getRealLanguage(context);
         if (xwiki.isMultiLingual(context) && (!"".equals(realLang))) {
             language = realLang;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactory.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -63,6 +64,9 @@ public class FileSystemURLFactory extends XWikiServletURLFactory
 
     /** Segment separator used in the collision-free key generation. */
     private static final char SEPARATOR = '/';
+
+    /** Context key under which the resource-key-to-temporary-file mapping is stored during the export. */
+    private static final String FILE_MAPPING_KEY = "pdfexport-file-mapping";
 
     private LegacySpaceResolver legacySpaceResolver = Utils.getComponent(LegacySpaceResolver.class);
 
@@ -117,10 +121,6 @@ public class FileSystemURLFactory extends XWikiServletURLFactory
     {
         try {
             Map<String, File> usedFiles = getFileMapping(context);
-            if (usedFiles == null) {
-                // No PDF export file mapping in the context, just return a http:// URL.
-                return super.createSkinURL(filename, skin, context);
-            }
             String key = getSkinfileKey(filename, skin);
             if (!usedFiles.containsKey(key)
                 && !copyResource("/skins/" + skin + '/' + filename, key, usedFiles, context)) {
@@ -139,10 +139,6 @@ public class FileSystemURLFactory extends XWikiServletURLFactory
     {
         try {
             Map<String, File> usedFiles = getFileMapping(context);
-            if (usedFiles == null) {
-                // No PDF export file mapping in the context, just return a http:// URL.
-                return super.createResourceURL(filename, forceSkinAction, context);
-            }
             String key = getResourceKey(filename);
             if (!usedFiles.containsKey(key) && !copyResource("/resources/" + filename, key, usedFiles, context)) {
                 return super.createResourceURL(filename, forceSkinAction, context);
@@ -325,15 +321,21 @@ public class FileSystemURLFactory extends XWikiServletURLFactory
     }
 
     /**
-     * Retrieve the Map that relates resource keys to their corresponding temporary file.
+     * Retrieve the Map that relates resource keys to their corresponding temporary file, creating and storing it in the
+     * context when it's not there yet so that callers can always rely on a non-null, mutable mapping whose entries
+     * persist in the context.
      *
      * @param context the current request context
-     * @return the mapping as it was found in the context (read-write)
+     * @return the mapping stored in the context (read-write)
      */
     private Map<String, File> getFileMapping(XWikiContext context)
     {
         @SuppressWarnings("unchecked")
-        Map<String, File> usedFiles = (Map<String, File>) context.get("pdfexport-file-mapping");
+        Map<String, File> usedFiles = (Map<String, File>) context.get(FILE_MAPPING_KEY);
+        if (usedFiles == null) {
+            usedFiles = new HashMap<>();
+            context.put(FILE_MAPPING_KEY, usedFiles);
+        }
         return usedFiles;
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactory.java
@@ -117,6 +117,10 @@ public class FileSystemURLFactory extends XWikiServletURLFactory
     {
         try {
             Map<String, File> usedFiles = getFileMapping(context);
+            if (usedFiles == null) {
+                // No PDF export file mapping in the context, just return a http:// URL.
+                return super.createSkinURL(filename, skin, context);
+            }
             String key = getSkinfileKey(filename, skin);
             if (!usedFiles.containsKey(key)
                 && !copyResource("/skins/" + skin + '/' + filename, key, usedFiles, context)) {
@@ -135,6 +139,10 @@ public class FileSystemURLFactory extends XWikiServletURLFactory
     {
         try {
             Map<String, File> usedFiles = getFileMapping(context);
+            if (usedFiles == null) {
+                // No PDF export file mapping in the context, just return a http:// URL.
+                return super.createResourceURL(filename, forceSkinAction, context);
+            }
             String key = getResourceKey(filename);
             if (!usedFiles.containsKey(key) && !copyResource("/resources/" + filename, key, usedFiles, context)) {
                 return super.createResourceURL(filename, forceSkinAction, context);

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/script/WysiwygEditorScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/script/WysiwygEditorScriptService.java
@@ -302,7 +302,13 @@ public class WysiwygEditorScriptService implements ScriptService
     public String toAnnotatedXHTML(String source, String syntaxId)
     {
         XWikiContext xwikiContext = this.xcontextProvider.get();
-        return toAnnotatedXHTML(source, getSyntax(syntaxId), xwikiContext.getDoc().getDocumentReference());
+        XWikiDocument currentDocument = xwikiContext.getDoc();
+        if (currentDocument == null) {
+            // No current document to resolve the source reference from: return the source unchanged, as done when the
+            // conversion fails.
+            return source;
+        }
+        return toAnnotatedXHTML(source, getSyntax(syntaxId), currentDocument.getDocumentReference());
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/script/WysiwygEditorScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/script/WysiwygEditorScriptService.java
@@ -301,14 +301,11 @@ public class WysiwygEditorScriptService implements ScriptService
     @Deprecated
     public String toAnnotatedXHTML(String source, String syntaxId)
     {
-        XWikiContext xwikiContext = this.xcontextProvider.get();
-        XWikiDocument currentDocument = xwikiContext.getDoc();
-        if (currentDocument == null) {
-            // No current document to resolve the source reference from: return the source unchanged, as done when the
-            // conversion fails.
-            return source;
-        }
-        return toAnnotatedXHTML(source, getSyntax(syntaxId), currentDocument.getDocumentReference());
+        XWikiDocument currentDocument = this.xcontextProvider.get().getDoc();
+        // Pass a null source reference when there's no current document and let the overload below handle it, so that
+        // the null case is handled in a single place.
+        EntityReference sourceReference = currentDocument == null ? null : currentDocument.getDocumentReference();
+        return toAnnotatedXHTML(source, getSyntax(syntaxId), sourceReference);
     }
 
     /**
@@ -342,6 +339,12 @@ public class WysiwygEditorScriptService implements ScriptService
      */
     public String toAnnotatedXHTML(String source, Syntax syntax, EntityReference sourceReference, boolean restricted)
     {
+        if (sourceReference == null) {
+            // Without a source reference, we can't resolve either the author to execute as, or the document to convert
+            // against. Thus we return the source unchanged, as is also done when the conversion fails below.
+            return source;
+        }
+
         XWikiDocument securityDocument = createSecurityDocument();
         XWikiDocument originalSecurityDocument = setSecurityDocument(securityDocument);
 


### PR DESCRIPTION
# Jira URL

N/A — `[Misc]` change (SonarQube quality-gate cleanup, no dedicated issue).

# Changes

## Description

Follow-up to `[Misc] Fix sonarqube-reported issues that block the quality gate` (630fe598748),
addressing the remaining, behaviourally-sensitive NPE risks (`javabugs:S2259`) reported on the new
code period. These touch `oldcore`, so they are proposed as a PR rather than pushed directly.

* `WysiwygEditorScriptService#toAnnotatedXHTML(String, String)` (deprecated): guard against a null
  current document — return the source unchanged (consistent with the existing exception fallback of
  the delegate method) instead of throwing an NPE.
* `XWikiDocument#getEditURL(String, String, XWikiContext)`: fall back to the current document
  (`this`) when no translated document is present in the context, instead of dereferencing a null
  `tdoc`.
* `FileSystemURLFactory#createSkinURL` / `#createResourceURL`: return the default (`super`) URL when
  the PDF-export file mapping is absent from the context (`getFileMapping` returns null), instead of
  relying on the surrounding `try/catch` to swallow the NPE.

## Clarifications

* All three are internal null-guards / defensive changes; no public API signatures change, so
  Revapi is unaffected and there is no backward-compatibility impact.
* `getFileMapping` is intentionally left returning null (rather than an empty map): callers mutate
  the returned map and expect it to persist in the context, so returning a fresh map would silently
  drop those entries.
* Not included here (kept as SonarQube False-Positive / Accept rather than code changes):
  `XWikiDocument:8954` (backup/restore stores a null value intentionally so it round-trips through
  `restoreContext`), `XWiki.java:2623` and `XWikiDocument:4854`.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

* `mvn clean install -Pquality -pl xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api`
  → BUILD SUCCESS (with tests), 0 Checkstyle violations.
* `mvn clean install -Pquality -DskipTests -pl xwiki-platform-core/xwiki-platform-oldcore`
  → BUILD SUCCESS, 0 Checkstyle violations.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  *
