### PR TITLE
[stable-18.4.x] [Misc] Fix sonarqube-reported issues that block the quality gate

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/DefaultLiveDataConfigurationResolver.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/DefaultLiveDataConfigurationResolver.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -184,10 +185,18 @@ public class DefaultLiveDataConfigurationResolver implements LiveDataConfigurati
 
     private LiveDataConfiguration translate(LiveDataConfiguration config)
     {
-        config.getMeta().getLayouts().stream().filter(Objects::nonNull).forEach(this::translate);
-        config.getMeta().getFilters().stream().filter(Objects::nonNull).forEach(this::translate);
-        config.getMeta().getActions().stream().filter(Objects::nonNull).forEach(this::translate);
+        LiveDataMeta meta = config.getMeta();
+        if (meta != null) {
+            streamNonNull(meta.getLayouts()).forEach(this::translate);
+            streamNonNull(meta.getFilters()).forEach(this::translate);
+            streamNonNull(meta.getActions()).forEach(this::translate);
+        }
         return config;
+    }
+
+    private <T> Stream<T> streamNonNull(Collection<T> collection)
+    {
+        return collection == null ? Stream.empty() : collection.stream().filter(Objects::nonNull);
     }
 
     private void translate(LiveDataLayoutDescriptor layout)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -5481,7 +5481,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         DocumentInstanceOutputProperties documentProperties = new DocumentInstanceOutputProperties();
         XWikiContext xcontext = getXWikiContext();
         if (xcontext != null) {
-            documentProperties.setDefaultReference(getXWikiContext().getWikiReference());
+            documentProperties.setDefaultReference(xcontext.getWikiReference());
         }
 
         // Input

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-async/xwiki-platform-rendering-async-default/src/main/java/org/xwiki/rendering/async/internal/AsyncRendererCacheListener.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-async/xwiki-platform-rendering-async-default/src/main/java/org/xwiki/rendering/async/internal/AsyncRendererCacheListener.java
@@ -126,7 +126,9 @@ public class AsyncRendererCacheListener extends AbstractEventListener
                 obj = document.getXObject(objectEvent.getReference());
             }
 
-            this.cache.cleanCache(obj.getXClassReference());
+            if (obj != null) {
+                this.cache.cleanCache(obj.getXClassReference());
+            }
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/SchedulerPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/SchedulerPlugin.java
@@ -365,6 +365,10 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
 
     private void register(BaseObject jobObj, XWikiContext context) throws SchedulerPluginException
     {
+        if (jobObj == null) {
+            return;
+        }
+
         String status = jobObj.getStringValue("status");
         if (status.equals(JobState.STATE_NORMAL) || status.equals(JobState.STATE_PAUSED)) {
             scheduleJob(jobObj, context);

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/viewers/attachments.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/viewers/attachments.js
@@ -85,7 +85,7 @@ viewers.Attachments = Class.create({
       return new XWiki.FileUploader(input, {
         'responseContainer' : document.createElement('div'),
         'responseURL' : '',
-        'maxFilesize' : parseInt(input.readAttribute('data-max-file-size'))
+        'maxFilesize' : Number.parseInt(input.readAttribute('data-max-file-size'))
       });
     }
     return false;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
@@ -66,7 +66,7 @@ var XWiki = (function(XWiki) {
     bytesToSize : function (bytes) {
       var sizes = ['b', 'Kb', 'Mb'];
       if (bytes == 0) return 'n/a';
-      var i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)));
+      var i = Number.parseInt(Math.floor(Math.log(bytes) / Math.log(1024)));
       if (i >= sizes.length) {
         i = sizes.length - 1;
       }


### PR DESCRIPTION
Backport of master commit 630fe598748109ba75f6de268c972ad08c5c3ce3 to fix the SonarCloud quality gate on `stable-18.4.x`.

## What

Fixes the BUG-type (`javabugs:S2259`, NPE) SonarCloud blockers on this branch by adding null-checks, plus the matching `parseInt` → `Number.parseInt` cleanups:

- `DefaultLiveDataConfigurationResolver` — guard `config.getMeta()` and null collections (`streamNonNull` helper).
- `AsyncRendererCacheListener` — guard `obj` before `cleanCache`.
- `SchedulerPlugin#register(BaseObject, ...)` — return early when `jobObj` is null.
- `XWikiDocument.fromXML` — reuse the already null-checked `xcontext` local.
- `attachments.js` / `upload.js` — `parseInt` → `Number.parseInt`.

## Adaptation to the branch

master's code was refactored after 18.4.x was cut, so this is **not** a verbatim cherry-pick:

- **`locationPicker.js` change dropped** — it targeted code introduced by XWIKI-24534, which is not on this branch (no issue to fix here).
- **`SchedulerPlugin`** keeps the `"status"` string literal (the `STATUS` constant from the master S1192 cleanup is not on this branch).
- **`attachments.js` / `upload.js`** fixes applied to this branch's own (pre-XWIKI-22125) lines.

The two broad master `[Misc]` cleanups (S6204 `Stream.toList()`, S1192 constants) and the XWIKI-22125 feature / XWIKI-24534 bugfix that caused the merge conflicts were deliberately **not** backported — they only enable code smells (not BUG-type gate blockers) or would drag a feature/refactors onto a stable branch.

## Verification

`xwiki-platform-livedata-api` and `xwiki-platform-scheduler-api` compile with `-Plegacy` (`BUILD SUCCESS`).