### PR TITLE
XWIKI-24594: Wrong mathttool declared in velocity configuration instead of overriding mathtool

### DIFF
--- a/xwiki-platform-core/xwiki-platform-velocity/xwiki-platform-velocity-xwiki/src/main/java/org/xwiki/velocity/internal/XWikiVelocityConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-velocity/xwiki-platform-velocity-xwiki/src/main/java/org/xwiki/velocity/internal/XWikiVelocityConfiguration.java
@@ -63,7 +63,9 @@ public class XWikiVelocityConfiguration extends DefaultVelocityConfiguration
         // Override some tools
         this.defaultTools.put("numbertool", this.numberTool);
         this.defaultTools.put("datetool", this.dateTool);
+        // We use to wrongly declare the tool with that typo, we cannot really get rid of it now so keeping both.
         this.defaultTools.put("mathttool", this.mathTool);
+        this.defaultTools.put("mathtool", this.mathTool);
 
         if (this.componentManager.hasComponent(ResourceLoaderInitializer.class)) {
             try {


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24594

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Properly override mathtool without the typo and keep old mathttool for backward compatibility reasons

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

`mvn clean install -Pquality` on the module

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-18.4.x
  * stable-17.10.x
  * stable-18.6.x