### PR TITLE
[Misc] Merge collapsible nested if statements (SonarQube java:S1066)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -8462,10 +8462,9 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
                 if (currentBlock instanceof SectionBlock) {
                     // The next children block is a HeaderBlock but we check to be on the safe side...
                     Block nextChildrenBlock = currentBlock.getChildren().get(0);
-                    if (nextChildrenBlock instanceof HeaderBlock headerBlock) {
-                        if (headerBlock.getLevel().getAsInt() <= sectionDepth) {
-                            filteredHeaders.add(headerBlock);
-                        }
+                    if (nextChildrenBlock instanceof HeaderBlock headerBlock
+                        && headerBlock.getLevel().getAsInt() <= sectionDepth) {
+                        filteredHeaders.add(headerBlock);
                     }
                     currentBlock = nextChildrenBlock;
                 } else {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/DatabaseProduct.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/DatabaseProduct.java
@@ -132,10 +132,8 @@ public final class DatabaseProduct
     public boolean equals(Object object)
     {
         boolean result = false;
-        if (object instanceof DatabaseProduct product) {
-            if (product.getProductName().equals(getProductName())) {
-                result = true;
-            }
+        if (object instanceof DatabaseProduct product && product.getProductName().equals(getProductName())) {
+            result = true;
         }
 
         return result;


### PR DESCRIPTION
## Summary

Fixes two SonarCloud `java:S1066` ("Merge this if statement with the enclosing one") issues by collapsing a nested `if` into a single condition using `&&`:

- [`XWikiDocument.getFilteredHeaders()`](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZ98rhC27D0Q84qnpYlm&open=AZ98rhC27D0Q84qnpYlm) — `AZ98rhC27D0Q84qnpYlm`
- [`DatabaseProduct.equals()`](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZ98rhZ97D0Q84qnpYlp&open=AZ98rhZ97D0Q84qnpYlp) — `AZ98rhZ97D0Q84qnpYlp`

Both are pure, behaviour-preserving structural merges (the inner `if` was the sole statement of the outer block, no `else` involved).

## Test plan

- `mvn clean install -pl xwiki-platform-core/xwiki-platform-oldcore -Plegacy,quality` — BUILD SUCCESS, 1139 tests pass (checkstyle, spoon, revapi and JaCoCo included).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZLHVXDUoyG7tn8JKYdtnp)_