### PR TITLE
[Misc] Use isEmpty() instead of length() comparisons flagged by SonarCloud

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/internal/content/SpaceNormalizerContentAlterer.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/internal/content/SpaceNormalizerContentAlterer.java
@@ -91,7 +91,7 @@ public class SpaceNormalizerContentAlterer extends AbstractContentAlterer
             }
         }
         // if the last character is a space, remove it and add it to the removed chars
-        if (buffer.length() > 0 && buffer.charAt(buffer.length() - 1) == ' ') {
+        if (!buffer.isEmpty() && buffer.charAt(buffer.length() - 1) == ' ') {
             buffer.deleteCharAt(buffer.length() - 1);
             removedChars++;
             // remove the mapping from the altered to initial mapping since it doesn't exist anymore. buffer.length is
@@ -99,7 +99,7 @@ public class SpaceNormalizerContentAlterer extends AbstractContentAlterer
             alteredToInitial.remove(buffer.length());
         }
         // finally update the indexes for the last stream of removed chars
-        if (buffer.length() > 0) {
+        if (!buffer.isEmpty()) {
             // add the offsets for the remaining removed chars
             for (int t = 0; t < removedChars; ++t) {
                 initialToAltered.put(sequence.length() - 1 - t, buffer.length() - 1 - 1);

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/internal/renderer/AnnotationMarkersXHTMLPrinter.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/internal/renderer/AnnotationMarkersXHTMLPrinter.java
@@ -191,7 +191,7 @@ public class AnnotationMarkersXHTMLPrinter extends XHTMLWikiPrinter
             // create the current chunk
             String currentChunk = text.substring(previous, index);
             // print the current chunk
-            if (currentChunk.length() > 0) {
+            if (!currentChunk.isEmpty()) {
                 printXML(currentChunk);
             }
             // handle all annotations at this position
@@ -213,7 +213,7 @@ public class AnnotationMarkersXHTMLPrinter extends XHTMLWikiPrinter
         }
         // print the last chunk of text
         String chunk = text.substring(previous);
-        if (chunk.length() > 0) {
+        if (!chunk.isEmpty()) {
             printXML(chunk);
         }
     }

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/test/java/org/xwiki/annotation/MockDocument.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/test/java/org/xwiki/annotation/MockDocument.java
@@ -111,6 +111,6 @@ public class MockDocument
     public String getSyntax()
     {
         String sourceSyntax = (String) properties.get("sourceSyntax");
-        return sourceSyntax == null || sourceSyntax.length() == 0 ? "xwiki/2.0" : sourceSyntax;
+        return sourceSyntax == null || sourceSyntax.isEmpty() ? "xwiki/2.0" : sourceSyntax;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/test/java/org/xwiki/annotation/TestDocumentFactory.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/test/java/org/xwiki/annotation/TestDocumentFactory.java
@@ -99,7 +99,7 @@ public class TestDocumentFactory
                 }
                 currentKey = line.substring(1);
             } else {
-                if (currentValue.length() > 0) {
+                if (!currentValue.isEmpty()) {
                     currentValue.append("\n");
                 }
                 currentValue.append(line);

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/internal/AnnotationEventGeneratorEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/internal/AnnotationEventGeneratorEventListener.java
@@ -166,7 +166,7 @@ public class AnnotationEventGeneratorEventListener implements EventListener
             if (defaultCommentsClassReference.equals(object.getXClassReference())) {
                 // A comment is considered an annotation when it has a text selection.
                 String selection = object.getStringValue(Annotation.SELECTION_FIELD);
-                if (selection == null || selection.trim().length() == 0) {
+                if (selection == null || selection.trim().isEmpty()) {
                     // This is a simple comment. Skip it.
                     return;
                 }

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/io/internal/DefaultIOService.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/io/internal/DefaultIOService.java
@@ -409,7 +409,7 @@ public class DefaultIOService implements IOService
         Annotation annotation = new Annotation(String.valueOf(object.getNumber()));
         annotation.setState(AnnotationState.valueOf(object.getStringValue(Annotation.STATE_FIELD)));
         String originalSelection = object.getStringValue(Annotation.ORIGINAL_SELECTION_FIELD);
-        if (originalSelection != null && originalSelection.length() > 0) {
+        if (originalSelection != null && !originalSelection.isEmpty()) {
             annotation.setOriginalSelection(originalSelection);
         }
 

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-maintainer/src/main/java/org/xwiki/annotation/maintainer/AbstractAnnotationMaintainer.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-maintainer/src/main/java/org/xwiki/annotation/maintainer/AbstractAnnotationMaintainer.java
@@ -208,7 +208,7 @@ public abstract class AbstractAnnotationMaintainer implements AnnotationMaintain
         // map spaceless annotation (in context) on the spaceless version of the content
         int cStart = spacelessPreviousContent.getContent().toString().indexOf(spacelessContext);
 
-        if (spacelessContext.length() == 0 || cStart < 0) {
+        if (spacelessContext.isEmpty() || cStart < 0) {
             // annotation context does not exist or could not be found in the previous rendered content, it must be
             // somewhere in the generated content or something like that, skip it
             return updated;

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/AbstractStringEntityReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/AbstractStringEntityReferenceResolver.java
@@ -298,7 +298,7 @@ public abstract class AbstractStringEntityReferenceResolver extends AbstractEnti
         Object... parameters)
     {
         EntityReference newReference;
-        if (representation.length() > 0) {
+        if (!representation.isEmpty()) {
             String name = representation.toString();
             if (unescape) {
                 name = unescape(name);

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/DefaultStringEntityReferenceSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/DefaultStringEntityReferenceSerializer.java
@@ -73,7 +73,7 @@ public class DefaultStringEntityReferenceSerializer extends AbstractStringEntity
         // Since the representation is being built from the root reference (i.e. from left to right), we need to add a
         // separator if some content has already been added to the representation string (i.e. if a higher level entity
         // type has already been processed).
-        if (parentReference != null && representation.length() > 0) {
+        if (parentReference != null && !representation.isEmpty()) {
             // Get the separator to use between the previous type and the current type
             Character separator =
                 getSymbolScheme().getSeparatorSymbols().get(currentType).get(parentReference.getType());

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/EntityReferenceTreeNode.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/EntityReferenceTreeNode.java
@@ -270,7 +270,7 @@ public class EntityReferenceTreeNode
         }
 
         if (!getChildren().isEmpty()) {
-            if (builder.length() > 0) {
+            if (!builder.isEmpty()) {
                 builder.append(" = ");
             }
             builder.append(getChildren());

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-xwql/src/main/java/org/xwiki/query/xwql/internal/hql/TreePrinter.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-xwql/src/main/java/org/xwiki/query/xwql/internal/hql/TreePrinter.java
@@ -78,7 +78,7 @@ public class TreePrinter extends DepthFirstAdapter
         if (node.getWhereClause() == null) {
             // needed for #outAWhereClause
             node.setWhereClause(new AWhereClause());
-        } else if (printer.where.length() > 0) {
+        } else if (!printer.where.isEmpty()) {
             AWhereClause where = (AWhereClause) node.getWhereClause();
             // where := ( where )
             where.setConditionalExpression(
@@ -112,7 +112,7 @@ public class TreePrinter extends DepthFirstAdapter
     public void outAFromClause(AFromClause node)
     {
         String from = getPrinter().from.toString();
-        if (from.length() > 0) {
+        if (!from.isEmpty()) {
             builder.append(' ').append(from);
         }
     }
@@ -120,7 +120,7 @@ public class TreePrinter extends DepthFirstAdapter
     @Override
     public void outAWhereClause(AWhereClause node)
     {
-        if (getPrinter().where.length() > 0) {
+        if (!getPrinter().where.isEmpty()) {
             if (node.getWhere() == null) {
                 builder.append(" WHERE 1=1 ");
             }

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-xwql/src/main/java/org/xwiki/query/xwql/internal/hql/XWQLtoHQLTranslator.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-xwql/src/main/java/org/xwiki/query/xwql/internal/hql/XWQLtoHQLTranslator.java
@@ -46,7 +46,7 @@ public class XWQLtoHQLTranslator implements QueryTranslator
         input = input.trim();
         String lcInput = input.toLowerCase();
         String addition = "select doc.fullName from Document as doc ";
-        if (lcInput.startsWith("where") || lcInput.startsWith("order") || lcInput.length() == 0) {
+        if (lcInput.startsWith("where") || lcInput.startsWith("order") || lcInput.isEmpty()) {
             input = addition + input;
         } else if (lcInput.startsWith("from")) {
             input = addition + "," + input.substring(4);

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-async/xwiki-platform-rendering-async-api/src/main/java/org/xwiki/rendering/async/internal/AsyncRendererExecutorResponse.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-async/xwiki-platform-rendering-async-api/src/main/java/org/xwiki/rendering/async/internal/AsyncRendererExecutorResponse.java
@@ -90,7 +90,7 @@ public class AsyncRendererExecutorResponse
         StringBuilder builder = new StringBuilder();
 
         for (String element : id) {
-            if (builder.length() > 0) {
+            if (!builder.isEmpty()) {
                 builder.append('/');
             }
 

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-async/xwiki-platform-rendering-async-default/src/main/java/org/xwiki/rendering/async/internal/service/AsyncRendererResourceReferenceHandler.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-async/xwiki-platform-rendering-async-default/src/main/java/org/xwiki/rendering/async/internal/service/AsyncRendererResourceReferenceHandler.java
@@ -195,10 +195,10 @@ public class AsyncRendererResourceReferenceHandler extends AbstractResourceRefer
                     this.logger.error("Failed to get HTML head for handler type [{}]", entry.getKey(), e);
                 }
             }
-            if (head.length() > 0) {
+            if (!head.isEmpty()) {
                 servletResponse.getHttpServletResponse().addHeader("X-XWIKI-HTML-HEAD", head.toString());
             }
-            if (scripts.length() > 0) {
+            if (!scripts.isEmpty()) {
                 servletResponse.getHttpServletResponse().addHeader("X-XWIKI-HTML-SCRIPTS",
                     scripts.toString());
             }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/java/org/xwiki/rendering/internal/parser/pygments/BlocksGeneratorPygmentsListener.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/java/org/xwiki/rendering/internal/parser/pygments/BlocksGeneratorPygmentsListener.java
@@ -85,7 +85,7 @@ public class BlocksGeneratorPygmentsListener implements PygmentsListener
             String styleParameter = formatStyle(style);
 
             FormatBlock formatBlock;
-            if (styleParameter.length() > 0) {
+            if (!styleParameter.isEmpty()) {
                 formatBlock = new FormatBlock(blockList, Format.NONE);
                 formatBlock.setParameter("style", styleParameter);
                 this.blocks.add(formatBlock);

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/java/org/xwiki/rendering/internal/parser/pygments/PygmentsParser.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/java/org/xwiki/rendering/internal/parser/pygments/PygmentsParser.java
@@ -165,7 +165,7 @@ public class PygmentsParser extends AbstractHighlightParser implements Initializ
             throw new ParseException("Failed to read source", e);
         }
 
-        if (code.length() == 0) {
+        if (code.isEmpty()) {
             return Collections.emptyList();
         }
 

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-gallery/src/main/java/org/xwiki/rendering/internal/macro/gallery/GalleryMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-gallery/src/main/java/org/xwiki/rendering/internal/macro/gallery/GalleryMacro.java
@@ -120,7 +120,7 @@ public class GalleryMacro extends AbstractMacro<GalleryMacroParameters>
             groupParameters.put("class", ("gallery " + StringUtils.defaultString(parameters.getClassNames())).trim());
             // Disable lightbox for the gallery macro since the two features are very similar and it produces confusion.
             groupParameters.put("data-xwiki-lightbox", "false");
-            if (inlineStyle.length() > 0) {
+            if (!inlineStyle.isEmpty()) {
                 groupParameters.put("style", inlineStyle.toString());
             }
 

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-velocity/src/main/java/org/xwiki/rendering/internal/macro/velocity/filter/HTMLVelocityMacroFilter.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-velocity/src/main/java/org/xwiki/rendering/internal/macro/velocity/filter/HTMLVelocityMacroFilter.java
@@ -162,7 +162,7 @@ public class HTMLVelocityMacroFilter implements VelocityMacroFilter, Initializab
 
                     continue;
                 } else if (Character.isWhitespace(array[i])) {
-                    if (!filterContext.removeWhiteSpaces && contentBuffer.length() > 0) {
+                    if (!filterContext.removeWhiteSpaces && !contentBuffer.isEmpty()) {
                         filterContext.foundWhiteSpace = true;
                     }
 
@@ -204,7 +204,7 @@ public class HTMLVelocityMacroFilter implements VelocityMacroFilter, Initializab
 
         if (context.getType() != VelocityType.COMMENT) {
             if (context.getType() == VelocityType.DIRECTIVE) {
-                if (filterContext.wsGroup.length() == 0) {
+                if (filterContext.wsGroup.isEmpty()) {
                     flushWhiteSpaces(filterContext.wsGroup, filterContext, false);
                 }
 
@@ -264,7 +264,7 @@ public class HTMLVelocityMacroFilter implements VelocityMacroFilter, Initializab
      */
     private void flushWhiteSpaces(StringBuffer contentBuffer, FilterContext filterContext, boolean forceNoSpace)
     {
-        if (filterContext.wsGroup.length() > 0) {
+        if (!filterContext.wsGroup.isEmpty()) {
             boolean space = filterContext.wsGroup.charAt(0) == ' ';
 
             if (forceNoSpace && space) {

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacro.java
@@ -231,7 +231,7 @@ public class DefaultWikiMacro extends AbstractAsyncContentBaseObjectWikiComponen
 
         // Verify the a macro content is not empty if it was declared mandatory.
         if (getDescriptor().getContentDescriptor() != null && getDescriptor().getContentDescriptor().isMandatory()
-            && (macroContent == null || macroContent.length() == 0)) {
+            && (macroContent == null || macroContent.isEmpty())) {
             throw new MacroExecutionException("Missing macro content: this macro requires content (a body)");
         }
     }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-jersey/src/main/java/org/xwiki/rest/jersey/internal/ConsumedBodyRestoringRequestWrapper.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-jersey/src/main/java/org/xwiki/rest/jersey/internal/ConsumedBodyRestoringRequestWrapper.java
@@ -307,7 +307,7 @@ class ConsumedBodyRestoringRequestWrapper extends HttpServletRequestWrapper
             appendBodyParameter(builder, entry.getKey(), entry.getValue(), queryParameters, charset);
         }
 
-        if (builder.length() == 0) {
+        if (builder.isEmpty()) {
             LOGGER.debug("The url-encoded request body was consumed and no body parameter is available to restore it.");
 
             return false;
@@ -335,7 +335,7 @@ class ConsumedBodyRestoringRequestWrapper extends HttpServletRequestWrapper
         }
 
         for (String value : bodyValues) {
-            if (builder.length() > 0) {
+            if (!builder.isEmpty()) {
                 builder.append('&');
             }
             builder.append(URLEncoder.encode(name, charset)).append('=').append(URLEncoder.encode(value, charset));

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/Utils.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/Utils.java
@@ -495,7 +495,7 @@ public class Utils
     {
         StringBuilder jobIdSegment = new StringBuilder();
         for (Object idElement : listSegment) {
-            if (jobIdSegment.length() > 0) {
+            if (!jobIdSegment.isEmpty()) {
                 jobIdSegment.append('/');
             }
             jobIdSegment.append(URIUtils.encodePathSegment(idElement.toString()));
@@ -519,7 +519,7 @@ public class Utils
     {
         StringBuilder spaceSegment = new StringBuilder();
         for (Object space : spaces) {
-            if (spaceSegment.length() > 0) {
+            if (!spaceSegment.isEmpty()) {
                 spaceSegment.append("/spaces/");
             }
             spaceSegment.append(URIUtils.encodePathSegment(space.toString()));

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/url/resources/AbstractJobRestURLGenerator.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/url/resources/AbstractJobRestURLGenerator.java
@@ -43,7 +43,7 @@ public abstract class AbstractJobRestURLGenerator<T> extends AbstractParametrize
         StringBuilder builder = new StringBuilder();
 
         for (String idElement : id) {
-            if (builder.length() > 0) {
+            if (!builder.isEmpty()) {
                 builder.append('/');
             }
             try {

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/main/java/org/xwiki/url/internal/AbstractParentResourceReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/main/java/org/xwiki/url/internal/AbstractParentResourceReferenceResolver.java
@@ -51,7 +51,7 @@ public abstract class AbstractParentResourceReferenceResolver extends AbstractRe
             StringBuilder pathBuilder = new StringBuilder();
             try {
                 for (String pathSegment : extendedURL.getSegments()) {
-                    if (pathBuilder.length() > 0) {
+                    if (!pathBuilder.isEmpty()) {
                         pathBuilder.append('/');
                     }
                     pathBuilder.append(URLEncoder.encode(pathSegment, "UTF8"));

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/group/MemberGroupsCache.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/group/MemberGroupsCache.java
@@ -50,7 +50,7 @@ public class MemberGroupsCache extends AbstractGroupCache
 
         if (wikis != null) {
             for (String wiki : wikis) {
-                if (builder.length() > 0) {
+                if (!builder.isEmpty()) {
                     builder.append('_');
                 }
                 builder.append(wiki);

--- a/xwiki-platform-core/xwiki-platform-xar/xwiki-platform-xar-model/src/main/java/org/xwiki/xar/internal/XarUtils.java
+++ b/xwiki-platform-core/xwiki-platform-xar/xwiki-platform-xar-model/src/main/java/org/xwiki/xar/internal/XarUtils.java
@@ -152,7 +152,7 @@ public final class XarUtils
                     } else if (XarDocumentModel.ELEMENT_LOCALE.equals(elementName)) {
                         if (locale == null) {
                             String value = xmlReader.getElementText();
-                            if (value.length() == 0) {
+                            if (value.isEmpty()) {
                                 locale = Locale.ROOT;
                             } else {
                                 locale = LocaleUtils.toLocale(value);

--- a/xwiki-platform-core/xwiki-platform-zipexplorer/src/main/java/com/xpn/xwiki/plugin/zipexplorer/ZipExplorerPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-zipexplorer/src/main/java/com/xpn/xwiki/plugin/zipexplorer/ZipExplorerPlugin.java
@@ -330,7 +330,7 @@ public class ZipExplorerPlugin extends XWikiDefaultPlugin
 
             // TODO: Ideally we should also check to see if the URL points to a file and not to
             // a directory.
-            if (filenameInZip.length() > 0) {
+            if (!filenameInZip.isEmpty()) {
                 isValidZipURL = true;
             }
         } catch (Exception e) {


### PR DESCRIPTION
## Summary

Fixes 35 SonarCloud [`java:S7158`](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS7158&rule_key=java%3AS7158) issues ("Use `isEmpty()` to check whether a `StringBuilder` is empty or not") across 26 files in 17 modules of `xwiki-platform-core`.

Each `length() == 0` comparison becomes `isEmpty()` and each `length() > 0` comparison becomes `!isEmpty()`. This is a purely mechanical, behaviour-neutral change (`isEmpty()` is exactly equivalent to `length() == 0` for `String`, `StringBuilder` and `StringBuffer`).

[View the S7158 issues on SonarCloud](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issueStatuses=OPEN&rules=java%3AS7158)

## Test plan

- `mvn clean install -Plegacy,quality` on all 17 affected modules — BUILD SUCCESS, all unit tests pass, JaCoCo / Revapi / Checkstyle gates green.

---
_Generated by [Claude Code](https://claude.ai/code/session_015kGGKSh4c2obcm1c7oQWtN)_