### PR TITLE
[stable-18.6.x] [Misc] Fix additional SonarQube-reported NPE risks blocking the quality gate

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -7744,6 +7744,10 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         com.xpn.xwiki.XWiki xwiki = context.getWiki();
         String language = "";
         XWikiDocument tdoc = (XWikiDocument) context.get(CKEY_TDOC);
+        // Fall back to this document when no translated document is set in the context.
+        if (tdoc == null) {
+            tdoc = this;
+        }
         String realLang = tdoc.getRealLanguage(context);
         if (xwiki.isMultiLingual(context) && (!"".equals(realLang))) {
             language = realLang;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactory.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -63,6 +64,9 @@ public class FileSystemURLFactory extends XWikiServletURLFactory
 
     /** Segment separator used in the collision-free key generation. */
     private static final char SEPARATOR = '/';
+
+    /** Context key under which the resource-key-to-temporary-file mapping is stored during the export. */
+    private static final String FILE_MAPPING_KEY = "pdfexport-file-mapping";
 
     private LegacySpaceResolver legacySpaceResolver = Utils.getComponent(LegacySpaceResolver.class);
 
@@ -317,15 +321,21 @@ public class FileSystemURLFactory extends XWikiServletURLFactory
     }
 
     /**
-     * Retrieve the Map that relates resource keys to their corresponding temporary file.
+     * Retrieve the Map that relates resource keys to their corresponding temporary file, creating and storing it in the
+     * context when it's not there yet so that callers can always rely on a non-null, mutable mapping whose entries
+     * persist in the context.
      *
      * @param context the current request context
-     * @return the mapping as it was found in the context (read-write)
+     * @return the mapping stored in the context (read-write)
      */
     private Map<String, File> getFileMapping(XWikiContext context)
     {
         @SuppressWarnings("unchecked")
-        Map<String, File> usedFiles = (Map<String, File>) context.get("pdfexport-file-mapping");
+        Map<String, File> usedFiles = (Map<String, File>) context.get(FILE_MAPPING_KEY);
+        if (usedFiles == null) {
+            usedFiles = new HashMap<>();
+            context.put(FILE_MAPPING_KEY, usedFiles);
+        }
         return usedFiles;
     }
 

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/script/WysiwygEditorScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/script/WysiwygEditorScriptService.java
@@ -301,8 +301,11 @@ public class WysiwygEditorScriptService implements ScriptService
     @Deprecated
     public String toAnnotatedXHTML(String source, String syntaxId)
     {
-        XWikiContext xwikiContext = this.xcontextProvider.get();
-        return toAnnotatedXHTML(source, getSyntax(syntaxId), xwikiContext.getDoc().getDocumentReference());
+        XWikiDocument currentDocument = this.xcontextProvider.get().getDoc();
+        // Pass a null source reference when there's no current document and let the overload below handle it, so that
+        // the null case is handled in a single place.
+        EntityReference sourceReference = currentDocument == null ? null : currentDocument.getDocumentReference();
+        return toAnnotatedXHTML(source, getSyntax(syntaxId), sourceReference);
     }
 
     /**
@@ -336,6 +339,12 @@ public class WysiwygEditorScriptService implements ScriptService
      */
     public String toAnnotatedXHTML(String source, Syntax syntax, EntityReference sourceReference, boolean restricted)
     {
+        if (sourceReference == null) {
+            // Without a source reference, we can't resolve either the author to execute as, or the document to convert
+            // against. Thus we return the source unchanged, as is also done when the conversion fails below.
+            return source;
+        }
+
         XWikiDocument securityDocument = createSecurityDocument();
         XWikiDocument originalSecurityDocument = setSecurityDocument(securityDocument);
 


### PR DESCRIPTION
# Jira URL

N/A — `[Misc]` change (SonarQube quality-gate fixes, no JIRA issue).

# Changes

## Description

Backport to `stable-18.6.x` of the master commit d33553c3cc47461cb9fc0d3a95b6b2369667c562
("[Misc] Fix additional SonarQube-reported NPE risks blocking the quality gate"). It fixes
three SonarQube-reported NPE risks:

* `XWikiDocument.getEditURL`: fall back to the current document when no translated document
  (`tdoc`) is set in the context, avoiding an NPE on `tdoc.getRealLanguage(context)`.
* `FileSystemURLFactory`: instead of null-checking the file mapping at each call site,
  `getFileMapping()` now lazily creates and stores the mapping in the context, so it is always
  non-null and callers' mutations still persist.
* `WysiwygEditorScriptService`: handle the null source reference in a single place (the 4-arg
  overload) rather than short-circuiting in the deprecated 2-arg overload.

## Clarifications

* This fix already exists on master and was backported to `stable-18.4.x`
  (commit 56fd0c2206c). It had been forgotten on `stable-18.6.x`; this PR fills that gap.
* Cherry-picked with `-x`; the backport reproduces the original commit's `--stat` exactly
  (3 files, 28 insertions, 5 deletions) and required no adaptation (no new modules/poms, no
  `@since` tags, no Java-level-sensitive APIs).

# Screenshots & Video

N/A — no UI change.

# Executed Tests

Compiled the two affected modules against `stable-18.6.x`:

```
mvn -B -ntp -Plegacy -DskipTests test-compile   # xwiki-platform-oldcore
mvn -B -ntp -Plegacy -DskipTests test-compile   # xwiki-platform-wysiwyg-api
```

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * N/A — this PR *is* the backport onto `stable-18.6.x`.
