### PR TITLE
[Misc] Fix duplicated ResourceReferenceHandler type parameter documentation

### DIFF
--- a/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-api/src/main/java/org/xwiki/resource/ResourceReferenceHandler.java
+++ b/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-api/src/main/java/org/xwiki/resource/ResourceReferenceHandler.java
@@ -26,9 +26,8 @@ import org.xwiki.component.annotation.Role;
 /**
  * Handles a given {@link ResourceReference}.
  *
- * @param <T> the qualifying element to specify what Resource Reference are handled by thus Handler (e.g. Resource Type,
- *            Entity Resource Action)
- * @param <T> the type of supported items
+ * @param <T> the type of supported items, used as the qualifying element to specify which Resource References are
+ *            handled by this Handler (e.g. Resource Type, Entity Resource Action)
  * @version $Id$
  * @since 6.1M2
  */


### PR DESCRIPTION
## Description

* Merge the duplicated `@param <T>` Javadoc entries in `ResourceReferenceHandler`.
* Preserve the useful information from both descriptions while documenting the type parameter only once.

## Clarifications

* This avoids an unused `@param <T>` Javadoc error without dropping the existing explanatory text.