### PR TITLE
XWIKI-24354: The quick action hint in CKEditor lacks contrast

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
@@ -232,8 +232,7 @@ a[data-linktype="create"]::after {
 [contenteditable="true"] [data-xwiki-focusedplaceholder]::before {
   /* Show the value of the focused line placeholder attribute */
   position: absolute;
-  opacity: .8;
-  color: #aaa;
+  color: var(--text-muted);
   content: attr(data-xwiki-focusedplaceholder);
 }
 

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
@@ -233,6 +233,7 @@ a[data-linktype="create"]::after {
   /* Show the value of the focused line placeholder attribute */
   position: absolute;
   color: var(--text-muted);
+  font-style: italic;
   content: attr(data-xwiki-focusedplaceholder);
 }
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-24354

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Replaced the hardcoded CKEditor quick action hint `color: #aaa; opacity: .8;` with `color: var(--text-muted);`
* Added italic on the quick action hint so that it's easier to differentiate it from regular text.

## Clarification
* Contrast check (body text is `#222222` in both versions):
  * Hint vs. background (white): 
    * before **1.92:1** fails WCAG AA's 4.5:1threshhold
    * after **7.46:1** passes AA and AAA
  * Hint vs. real text (to confirm the hint stays distinguishable from content): 
    * before **8.54:1**
    * after **2.2:1** There's no WCAG success criterion explicitely requiring a minimum contrast between hint and content, but relying only on that narrow color difference to signal "this isn't real content" would itself risk **SC 1.4.1 (Use of Color)**: *"Color is not used as the only visual means of ... distinguishing a visual element."* That's the same principle behind link-in-text-block accessibility checks (a link inside text needs a non-color cue, e.g. an underline). So I decided to italicize the hint, giving it a second, non-color cue. The screenshot below shows it stays clearly distinct from the real text.


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
<img width="2120" height="915" alt="xwiki-24354-comparison" src="https://github.com/user-attachments/assets/5eca1632-de3d-469c-9b7b-fc7c4232d040" />


For safekeeping until the release note, here is a simplified comparison screenshot:
<img width="2040" height="402" alt="XWIKI-24354-release-note-comparison-trimmed" src="https://github.com/user-attachments/assets/6b136137-2aba-4809-8a7e-341eed3e763b" />


# Executed Tests
Tested the change manually on a local instance by editing a page in CKEditor and placing the cursor on an empty line to trigger the focused-line placeholder hint.
Slight visual variations on a non-interactive element so I doubt any automatic test would be changed by this update.

Built the changed module with quality and checkstyle checks enabled:
`mvn clean install -pl xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui -Plegacy,snapshot,quality`
Result: `BUILD SUCCESS`, 0 Checkstyle violations, license check OK (25/25 files), XAR XML validity check OK.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A
