### PR TITLE
[Misc] Fix various SonarCloud issues (unused field, collapsible if, Collectors.toList)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/io/internal/DefaultIOService.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/io/internal/DefaultIOService.java
@@ -230,12 +230,10 @@ public class DefaultIOService implements IOService
             }
             for (BaseObject object : objects) {
                 // Use the object number as annotation id
-                if (object != null) {
-                    // The legacy behavior is to have a non-empty target, which can lead to issues when the document
-                    // is moved. Now, we consider an object with an empty target as related to the containing document.
-                    if (matchesTarget(object, localTargetId, isDocumentType)) {
-                        result.add(loadAnnotationFromObject(object, localTargetId));
-                    }
+                // The legacy behavior is to have a non-empty target, which can lead to issues when the document
+                // is moved. Now, we consider an object with an empty target as related to the containing document.
+                if (object != null && matchesTarget(object, localTargetId, isDocumentType)) {
+                    result.add(loadAnnotationFromObject(object, localTargetId));
                 }
             }
             return result;

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/io/internal/migration/hibernate/R180600000XWIKI20699DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/io/internal/migration/hibernate/R180600000XWIKI20699DataMigration.java
@@ -20,7 +20,6 @@
 package org.xwiki.annotation.io.internal.migration.hibernate;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -92,7 +91,7 @@ public class R180600000XWIKI20699DataMigration extends AbstractDocumentsMigratio
                 // always the root one. It must be passed as the empty string: a null locale resolves to no
                 // reference at all, silently discarding every selected document.
                 .flatMap(fullName -> resolveDocumentReference(String.valueOf(fullName), "").stream())
-                .collect(Collectors.toList());
+                .toList();
         } catch (QueryException e) {
             throw new DataMigrationException(
                 String.format("Failed retrieve the list of all the documents with annotations for wiki [%s].",

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/DocumentInstanceOutputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/DocumentInstanceOutputFilterStream.java
@@ -84,8 +84,6 @@ public class DocumentInstanceOutputFilterStream extends AbstractBeanOutputFilter
 
     private boolean firstVersion;
 
-    private FilterEventParameters currentLocaleParameters;
-
     private FilterEventParameters currentRevisionParameters;
 
     @Override
@@ -113,7 +111,6 @@ public class DocumentInstanceOutputFilterStream extends AbstractBeanOutputFilter
     @Override
     public void beginWikiDocument(String name, FilterEventParameters parameters) throws FilterException
     {
-        this.currentLocaleParameters = parameters;
         this.currentRevisionParameters = parameters;
 
         // Init the first version marker
@@ -127,14 +124,12 @@ public class DocumentInstanceOutputFilterStream extends AbstractBeanOutputFilter
 
         // Reset
         this.currentRevisionParameters = null;
-        this.currentLocaleParameters = null;
         this.firstVersion = false;
     }
 
     @Override
     public void beginWikiDocumentLocale(Locale locale, FilterEventParameters parameters) throws FilterException
     {
-        this.currentLocaleParameters = parameters;
         this.currentRevisionParameters = parameters;
 
         // Init the first version marker
@@ -148,7 +143,6 @@ public class DocumentInstanceOutputFilterStream extends AbstractBeanOutputFilter
 
         // Reset
         this.currentRevisionParameters = null;
-        this.currentLocaleParameters = null;
         this.firstVersion = false;
     }
 


### PR DESCRIPTION
## Summary

Fixes three safe, mechanical SonarCloud issues in xwiki-platform:

- [`java:S1068`](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AW5-S56-1Yj5qvzeRm8Z&open=AW5-S56-1Yj5qvzeRm8Z) — remove the unused private `currentLocaleParameters` field in `DocumentInstanceOutputFilterStream` (write-only: assigned in 4 places, never read).
- [`java:S1066`](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZ-LGf4mRQLNEUYjlwfU&open=AZ-LGf4mRQLNEUYjlwfU) — merge a collapsible nested `if` in `DefaultIOService` (comment preserved).
- [`java:S6204`](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZ-LGf5PRQLNEUYjlwfV&open=AZ-LGf5PRQLNEUYjlwfV) — replace `Stream.collect(Collectors.toList())` with `Stream.toList()` in `R180600000XWIKI20699DataMigration` (result stays confined — only iterated/sized by the migration framework; orphaned `Collectors` import removed).

## Test plan

Built the affected modules with tests and the quality profile:

```
mvn clean install -pl xwiki-platform-core/xwiki-platform-oldcore,xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io -Plegacy,quality
```

`BUILD SUCCESS` — all unit tests pass (oldcore 1139+, annotation-io 30), including `DefaultIOServiceTest`, `R180600000XWIKI20699DataMigrationTest` and `DocumentInstanceOutputFilterStreamTest`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEoHbi4gbXvS3CLFafSRkX)_