### PR TITLE
[stable-18.6.x] [Misc] Fix sonarqube-reported issues that block the quality gate

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/DefaultLiveDataConfigurationResolver.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/DefaultLiveDataConfigurationResolver.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -184,10 +185,18 @@ public class DefaultLiveDataConfigurationResolver implements LiveDataConfigurati
 
     private LiveDataConfiguration translate(LiveDataConfiguration config)
     {
-        config.getMeta().getLayouts().stream().filter(Objects::nonNull).forEach(this::translate);
-        config.getMeta().getFilters().stream().filter(Objects::nonNull).forEach(this::translate);
-        config.getMeta().getActions().stream().filter(Objects::nonNull).forEach(this::translate);
+        LiveDataMeta meta = config.getMeta();
+        if (meta != null) {
+            streamNonNull(meta.getLayouts()).forEach(this::translate);
+            streamNonNull(meta.getFilters()).forEach(this::translate);
+            streamNonNull(meta.getActions()).forEach(this::translate);
+        }
         return config;
+    }
+
+    private <T> Stream<T> streamNonNull(Collection<T> collection)
+    {
+        return collection == null ? Stream.empty() : collection.stream().filter(Objects::nonNull);
     }
 
     private void translate(LiveDataLayoutDescriptor layout)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -5493,7 +5493,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         DocumentInstanceOutputProperties documentProperties = new DocumentInstanceOutputProperties();
         XWikiContext xcontext = getXWikiContext();
         if (xcontext != null) {
-            documentProperties.setDefaultReference(getXWikiContext().getWikiReference());
+            documentProperties.setDefaultReference(xcontext.getWikiReference());
         }
 
         // Input

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-async/xwiki-platform-rendering-async-default/src/main/java/org/xwiki/rendering/async/internal/AsyncRendererCacheListener.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-async/xwiki-platform-rendering-async-default/src/main/java/org/xwiki/rendering/async/internal/AsyncRendererCacheListener.java
@@ -126,7 +126,9 @@ public class AsyncRendererCacheListener extends AbstractEventListener
                 obj = document.getXObject(objectEvent.getReference());
             }
 
-            this.cache.cleanCache(obj.getXClassReference());
+            if (obj != null) {
+                this.cache.cleanCache(obj.getXClassReference());
+            }
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/SchedulerPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/SchedulerPlugin.java
@@ -373,6 +373,10 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
 
     private void register(BaseObject jobObj, XWikiContext context) throws SchedulerPluginException
     {
+        if (jobObj == null) {
+            return;
+        }
+
         String status = jobObj.getStringValue(STATUS);
         if (status.equals(JobState.STATE_NORMAL) || status.equals(JobState.STATE_PAUSED)) {
             scheduleJob(jobObj, context);

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/viewers/attachments.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/viewers/attachments.js
@@ -86,7 +86,7 @@ require(['jquery', 'xwiki-upload', 'xwiki-events-bridge'], function($, FileUploa
         return new FileUploader(input[0], {
           'responseContainer' : document.createElement('div'),
           'responseURL' : '',
-          'maxFilesize' : parseInt(input.attr('data-max-file-size'))
+          'maxFilesize' : Number.parseInt(input.attr('data-max-file-size'))
         });
       }
       return false;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.js
@@ -408,7 +408,7 @@ require(['jquery'], function($) {
         failureMessage: l10n['core.validation.spacevalidation.message.invalidreference'],
         against: function(value) {
           if (typeof value === 'string') {
-            let separatorsOnly = value.strip().replace(/\\\\/g, 'x').replace(/\\./g, 'x');
+            let separatorsOnly = value.strip().replaceAll(/\\\\/g, 'x').replaceAll(/\\./g, 'x');
             return separatorsOnly.search(dotRegex) === -1;
           } else {
             return true;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
@@ -88,7 +88,7 @@ define('xwiki-upload', ['xwiki-l10n!upload-translations'], function(l10n) {
     {
       if (bytes === 0) return 'N/A';
       let sizes = ['B', 'KB', 'MB'];
-      let unitIndex = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)));
+      let unitIndex = Number.parseInt(Math.floor(Math.log(bytes) / Math.log(1024)));
       return (bytes / Math.pow(1024, unitIndex)).toFixed(1) +
           sizes[Math.min(unitIndex, sizes.length - 1)];
     }


### PR DESCRIPTION
# Jira URL

N/A — `[Misc]` change (SonarQube quality-gate fixes, no JIRA issue).

# Changes

## Description

Backport to `stable-18.6.x` of the master commit 630fe598748109ba75f6de268c972ad08c5c3ce3
("[Misc] Fix sonarqube-reported issues that block the quality gate"). It fixes several
SonarQube-reported issues (mostly NPE risks) across Java and JavaScript:

* `DefaultLiveDataConfigurationResolver`: guard the meta/layout/filter/action collections against
  null before streaming them (new `streamNonNull` helper), avoiding NPEs during translation.
* `XWikiDocument.fromXML`: set the default reference on the parsed document properties from the
  context wiki reference.
* `AsyncRendererCacheListener`: null-check the retrieved object before cleaning its class from the
  cache.
* `SchedulerPlugin`: return early when the job object is null.
* `attachments.js`, `locationPicker.js`, `upload.js`: minor JavaScript robustness fixes
  (`Number.parseInt`, safer separator handling).

## Clarifications

* Cherry-picked with `-x`; the backport reproduces the original commit's `--stat` exactly
  (7 files, 23 insertions, 8 deletions).
* One trivial conflict resolved by adapting to the branch: `DefaultLiveDataConfigurationResolver`
  still uses `Collectors.toList()` on `stable-18.6.x` (master had migrated it to `Stream.toList()`
  and dropped the `Collectors` import), so the backport keeps the existing `import
  java.util.stream.Collectors;` alongside the newly-added `import java.util.stream.Stream;`.
* No new modules/poms, no `@since` tags, no Java-level-sensitive APIs.

# Screenshots & Video

N/A — no visible UI change.

# Executed Tests

Compiled the three affected Java modules against `stable-18.6.x` (JavaScript files need no
compilation):

```
mvn -B -ntp -Plegacy -DskipTests test-compile   # xwiki-platform-livedata-api            -> BUILD SUCCESS
mvn -B -ntp -Plegacy -DskipTests test-compile   # xwiki-platform-rendering-async-default -> BUILD SUCCESS
mvn -B -ntp -Plegacy -DskipTests test-compile   # xwiki-platform-oldcore                 -> BUILD SUCCESS
```

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * N/A — this PR *is* the backport onto `stable-18.6.x`.
