### PR TITLE
[Misc] Fix various mechanical SonarCloud issues (EnumMap, lambda, StringBuilder)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/internal/renderer/AnnotationXHTMLChainingRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/internal/renderer/AnnotationXHTMLChainingRenderer.java
@@ -19,7 +19,7 @@
  */
 package org.xwiki.annotation.internal.renderer;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
@@ -52,7 +52,7 @@ public class AnnotationXHTMLChainingRenderer extends XHTMLChainingRenderer imple
     /**
      * Map to store the events count to be able to identify an event in the emitted events.
      */
-    private Map<EventType, Integer> eventsCount = new HashMap<>();
+    private Map<EventType, Integer> eventsCount = new EnumMap<>(EventType.class);
 
     /**
      * The annotations XHTML markers printer, used to handle annotations markers rendering and nesting.

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/io/internal/migration/hibernate/R40001XWIKI7540DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/io/internal/migration/hibernate/R40001XWIKI7540DataMigration.java
@@ -21,7 +21,6 @@ package org.xwiki.annotation.io.internal.migration.hibernate;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -350,14 +349,8 @@ public class R40001XWIKI7540DataMigration extends AbstractHibernateDataMigration
             session.clear();
 
             // Sort the objects by date. The objects were removed from the session but are still available in-memory.
-            Collections.sort(datedObjects, new Comparator<Entry<Date, BaseObject>>()
-            {
-                @Override
-                public int compare(Entry<Date, BaseObject> datedObject1, Entry<Date, BaseObject> datedObject2)
-                {
-                    return datedObject1.getKey().compareTo(datedObject2.getKey());
-                }
-            });
+            Collections.sort(datedObjects,
+                (datedObject1, datedObject2) -> datedObject1.getKey().compareTo(datedObject2.getKey()));
 
             // Reassign object numbers and convert annotations for the current document, based on the previous sorting.
             for (int newObjectNumber = 0; newObjectNumber < datedObjects.size(); newObjectNumber++) {

--- a/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-macro/src/main/java/org/xwiki/rendering/internal/macro/dashboard/ColumnsDashboardRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-macro/src/main/java/org/xwiki/rendering/internal/macro/dashboard/ColumnsDashboardRenderer.java
@@ -21,7 +21,6 @@ package org.xwiki.rendering.internal.macro.dashboard;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -85,14 +84,8 @@ public class ColumnsDashboardRenderer implements DashboardRenderer
 
         // sort the column gadgets by first the column number then by index in column, for all those which have a valid
         // position
-        Collections.sort(columnGadgets, new Comparator<ColumnGadget>()
-        {
-            public int compare(ColumnGadget g1, ColumnGadget g2)
-            {
-                return g1.getColumn().equals(g2.getColumn()) ? g1.getIndex() - g2.getIndex() : g1.getColumn()
-                    - g2.getColumn();
-            }
-        });
+        Collections.sort(columnGadgets, (g1, g2) -> g1.getColumn().equals(g2.getColumn())
+            ? g1.getIndex() - g2.getIndex() : g1.getColumn() - g2.getColumn());
 
         // get the maximmum column number in the gadgets list and create that number of columns. This is the column
         // number of the last gadget in the ordered list. Default is 1 column, the empty dashboard is made of one empty

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-distribution/src/main/java/org/xwiki/extension/distribution/internal/DefaultDistributionManager.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-distribution/src/main/java/org/xwiki/extension/distribution/internal/DefaultDistributionManager.java
@@ -213,23 +213,18 @@ public class DefaultDistributionManager implements DistributionManager, Initiali
             request.setUserReference(xcontext.getUserReference());
             request.setInteractive(this.distributionConfiguration.isInteractiveDistributionWizardEnabledForMainWiki());
 
-            Thread distributionJobThread = new Thread(new Runnable()
-            {
-                @Override
-                public void run()
-                {
-                    // Create a clean Execution Context
-                    ExecutionContext context = new ExecutionContext();
+            Thread distributionJobThread = new Thread(() -> {
+                // Create a clean Execution Context
+                ExecutionContext context = new ExecutionContext();
 
-                    try {
-                        executionContextManager.initialize(context);
-                    } catch (ExecutionContextException e) {
-                        throw new RuntimeException("Failed to initialize farm distribution job execution context", e);
-                    }
-
-                    farmDistributionJob.initialize(request);
-                    farmDistributionJob.run();
+                try {
+                    executionContextManager.initialize(context);
+                } catch (ExecutionContextException e) {
+                    throw new RuntimeException("Failed to initialize farm distribution job execution context", e);
                 }
+
+                farmDistributionJob.initialize(request);
+                farmDistributionJob.run();
             });
 
             distributionJobThread.setDaemon(true);
@@ -266,25 +261,20 @@ public class DefaultDistributionManager implements DistributionManager, Initiali
                 DistributionJob wikiJob = this.componentManager.getInstance(Job.class, DefaultDistributionJob.HINT);
                 this.wikiDistributionJobs.put(wiki, wikiJob);
 
-                Thread distributionJobThread = new Thread(new Runnable()
-                {
-                    @Override
-                    public void run()
-                    {
-                        // Create a clean Execution Context
-                        ExecutionContext context = new ExecutionContext();
+                Thread distributionJobThread = new Thread(() -> {
+                    // Create a clean Execution Context
+                    ExecutionContext context = new ExecutionContext();
 
-                        try {
-                            executionContextManager.initialize(context);
-                        } catch (ExecutionContextException e) {
-                            throw new RuntimeException("Failed to initialize wiki distribution job execution context",
-                                e);
-                        }
-
-                        DistributionJob job = wikiDistributionJobs.get(request.getWiki());
-                        job.initialize(request);
-                        job.run();
+                    try {
+                        executionContextManager.initialize(context);
+                    } catch (ExecutionContextException e) {
+                        throw new RuntimeException("Failed to initialize wiki distribution job execution context",
+                            e);
                     }
+
+                    DistributionJob job = wikiDistributionJobs.get(request.getWiki());
+                    job.initialize(request);
+                    job.run();
                 });
 
                 distributionJobThread.setDaemon(true);

--- a/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
@@ -782,9 +782,12 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
                 "select distinct obj.number, obj.name from BaseObject as obj, StringProperty as prop , LargeStringProperty as lprop "
                     + "where obj.className='XWiki.FeedEntryClass' and obj.id=prop.id.id and obj.id=lprop.id.id ";
 
+            StringBuilder sqlBuilder = new StringBuilder(sql);
             for (int i = 0; i < queryTab.length; i++) {
-                sql += " and (prop.value LIKE '%" + queryTab[i] + "%' or lprop.value LIKE '%" + queryTab[i] + "%')";
+                sqlBuilder.append(" and (prop.value LIKE '%").append(queryTab[i])
+                    .append("%' or lprop.value LIKE '%").append(queryTab[i]).append("%')");
             }
+            sql = sqlBuilder.toString();
             List<Object[]> res = context.getWiki().search(sql, context);
 
             if (res == null) {

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-messagestream/xwiki-platform-legacy-messagestream-api/src/test/java/org/xwiki/messagestream/internal/DirectMessageStreamNotificationFilterTest.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-messagestream/xwiki-platform-legacy-messagestream-api/src/test/java/org/xwiki/messagestream/internal/DirectMessageStreamNotificationFilterTest.java
@@ -19,7 +19,7 @@
  */
 package org.xwiki.messagestream.internal;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -79,14 +79,14 @@ class DirectMessageStreamNotificationFilterTest
     void matchesPreference()
     {
         NotificationPreference notificationPreference = mock(NotificationPreference.class);
-        Map<NotificationPreferenceProperty, Object> properties = new HashMap<>();
+        Map<NotificationPreferenceProperty, Object> properties = new EnumMap<>(NotificationPreferenceProperty.class);
         properties.put(NotificationPreferenceProperty.EVENT_TYPE, "directMessage");
         when(notificationPreference.getProperties()).thenReturn(properties);
 
         assertTrue(this.groupMessageFilter.matchesPreference(notificationPreference));
 
         NotificationPreference notificationPreference2 = mock(NotificationPreference.class);
-        Map<NotificationPreferenceProperty, Object> properties2 = new HashMap<>();
+        Map<NotificationPreferenceProperty, Object> properties2 = new EnumMap<>(NotificationPreferenceProperty.class);
         properties2.put(NotificationPreferenceProperty.EVENT_TYPE, "otherEventType");
         when(notificationPreference2.getProperties()).thenReturn(properties2);
 

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-messagestream/xwiki-platform-legacy-messagestream-api/src/test/java/org/xwiki/messagestream/internal/PersonalMessageStreamNotificationFilterTest.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-messagestream/xwiki-platform-legacy-messagestream-api/src/test/java/org/xwiki/messagestream/internal/PersonalMessageStreamNotificationFilterTest.java
@@ -19,7 +19,7 @@
  */
 package org.xwiki.messagestream.internal;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -93,14 +93,14 @@ class PersonalMessageStreamNotificationFilterTest
     void matchesPreference()
     {
         NotificationPreference notificationPreference = mock(NotificationPreference.class);
-        Map<NotificationPreferenceProperty, Object> properties = new HashMap<>();
+        Map<NotificationPreferenceProperty, Object> properties = new EnumMap<>(NotificationPreferenceProperty.class);
         properties.put(EVENT_TYPE, "personalMessage");
         when(notificationPreference.getProperties()).thenReturn(properties);
 
         assertTrue(this.personalMessageFilter.matchesPreference(notificationPreference));
 
         NotificationPreference notificationPreference2 = mock(NotificationPreference.class);
-        Map<NotificationPreferenceProperty, Object> properties2 = new HashMap<>();
+        Map<NotificationPreferenceProperty, Object> properties2 = new EnumMap<>(NotificationPreferenceProperty.class);
         properties2.put(EVENT_TYPE, "otherEventType");
         when(notificationPreference2.getProperties()).thenReturn(properties2);
 

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-notifications/xwiki-platform-legacy-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/LegacyDefaultNotificationParametersFactoryTest.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-notifications/xwiki-platform-legacy-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/LegacyDefaultNotificationParametersFactoryTest.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -245,7 +245,7 @@ class LegacyDefaultNotificationParametersFactoryTest
             this.parametersFactory.createNotificationParameters(Collections.emptyMap()));
         verify(wikiDescriptorManager).getCurrentWikiId();
 
-        Map<ParametersKey, String> parametersMap = new HashMap<>();
+        Map<ParametersKey, String> parametersMap = new EnumMap<>(ParametersKey.class);
         parametersMap.put(ParametersKey.FORMAT, "EMAIL");
         parametersMap.put(ParametersKey.USER_ID, USER_SERIALIZED_REFERENCE);
         parametersMap.put(ParametersKey.USE_USER_PREFERENCES, "true");

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/cache/CacheKeyFactory.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/cache/CacheKeyFactory.java
@@ -84,12 +84,15 @@ public class CacheKeyFactory
                 XWiki.CACHE_VERSION);
             if (request instanceof ServletRequest servletRequest) {
                 Map<String, String[]> parameters = servletRequest.getHttpServletRequest().getParameterMap();
+                StringBuilder resultBuilder = new StringBuilder(result);
                 for (Map.Entry<String, String[]> entry : parameters.entrySet()) {
                     if (!excludes.contains(entry.getKey())) {
                         String[] values = entry.getValue();
-                        result += CACHE_KEY_SEPARATOR + entry.getKey() + ":" + StringUtils.join(values, "|");
+                        resultBuilder.append(CACHE_KEY_SEPARATOR).append(entry.getKey()).append(":")
+                            .append(StringUtils.join(values, "|"));
                     }
                 }
+                result = resultBuilder.toString();
             }
 
             String xcontext = xcontextCacheKeyFactory.getCacheKey();

--- a/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSenderPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSenderPlugin.java
@@ -421,10 +421,12 @@ public class MailSenderPlugin extends XWikiDefaultPlugin
                 String header = m.group(1);
                 String value = m.group(2);
                 line = input.readLine();
+                StringBuilder valueBuilder = new StringBuilder(value);
                 while (line != null && (line.startsWith(" ") || line.startsWith("\t"))) {
-                    value += line;
+                    valueBuilder.append(line);
                     line = input.readLine();
                 }
+                value = valueBuilder.toString();
                 if (SUBJECT.equals(header)) {
                     toMail.setSubject(value);
                 } else if (FROM.equals(header)) {

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/EntityReferenceSet.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/EntityReferenceSet.java
@@ -22,6 +22,7 @@ package org.xwiki.model.reference;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -116,7 +117,7 @@ public class EntityReferenceSet
                     return null;
                 }
 
-                this.children = new HashMap<>();
+                this.children = new EnumMap<>(EntityType.class);
             }
 
             EntityReferenceEntryChildren child = this.children.get(entityType);

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterTest.java
@@ -21,7 +21,7 @@ package org.xwiki.notifications.filters.internal.scope;
 
 import java.util.Collection;
 import java.util.Date;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -163,7 +163,7 @@ class ScopeNotificationFilterTest
         // Mock α
         NotificationPreference preference = mock(NotificationPreference.class);
         when(preference.getFormat()).thenReturn(NotificationFormat.ALERT);
-        Map<NotificationPreferenceProperty, Object> properties = new HashMap<>();
+        Map<NotificationPreferenceProperty, Object> properties = new EnumMap<>(NotificationPreferenceProperty.class);
         properties.put(NotificationPreferenceProperty.EVENT_TYPE, "update");
         when(preference.getProperties()).thenReturn(properties);
 
@@ -253,7 +253,7 @@ class ScopeNotificationFilterTest
         // Mock α
         NotificationPreference preference = mock(NotificationPreference.class);
         when(preference.getFormat()).thenReturn(NotificationFormat.ALERT);
-        Map<NotificationPreferenceProperty, Object> properties = new HashMap<>();
+        Map<NotificationPreferenceProperty, Object> properties = new EnumMap<>(NotificationPreferenceProperty.class);
         properties.put(NotificationPreferenceProperty.EVENT_TYPE, "update");
         when(preference.getProperties()).thenReturn(properties);
 
@@ -326,8 +326,8 @@ class ScopeNotificationFilterTest
     {
         NotificationPreference pref1 = mock(NotificationPreference.class);
         NotificationPreference pref2 = mock(NotificationPreference.class);
-        Map<NotificationPreferenceProperty, Object> properties1 = new HashMap<>();
-        Map<NotificationPreferenceProperty, Object> properties2 = new HashMap<>();
+        Map<NotificationPreferenceProperty, Object> properties1 = new EnumMap<>(NotificationPreferenceProperty.class);
+        Map<NotificationPreferenceProperty, Object> properties2 = new EnumMap<>(NotificationPreferenceProperty.class);
         when(pref1.getProperties()).thenReturn(properties1);
         when(pref2.getProperties()).thenReturn(properties2);
         properties1.put(NotificationPreferenceProperty.EVENT_TYPE, "type1");
@@ -392,7 +392,7 @@ class ScopeNotificationFilterTest
         // Mock α
         NotificationPreference preference = mock(NotificationPreference.class);
         when(preference.getFormat()).thenReturn(NotificationFormat.ALERT);
-        Map<NotificationPreferenceProperty, Object> properties = new HashMap<>();
+        Map<NotificationPreferenceProperty, Object> properties = new EnumMap<>(NotificationPreferenceProperty.class);
         properties.put(NotificationPreferenceProperty.EVENT_TYPE, "update");
         when(preference.getProperties()).thenReturn(properties);
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/migrators/NotificationFilterPreferencesMigrator.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/migrators/NotificationFilterPreferencesMigrator.java
@@ -21,7 +21,7 @@ package org.xwiki.notifications.filters.internal.migrators;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -249,7 +249,8 @@ public class NotificationFilterPreferencesMigrator extends AbstractEventListener
 
     private Map<NotificationFilterProperty, List<String>> createNotificationFilterPropertiesMap(BaseObject obj)
     {
-        Map<NotificationFilterProperty, List<String>> filterPreferenceProperties = new HashMap<>();
+        Map<NotificationFilterProperty, List<String>> filterPreferenceProperties =
+            new EnumMap<>(NotificationFilterProperty.class);
 
         filterPreferenceProperties.put(NotificationFilterProperty.APPLICATION,
             obj.getListValue(FIELD_APPLICATIONS));

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/test/java/org/xwiki/notifications/preferences/internal/DefaultNotificationPreferenceManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/test/java/org/xwiki/notifications/preferences/internal/DefaultNotificationPreferenceManagerTest.java
@@ -20,7 +20,7 @@
 package org.xwiki.notifications.preferences.internal;
 
 import java.util.Date;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
@@ -88,9 +88,9 @@ class DefaultNotificationPreferenceManagerTest
     @BeforeEach
     void setUp()
     {
-        Map<NotificationPreferenceProperty, Object> map1 = new HashMap<>();
+        Map<NotificationPreferenceProperty, Object> map1 = new EnumMap<>(NotificationPreferenceProperty.class);
         map1.put(NotificationPreferenceProperty.EVENT_TYPE, "update");
-        Map<NotificationPreferenceProperty, Object> map2 = new HashMap<>();
+        Map<NotificationPreferenceProperty, Object> map2 = new EnumMap<>(NotificationPreferenceProperty.class);
         map1.put(NotificationPreferenceProperty.EVENT_TYPE, "addComment");
         this.mockPreference11 = new NotificationPreferenceImplementation(true, NotificationFormat.ALERT,
                 NotificationPreferenceCategory.DEFAULT, null, "1", map1);

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/test/java/org/xwiki/notifications/preferences/script/NotificationPreferenceScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/test/java/org/xwiki/notifications/preferences/script/NotificationPreferenceScriptServiceTest.java
@@ -19,7 +19,7 @@
  */
 package org.xwiki.notifications.preferences.script;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
@@ -106,7 +106,7 @@ class NotificationPreferenceScriptServiceTest
         private NotificationPreferenceImpl(boolean isNotificationEnabled, NotificationFormat format,
                 String eventType)
         {
-            super(isNotificationEnabled, format, null, null, null, new HashMap<>());
+            super(isNotificationEnabled, format, null, null, null, new EnumMap<>(NotificationPreferenceProperty.class));
             properties.put(NotificationPreferenceProperty.EVENT_TYPE, eventType);
         }
     }
@@ -162,12 +162,12 @@ class NotificationPreferenceScriptServiceTest
         NotificationPreference pref2 = mock(NotificationPreference.class);
 
         when(pref1.getFormat()).thenReturn(NotificationFormat.EMAIL);
-        Map<NotificationPreferenceProperty, Object> properties1 = new HashMap<>();
+        Map<NotificationPreferenceProperty, Object> properties1 = new EnumMap<>(NotificationPreferenceProperty.class);
         properties1.put(NotificationPreferenceProperty.EVENT_TYPE, "update");
         when(pref1.getProperties()).thenReturn(properties1);
 
         when(pref2.getFormat()).thenReturn(NotificationFormat.ALERT);
-        Map<NotificationPreferenceProperty, Object> properties2 = new HashMap<>();
+        Map<NotificationPreferenceProperty, Object> properties2 = new EnumMap<>(NotificationPreferenceProperty.class);
         properties2.put(NotificationPreferenceProperty.EVENT_TYPE, "update");
         when(pref2.getProperties()).thenReturn(properties2);
         when(pref2.isNotificationEnabled()).thenReturn(true);
@@ -215,12 +215,12 @@ class NotificationPreferenceScriptServiceTest
         NotificationPreference pref2 = mock(NotificationPreference.class);
 
         when(pref1.getFormat()).thenReturn(NotificationFormat.EMAIL);
-        Map<NotificationPreferenceProperty, Object> properties1 = new HashMap<>();
+        Map<NotificationPreferenceProperty, Object> properties1 = new EnumMap<>(NotificationPreferenceProperty.class);
         properties1.put(NotificationPreferenceProperty.EVENT_TYPE, "update");
         when(pref1.getProperties()).thenReturn(properties1);
 
         when(pref2.getFormat()).thenReturn(NotificationFormat.ALERT);
-        Map<NotificationPreferenceProperty, Object> properties2 = new HashMap<>();
+        Map<NotificationPreferenceProperty, Object> properties2 = new EnumMap<>(NotificationPreferenceProperty.class);
         properties2.put(NotificationPreferenceProperty.EVENT_TYPE, "update");
         when(pref2.getProperties()).thenReturn(properties2);
         when(pref2.isNotificationEnabled()).thenReturn(true);

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-default/src/main/java/org/xwiki/notifications/preferences/internal/DefaultNotificationPreferenceModelBridge.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-default/src/main/java/org/xwiki/notifications/preferences/internal/DefaultNotificationPreferenceModelBridge.java
@@ -22,7 +22,7 @@ package org.xwiki.notifications.preferences.internal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
@@ -181,7 +181,7 @@ public class DefaultNotificationPreferenceModelBridge implements NotificationPre
 
     private Map<NotificationPreferenceProperty, Object> extractNotificationPreferenceProperties(BaseObject object)
     {
-        Map<NotificationPreferenceProperty, Object> properties = new HashMap<>();
+        Map<NotificationPreferenceProperty, Object> properties = new EnumMap<>(NotificationPreferenceProperty.class);
 
         String eventType = object.getStringValue(EVENT_TYPE_FIELD);
         if (StringUtils.isNotBlank(eventType)) {

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/main/java/org/xwiki/notifications/rest/internal/DefaultNotificationsResource.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/main/java/org/xwiki/notifications/rest/internal/DefaultNotificationsResource.java
@@ -20,7 +20,7 @@
 package org.xwiki.notifications.rest.internal;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
@@ -269,7 +269,7 @@ public class DefaultNotificationsResource extends XWikiResource implements Notif
         int maxCount, String displayOwnEvents, String displayMinorEvents, String displaySystemEvents,
         String displayReadEvents, String tags, String currentWiki, boolean onlyUnread) throws NotificationException
     {
-        Map<ParametersKey, String> parametersMap = new HashMap<>();
+        Map<ParametersKey, String> parametersMap = new EnumMap<>(ParametersKey.class);
         parametersMap.put(ParametersKey.USE_USER_PREFERENCES, useUserPreferences);
         parametersMap.put(ParametersKey.USER_ID, userId);
         parametersMap.put(ParametersKey.UNTIL_DATE, untilDate);

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/test/java/org/xwiki/notifications/rest/internal/DefaultNotificationsResourceTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/test/java/org/xwiki/notifications/rest/internal/DefaultNotificationsResourceTest.java
@@ -20,7 +20,7 @@
 package org.xwiki.notifications.rest.internal;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
@@ -220,7 +220,8 @@ class DefaultNotificationsResourceTest
         String tags = "foo";
         String currentWiki = "xwiki";
 
-        Map<DefaultNotificationParametersFactory.ParametersKey, String> parametersMap = new HashMap<>();
+        Map<DefaultNotificationParametersFactory.ParametersKey, String> parametersMap =
+            new EnumMap<>(DefaultNotificationParametersFactory.ParametersKey.class);
         parametersMap.put(DefaultNotificationParametersFactory.ParametersKey.USE_USER_PREFERENCES, useUserPreferences);
         parametersMap.put(DefaultNotificationParametersFactory.ParametersKey.USER_ID, userId);
         parametersMap.put(DefaultNotificationParametersFactory.ParametersKey.UNTIL_DATE, untilDate);

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/DefaultNotificationParametersFactory.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/DefaultNotificationParametersFactory.java
@@ -22,7 +22,7 @@ package org.xwiki.notifications.sources.internal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -294,7 +294,7 @@ public class DefaultNotificationParametersFactory
     public NotificationParameters createNotificationParametersWithStringMap(Map<String, String> parameters)
         throws NotificationException
     {
-        Map<ParametersKey, String> keyStringMap = new HashMap<>();
+        Map<ParametersKey, String> keyStringMap = new EnumMap<>(ParametersKey.class);
 
         for (Map.Entry<String, String> parameterPair : parameters.entrySet()) {
             String parameterKey = parameterPair.getKey();

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/InternalNotificationPreference.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/InternalNotificationPreference.java
@@ -20,7 +20,7 @@
 package org.xwiki.notifications.sources.internal;
 
 import java.util.Date;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -72,7 +72,7 @@ public class InternalNotificationPreference implements NotificationPreference
     @Override
     public Map<NotificationPreferenceProperty, Object> getProperties()
     {
-        Map<NotificationPreferenceProperty, Object> properties = new HashMap<>();
+        Map<NotificationPreferenceProperty, Object> properties = new EnumMap<>(NotificationPreferenceProperty.class);
         properties.put(NotificationPreferenceProperty.EVENT_TYPE, descriptor.getEventType());
         return properties;
     }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/DefaultNotificationParametersFactoryTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/DefaultNotificationParametersFactoryTest.java
@@ -22,7 +22,7 @@ package org.xwiki.notifications.sources.internal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -243,7 +243,7 @@ class DefaultNotificationParametersFactoryTest
             this.parametersFactory.createNotificationParameters(Collections.emptyMap()));
         verify(this.wikiDescriptorManager).getCurrentWikiId();
 
-        Map<ParametersKey, String> parametersMap = new HashMap<>();
+        Map<ParametersKey, String> parametersMap = new EnumMap<>(ParametersKey.class);
         parametersMap.put(ParametersKey.FORMAT, "EMAIL");
         parametersMap.put(ParametersKey.USER_ID, USER_SERIALIZED_REFERENCE);
         parametersMap.put(ParametersKey.USE_USER_PREFERENCES, "true");

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/filter/LineBreakFilter.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/filter/LineBreakFilter.java
@@ -31,7 +31,6 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.xml.html.filter.AbstractHTMLFilter;
-import org.xwiki.xml.html.filter.ElementSelector;
 
 /**
  * Replaces {@code<br/>} elements placed in between block elements with {@code<div class="wikikmodel-emptyline"/>}.
@@ -59,15 +58,10 @@ public class LineBreakFilter extends AbstractHTMLFilter
     public void filter(Document document, Map<String, String> cleaningParams)
     {
         List<Element> lineBreaksToReplace =
-            filterDescendants(document.getDocumentElement(), new String[] {TAG_BR}, new ElementSelector()
-            {
-                @Override
-                public boolean isSelected(Element element)
-                {
-                    Node prev = findPreviousNode(element);
-                    Node next = findNextNode(element);
-                    return !(null == prev && null == next) && (isBlockElement(prev) || isBlockElement(next));
-                }
+            filterDescendants(document.getDocumentElement(), new String[] {TAG_BR}, element -> {
+                Node prev = findPreviousNode(element);
+                Node next = findNextNode(element);
+                return !(null == prev && null == next) && (isBlockElement(prev) || isBlockElement(next));
             });
         for (Element lineBreak : lineBreaksToReplace) {
             Node parent = lineBreak.getParentNode();

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/filter/ParagraphFilter.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/filter/ParagraphFilter.java
@@ -32,7 +32,6 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.xml.html.filter.AbstractHTMLFilter;
-import org.xwiki.xml.html.filter.ElementSelector;
 
 /**
  * Open Office server creates a new paragraph element for every line break (enter) in the original office document. For
@@ -79,14 +78,8 @@ public class ParagraphFilter extends AbstractHTMLFilter
     private List<Node> findEmptyLineParagraphSequences(Document document)
     {
         List<Element> emptyLineParagraphs =
-            filterDescendants(document.getDocumentElement(), new String[] {TAG_P}, new ElementSelector()
-            {
-                @Override
-                public boolean isSelected(Element element)
-                {
-                    return isEmptyLineParagraph(element);
-                }
-            });
+            filterDescendants(document.getDocumentElement(), new String[] {TAG_P},
+                element -> isEmptyLineParagraph(element));
         List<Node> sequences = new ArrayList<>();
         for (Element emptyLineParagraph : emptyLineParagraphs) {
             Node prev = emptyLineParagraph.getPreviousSibling();

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/filter/RedundancyFilter.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/filter/RedundancyFilter.java
@@ -29,7 +29,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.xml.html.filter.AbstractHTMLFilter;
-import org.xwiki.xml.html.filter.ElementSelector;
 
 /**
  * This filter is used to remove those tags that doesn't play any role with the representation of information. This type
@@ -61,26 +60,14 @@ public class RedundancyFilter extends AbstractHTMLFilter
     public void filter(Document document, Map<String, String> cleaningParams)
     {
         List<Element> elementsWithNoAttributes =
-            filterDescendants(document.getDocumentElement(), FILTERED_IF_NO_ATTRIBUTES_TAGS, new ElementSelector()
-            {
-                @Override
-                public boolean isSelected(Element element)
-                {
-                    return !element.hasAttributes();
-                }
-            });
+            filterDescendants(document.getDocumentElement(), FILTERED_IF_NO_ATTRIBUTES_TAGS,
+                element -> !element.hasAttributes());
         for (Element element : elementsWithNoAttributes) {
             replaceWithChildren(element);
         }
         List<Element> elementsWithNoContent =
-            filterDescendants(document.getDocumentElement(), FILTERED_IF_NO_CONTENT_TAGS, new ElementSelector()
-            {
-                @Override
-                public boolean isSelected(Element element)
-                {
-                    return "".equals(element.getTextContent().trim());
-                }
-            });
+            filterDescendants(document.getDocumentElement(), FILTERED_IF_NO_CONTENT_TAGS,
+                element -> "".equals(element.getTextContent().trim()));
         for (Element element : elementsWithNoContent) {
             String textContent = element.getTextContent();
             if ("".equals(textContent)) {

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/filter/TableFilter.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/filter/TableFilter.java
@@ -29,7 +29,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.xml.html.filter.AbstractHTMLFilter;
-import org.xwiki.xml.html.filter.ElementSelector;
 
 /**
  * This filter is used to rip-off or modify HTML tables so that they can be rendered properly.
@@ -55,14 +54,8 @@ public class TableFilter extends AbstractHTMLFilter
         }
         // Strip off empty table rows. See https://jira.xwiki.org/browse/XWIKI-3136.
         List<Element> emptyRows =
-            filterDescendants(document.getDocumentElement(), new String[] {TAG_TR}, new ElementSelector()
-            {
-                @Override
-                public boolean isSelected(Element element)
-                {
-                    return element.getChildNodes().getLength() == 0;
-                }
-            });
+            filterDescendants(document.getDocumentElement(), new String[] {TAG_TR},
+                element -> element.getChildNodes().getLength() == 0);
         for (Element emptyRow : emptyRows) {
             emptyRow.getParentNode().removeChild(emptyRow);
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/input/XWikiDocumentLocaleEventGenerator.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/input/XWikiDocumentLocaleEventGenerator.java
@@ -22,7 +22,6 @@ package com.xpn.xwiki.internal.filter.input;
 import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -217,22 +216,17 @@ public class XWikiDocumentLocaleEventGenerator
 
         if (properties.isWithWikiAttachments()) {
             List<XWikiAttachment> sortedAttachments = new ArrayList<>(document.getAttachmentList());
-            Collections.sort(sortedAttachments, new Comparator<XWikiAttachment>()
-            {
-                @Override
-                public int compare(XWikiAttachment attachement1, XWikiAttachment attachement2)
-                {
-                    if (attachement1 == null || attachement2 == null) {
-                        int result = 0;
-                        if (attachement1 != null) {
-                            result = -1;
-                        } else if (attachement2 != null) {
-                            result = 1;
-                        }
-                        return result;
+            Collections.sort(sortedAttachments, (attachement1, attachement2) -> {
+                if (attachement1 == null || attachement2 == null) {
+                    int result = 0;
+                    if (attachement1 != null) {
+                        result = -1;
+                    } else if (attachement2 != null) {
+                        result = 1;
                     }
-                    return attachement1.getFilename().compareTo(attachement2.getFilename());
+                    return result;
                 }
+                return attachement1.getFilename().compareTo(attachement2.getFilename());
             });
 
             for (XWikiAttachment attachment : sortedAttachments) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DBListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DBListClass.java
@@ -460,11 +460,13 @@ public class DBListClass extends ListClass
 
                 if (words.get(comma).compareTo("(") == 0) {
                     int i = comma + 1;
+                    StringBuilder secondColBuilder = new StringBuilder(secondCol);
                     while (words.get(i).compareTo(")") != 0) {
-                        secondCol += words.get(i);
+                        secondColBuilder.append(words.get(i));
                         i++;
                     }
-                    secondCol += ")";
+                    secondColBuilder.append(")");
+                    secondCol = secondColBuilder.toString();
                 } else {
                     secondCol = words.get(comma).trim();
                 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListItem.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListItem.java
@@ -31,63 +31,16 @@ import org.apache.commons.collections4.ComparatorUtils;
 public class ListItem
 {
     /** Comparator that orders two strings in their natural order, keeping nulls at the end. */
-    private static final Comparator<String> BASE_COMPARATOR = ComparatorUtils
-        .nullHighComparator(new Comparator<String>()
-        {
-            /**
-             * Case insensitive comparison of two Strings.
-             *
-             * @param o1 the first item to be compared.
-             * @param o2 the second item to be compared.
-             * @return a negative integer, zero, or a positive integer as the first argument is less than, equal to, or
-             *         greater than the second.
-             */
-            @Override
-            public int compare(String o1, String o2)
-            {
-                return o1.compareToIgnoreCase(o2);
-            }
-        });
+    private static final Comparator<String> BASE_COMPARATOR =
+        ComparatorUtils.nullHighComparator((o1, o2) -> o1.compareToIgnoreCase(o2));
 
     /** Comparator that orders list items on their identifiers, keeping null items at the end. */
-    protected static final Comparator<ListItem> ID_COMPARATOR = ComparatorUtils
-        .nullHighComparator(new Comparator<ListItem>()
-        {
-            /**
-             * Sorts the items on their ID: the option with the lower ID (case insensitive String comparison) will be
-             * placed before the other one.
-             *
-             * @param o1 the first item to be compared.
-             * @param o2 the second item to be compared.
-             * @return a negative integer, zero, or a positive integer as the first argument is less than, equal to, or
-             *         greater than the second.
-             */
-            @Override
-            public int compare(ListItem o1, ListItem o2)
-            {
-                return BASE_COMPARATOR.compare(o1.getId(), o2.getId());
-            }
-        });
+    protected static final Comparator<ListItem> ID_COMPARATOR =
+        ComparatorUtils.nullHighComparator((o1, o2) -> BASE_COMPARATOR.compare(o1.getId(), o2.getId()));
 
     /** Comparator that orders list items on their values, keeping null items at the end. */
-    protected static final Comparator<ListItem> VALUE_COMPARATOR = ComparatorUtils
-        .nullHighComparator(new Comparator<ListItem>()
-        {
-            /**
-             * Sorts the items on their value: the option with the lower value (case insensitive String comparison) will
-             * be placed before the other one.
-             *
-             * @param o1 the first item to be compared.
-             * @param o2 the second item to be compared.
-             * @return a negative integer, zero, or a positive integer as the first argument is less than, equal to, or
-             *         greater than the second.
-             */
-            @Override
-            public int compare(ListItem o1, ListItem o2)
-            {
-                return BASE_COMPARATOR.compare(o1.getValue(), o2.getValue());
-            }
-        });
+    protected static final Comparator<ListItem> VALUE_COMPARATOR =
+        ComparatorUtils.nullHighComparator((o1, o2) -> BASE_COMPARATOR.compare(o1.getValue(), o2.getValue()));
 
     /** A unique identifier of this item, the actual value stored in the database when selecting items from a list. */
     private String id = "";

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/script/AbstractScriptRatingsManager.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/script/AbstractScriptRatingsManager.java
@@ -20,7 +20,7 @@
 package org.xwiki.ratings.script;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -114,7 +114,8 @@ public abstract class AbstractScriptRatingsManager implements RatingsScriptServi
     public List<Rating> getRatings(EntityReference reference, int offset, int limit, boolean asc)
     {
         try {
-            Map<RatingsManager.RatingQueryField, Object> queryParameters = new HashMap<>();
+            Map<RatingsManager.RatingQueryField, Object> queryParameters =
+                new EnumMap<>(RatingsManager.RatingQueryField.class);
             queryParameters.put(RatingsManager.RatingQueryField.ENTITY_REFERENCE, reference);
             return this.ratingsManager.getRatings(queryParameters, offset, limit,
                 RatingsManager.RatingQueryField.UPDATED_DATE, asc);
@@ -158,7 +159,8 @@ public abstract class AbstractScriptRatingsManager implements RatingsScriptServi
     public Optional<Rating> getRating(EntityReference reference, UserReference author)
     {
         Optional<Rating> result = Optional.empty();
-        Map<RatingsManager.RatingQueryField, Object> queryParameters = new HashMap<>();
+        Map<RatingsManager.RatingQueryField, Object> queryParameters =
+            new EnumMap<>(RatingsManager.RatingQueryField.class);
         queryParameters.put(RatingsManager.RatingQueryField.ENTITY_REFERENCE, reference);
         queryParameters.put(RatingsManager.RatingQueryField.USER_REFERENCE, author);
         try {
@@ -178,7 +180,8 @@ public abstract class AbstractScriptRatingsManager implements RatingsScriptServi
     public List<Rating> getCurrentUserRatings(int offset, int limit, boolean asc)
     {
         List<Rating> result;
-        Map<RatingsManager.RatingQueryField, Object> queryParameters = new HashMap<>();
+        Map<RatingsManager.RatingQueryField, Object> queryParameters =
+            new EnumMap<>(RatingsManager.RatingQueryField.class);
         queryParameters.put(RatingsManager.RatingQueryField.USER_REFERENCE, this.getCurrentUserReference());
         try {
             result = this.ratingsManager.getRatings(queryParameters, offset, limit,

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/script/RatingsScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/script/RatingsScriptServiceTest.java
@@ -21,7 +21,7 @@ package org.xwiki.ratings.script;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -193,7 +193,8 @@ class RatingsScriptServiceTest
         EntityReference reference = mock(EntityReference.class);
         int offset = 12;
         int limit = 17;
-        Map<RatingsManager.RatingQueryField, Object> queryParameters = new HashMap<>();
+        Map<RatingsManager.RatingQueryField, Object> queryParameters =
+            new EnumMap<>(RatingsManager.RatingQueryField.class);
         queryParameters.put(RatingsManager.RatingQueryField.ENTITY_REFERENCE, reference);
 
         List<Rating> expectedResult = Arrays.asList(mock(Rating.class), mock(Rating.class));
@@ -208,7 +209,8 @@ class RatingsScriptServiceTest
         EntityReference reference = mock(EntityReference.class);
         int offset = 23;
         int limit = 3;
-        Map<RatingsManager.RatingQueryField, Object> queryParameters = new HashMap<>();
+        Map<RatingsManager.RatingQueryField, Object> queryParameters =
+            new EnumMap<>(RatingsManager.RatingQueryField.class);
         queryParameters.put(RatingsManager.RatingQueryField.ENTITY_REFERENCE, reference);
 
         List<Rating> expectedResult = Arrays.asList(mock(Rating.class), mock(Rating.class));
@@ -232,7 +234,8 @@ class RatingsScriptServiceTest
     {
         EntityReference reference = mock(EntityReference.class);
         UserReference userReference = mock(UserReference.class);
-        Map<RatingsManager.RatingQueryField, Object> queryParameters = new HashMap<>();
+        Map<RatingsManager.RatingQueryField, Object> queryParameters =
+            new EnumMap<>(RatingsManager.RatingQueryField.class);
         queryParameters.put(RatingsManager.RatingQueryField.ENTITY_REFERENCE, reference);
         queryParameters.put(RatingsManager.RatingQueryField.USER_REFERENCE, userReference);
         Rating expectedRating = mock(Rating.class);
@@ -248,7 +251,8 @@ class RatingsScriptServiceTest
     {
         EntityReference reference = mock(EntityReference.class);
         UserReference userReference = mock(UserReference.class);
-        Map<RatingsManager.RatingQueryField, Object> queryParameters = new HashMap<>();
+        Map<RatingsManager.RatingQueryField, Object> queryParameters =
+            new EnumMap<>(RatingsManager.RatingQueryField.class);
         queryParameters.put(RatingsManager.RatingQueryField.ENTITY_REFERENCE, reference);
         queryParameters.put(RatingsManager.RatingQueryField.USER_REFERENCE, userReference);
 
@@ -267,7 +271,8 @@ class RatingsScriptServiceTest
 
         List<Rating> expectedResult = Arrays.asList(mock(Rating.class), mock(Rating.class));
 
-        Map<RatingsManager.RatingQueryField, Object> queryParameters = new HashMap<>();
+        Map<RatingsManager.RatingQueryField, Object> queryParameters =
+            new EnumMap<>(RatingsManager.RatingQueryField.class);
         queryParameters.put(RatingsManager.RatingQueryField.USER_REFERENCE, this.currentUser);
         when(this.defaultManager.getRatings(queryParameters, offset, limit,
             RatingsManager.RatingQueryField.UPDATED_DATE, asc)).thenReturn(expectedResult);

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/CreateJob.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/CreateJob.java
@@ -118,19 +118,14 @@ public class CreateJob extends AbstractEntityJob<CreateRequest, EntityJobStatus<
 
         if (templateSpaceReference != null) {
             // Space from template space.
-            visitDocuments(templateSpaceReference, new Visitor<DocumentReference>()
-            {
-                @Override
-                public void visit(final DocumentReference templateDocumentReference)
-                {
-                    DocumentReference newDocumentReference =
-                        templateDocumentReference.replaceParent(templateSpaceReference, newSpaceReference);
-                    try {
-                        maybeCreate(newDocumentReference, templateDocumentReference);
-                    } catch (Exception e) {
-                        logger.error("Failed to create document with reference [{}] and template [{}]",
-                            newDocumentReference, templateDocumentReference, e);
-                    }
+            visitDocuments(templateSpaceReference, templateDocumentReference -> {
+                DocumentReference newDocumentReference =
+                    templateDocumentReference.replaceParent(templateSpaceReference, newSpaceReference);
+                try {
+                    maybeCreate(newDocumentReference, templateDocumentReference);
+                } catch (Exception e) {
+                    logger.error("Failed to create document with reference [{}] and template [{}]",
+                        newDocumentReference, templateDocumentReference, e);
                 }
             });
         } else {

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/DeleteJob.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/DeleteJob.java
@@ -115,17 +115,12 @@ public class DeleteJob extends AbstractEntityJobWithChecks<DeleteRequest, Entity
 
     private void process(SpaceReference spaceReference)
     {
-        visitDocuments(spaceReference, new Visitor<DocumentReference>()
-        {
-            @Override
-            public void visit(DocumentReference documentReference)
-            {
-                try {
-                    maybeDelete(documentReference);
-                } catch (Exception e) {
-                    logger.error("Failed to delete document [{}] from space [{}]", documentReference, spaceReference,
-                        e);
-                }
+        visitDocuments(spaceReference, documentReference -> {
+            try {
+                maybeDelete(documentReference);
+            } catch (Exception e) {
+                logger.error("Failed to delete document [{}] from space [{}]", documentReference, spaceReference,
+                    e);
             }
         });
     }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/splitter/DefaultDocumentSplitter.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/splitter/DefaultDocumentSplitter.java
@@ -40,7 +40,6 @@ import org.xwiki.refactoring.splitter.criterion.SplittingCriterion;
 import org.xwiki.refactoring.splitter.criterion.naming.NamingCriterion;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.Block.Axes;
-import org.xwiki.rendering.block.BlockFilter;
 import org.xwiki.rendering.block.HeaderBlock;
 import org.xwiki.rendering.block.IdBlock;
 import org.xwiki.rendering.block.LinkBlock;
@@ -146,18 +145,13 @@ public class DefaultDocumentSplitter implements DocumentSplitter
         if (firstBlock instanceof HeaderBlock) {
             DocumentResourceReference reference = new DocumentResourceReference(target);
             // Clone the header block and remove any unwanted stuff
-            Block clonedHeaderBlock = firstBlock.clone(new BlockFilter()
-            {
-                @Override
-                public List<Block> filter(Block block)
-                {
-                    List<Block> blocks = new ArrayList<>();
-                    if (block instanceof WordBlock || block instanceof SpaceBlock
-                        || block instanceof SpecialSymbolBlock) {
-                        blocks.add(block);
-                    }
-                    return blocks;
+            Block clonedHeaderBlock = firstBlock.clone(child -> {
+                List<Block> blocks = new ArrayList<>();
+                if (child instanceof WordBlock || child instanceof SpaceBlock
+                    || child instanceof SpecialSymbolBlock) {
+                    blocks.add(child);
                 }
+                return blocks;
             });
             return new LinkBlock(clonedHeaderBlock.getChildren(), reference, false);
         } else if (firstBlock instanceof SectionBlock) {

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/splitter/criterion/naming/HeadingNameNamingCriterion.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/splitter/criterion/naming/HeadingNameNamingCriterion.java
@@ -35,7 +35,6 @@ import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.SpaceReference;
 import org.xwiki.refactoring.internal.RefactoringUtils;
 import org.xwiki.rendering.block.Block;
-import org.xwiki.rendering.block.BlockFilter;
 import org.xwiki.rendering.block.HeaderBlock;
 import org.xwiki.rendering.block.SpaceBlock;
 import org.xwiki.rendering.block.SpecialSymbolBlock;
@@ -136,17 +135,13 @@ public class HeadingNameNamingCriterion extends AbstractNamingCriterion
             Block firstChild = xdom.getChildren().get(0);
             if (firstChild instanceof HeaderBlock) {
                 // Clone the header block and remove any unwanted stuff.
-                Block clonedHeaderBlock = firstChild.clone(new BlockFilter()
-                {
-                    public List<Block> filter(Block block)
-                    {
-                        List<Block> blocks = new ArrayList<>();
-                        if (block instanceof WordBlock || block instanceof SpaceBlock
-                            || block instanceof SpecialSymbolBlock) {
-                            blocks.add(block);
-                        }
-                        return blocks;
+                Block clonedHeaderBlock = firstChild.clone(block -> {
+                    List<Block> blocks = new ArrayList<>();
+                    if (block instanceof WordBlock || block instanceof SpaceBlock
+                        || block instanceof SpecialSymbolBlock) {
+                        blocks.add(block);
                     }
+                    return blocks;
                 });
                 XDOM heading = new XDOM(clonedHeaderBlock.getChildren());
 

--- a/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/SchedulerPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/SchedulerPlugin.java
@@ -150,14 +150,8 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
         this.schedulersClassLoaderManager.setSchedulerPlugin(this);
 
         if (this.enabled) {
-            Thread thread = new Thread(new ExecutionContextRunnable(new Runnable()
-            {
-                @Override
-                public void run()
-                {
-                    initAsync();
-                }
-            }, Utils.getComponentManager()));
+            Thread thread = new Thread(new ExecutionContextRunnable(() -> initAsync(),
+                Utils.getComponentManager()));
             thread.setName("XWiki Scheduler initialization");
             thread.setDaemon(true);
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/reference/DefaultSolrReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/reference/DefaultSolrReferenceResolver.java
@@ -169,14 +169,7 @@ public class DefaultSolrReferenceResolver implements SolrReferenceResolver
                 throw new SolrIndexerException("Failed to get the list of available wikis.", e);
             }
 
-            return new Iterable<EntityReference>()
-            {
-                @Override
-                public Iterator<EntityReference> iterator()
-                {
-                    return new FarmIterator(wikis);
-                }
-            };
+            return () -> new FarmIterator(wikis);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/sx/CssExtension.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/sx/CssExtension.java
@@ -54,21 +54,16 @@ public class CssExtension implements Extension
     @Override
     public SxCompressor getCompressor()
     {
-        return new SxCompressor()
-        {
-            @Override
-            public String compress(String source)
-            {
-                try {
-                    CssCompressor compressor = new CssCompressor(new StringReader(source));
-                    StringWriter out = new StringWriter();
-                    compressor.compress(out, -1);
-                    return out.toString();
-                } catch (IOException ex) {
-                    LOGGER.warn("Exception compressing SSX code", ex);
-                }
-                return source;
+        return source -> {
+            try {
+                CssCompressor compressor = new CssCompressor(new StringReader(source));
+                StringWriter out = new StringWriter();
+                compressor.compress(out, -1);
+                return out.toString();
+            } catch (IOException ex) {
+                LOGGER.warn("Exception compressing SSX code", ex);
             }
+            return source;
         };
     }
 

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-api/src/main/java/org/xwiki/store/merge/MergeDocumentResult.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-api/src/main/java/org/xwiki/store/merge/MergeDocumentResult.java
@@ -19,7 +19,7 @@
  */
 package org.xwiki.store.merge;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
@@ -141,7 +141,7 @@ public class MergeDocumentResult extends MergeManagerResult<DocumentModelBridge,
         this.currentDocument = currentDocument;
         this.previousDocument = previousDocument;
         this.nextDocument = nextDocument;
-        this.mergeResults = new HashMap<>();
+        this.mergeResults = new EnumMap<>(DocumentPart.class);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-creationjob/src/main/java/org/xwiki/platform/wiki/creationjob/internal/WikiCreationJob.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-creationjob/src/main/java/org/xwiki/platform/wiki/creationjob/internal/WikiCreationJob.java
@@ -20,7 +20,6 @@
 package org.xwiki.platform.wiki.creationjob.internal;
 
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -80,14 +79,7 @@ public class WikiCreationJob extends AbstractJob<WikiCreationRequest, DefaultJob
             List<WikiCreationStep> wikiCreationStepList = componentManager.getInstanceList(WikiCreationStep.class);
             // Some extra steps needs to be executed AFTER some others, so we have introduce a getOrder() method in the
             // interface. We use this method to sort the list of extra steps by this order.
-            Collections.sort(wikiCreationStepList, new Comparator<WikiCreationStep>()
-            {
-                @Override
-                public int compare(WikiCreationStep o1, WikiCreationStep o2)
-                {
-                    return o1.getOrder() - o2.getOrder();
-                }
-            });
+            Collections.sort(wikiCreationStepList, (o1, o2) -> o1.getOrder() - o2.getOrder());
             // Now we can execute these extra steps
             this.progressManager.pushLevelProgress(wikiCreationStepList.size(), this);
 

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-workspaces-migrator/src/main/java/org/xwiki/wiki/workspacesmigrator/internal/WorkspacesMigration.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-workspaces-migrator/src/main/java/org/xwiki/wiki/workspacesmigrator/internal/WorkspacesMigration.java
@@ -200,17 +200,17 @@ public class WorkspacesMigration extends AbstractHibernateDataMigration
 
         // If the list is empty, the job is done
         if (!documentsToRestore.isEmpty()) {
-            String documentsToRestoreAsString = new String();
+            StringBuilder documentsToRestoreAsString = new StringBuilder();
             int counter = 0;
             for (DocumentReference d : documentsToRestore) {
                 if (counter++ > 0) {
-                    documentsToRestoreAsString += ", ";
+                    documentsToRestoreAsString.append(", ");
                 }
-                documentsToRestoreAsString += d;
+                documentsToRestoreAsString.append(d);
             }
             logger.warn("Failed to restore some documents: [{}]. You should import manually "
                     + "(1) xwiki-platform-administration-ui.xar and then (2) xwiki-platform-wiki-ui-wiki.xar into your"
-                    + " wiki, to restore these documents.", documentsToRestoreAsString);
+                    + " wiki, to restore these documents.", documentsToRestoreAsString.toString());
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes 63 mechanical, behaviour-neutral SonarCloud issues across 26 modules, in three families:

* [**java:S1640**](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&resolved=false&rules=java%3AS1640) — "Convert this Map to an EnumMap" (37 sites): replaced `HashMap` with `EnumMap` where the map key type is an enum.
* [**java:S1604**](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&resolved=false&rules=java%3AS1604) — "Make this anonymous inner class a lambda" (20 sites): converted single-abstract-method anonymous classes (`Comparator`, `Runnable`, `Visitor`, `BlockFilter`, `ElementSelector`, `Iterable`, …) to lambdas.
* [**java:S1643**](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&resolved=false&rules=java%3AS1643) — "Use a StringBuilder instead" (6 sites): replaced in-loop `String += …` accumulation with `StringBuilder`.

## Notes

* All changes are behaviour-preserving. The `EnumMap` conversions were applied only where keys are never `null` (`EnumMap` rejects `null` keys) and where iteration order is not relied upon; a few candidate sites that did not meet those criteria were intentionally left out. Likewise, `StringBuilder` conversions were applied only to genuine tail-append accumulation, not to prepend/length-condition patterns.

## Test plan

* Built all affected modules with `mvn clean install -Plegacy,quality` (Checkstyle, Revapi, JaCoCo, and the modules' unit tests) — passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeVYTmuBasbvm36m2P2bnF)_