### PR TITLE
[Misc] Fix a NullPointerException when an OSV response omits an optional list field

### DIFF
--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/pom.xml
@@ -38,7 +38,7 @@
     <xwiki.extension.name>Solr Indexer for the Extensions Security Vulnerabilities application</xwiki.extension.name>
     <!-- Category for the Extension Manager -->
     <xwiki.extension.category>api</xwiki.extension.category>
-    <xwiki.jacoco.instructionRatio>0.41</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.49</xwiki.jacoco.instructionRatio>
 
   </properties>
   <dependencies>

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/osv/OsvResponseAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/osv/OsvResponseAnalyzer.java
@@ -40,7 +40,6 @@ import org.xwiki.extension.index.security.ExtensionSecurityAnalysisResult;
 import org.xwiki.extension.index.security.SecurityVulnerabilityDescriptor;
 import org.xwiki.extension.security.internal.analyzer.osv.model.response.AffectObject;
 import org.xwiki.extension.security.internal.analyzer.osv.model.response.OsvResponse;
-import org.xwiki.extension.security.internal.analyzer.osv.model.response.RangeObject;
 import org.xwiki.extension.security.internal.analyzer.osv.model.response.VulnObject;
 import org.xwiki.extension.version.Version;
 import org.xwiki.extension.version.internal.DefaultVersion;
@@ -152,16 +151,11 @@ public class OsvResponseAnalyzer
 
     private boolean checkRanges(String version, AffectObject affected)
     {
-        boolean matchesOneRange = false;
-        if (!affected.getRanges().isEmpty()) {
-            List<RangeObject> ranges = affected.getRanges();
-            matchesOneRange = ranges.stream().anyMatch(range -> {
-                String start = range.getStart();
-                String end = range.getEnd();
-                return isInRange(start, end, version);
-            });
-        }
-        return matchesOneRange;
+        return affected.getRanges().stream().anyMatch(range -> {
+            String start = range.getStart();
+            String end = range.getEnd();
+            return isInRange(start, end, version);
+        });
     }
 
     private boolean isInRange(Object introduced, Object fixed, String version)

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/osv/model/response/AffectObject.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/osv/model/response/AffectObject.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.extension.security.internal.analyzer.osv.model.response;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.xwiki.extension.security.internal.analyzer.osv.model.PackageObject;
@@ -35,7 +36,7 @@ public class AffectObject
 {
     private PackageObject packag;
 
-    private List<RangeObject> ranges;
+    private List<RangeObject> ranges = new ArrayList<>();
 
     /**
      * @return the package
@@ -54,23 +55,20 @@ public class AffectObject
     }
 
     /**
-     * @return the ranges, or an empty list when the affected entry has no ranges (the field is optional in the OSV
-     *     schema, an affected entry can instead enumerate the affected versions)
+     * @return the ranges, never {@code null} but empty when the affected entry has no ranges (the field is optional in
+     *     the OSV schema, an affected entry can instead enumerate the affected versions)
      */
     public List<RangeObject> getRanges()
     {
-        if (this.ranges == null) {
-            return List.of();
-        }
         return this.ranges;
     }
 
     /**
-     * @param ranges the ranges
+     * @param ranges the ranges, {@code null} being stored as an empty list
      */
     public void setRanges(List<RangeObject> ranges)
     {
-        this.ranges = ranges;
+        this.ranges = (ranges == null) ? new ArrayList<>() : ranges;
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/osv/model/response/AffectObject.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/osv/model/response/AffectObject.java
@@ -54,10 +54,14 @@ public class AffectObject
     }
 
     /**
-     * @return the ranges
+     * @return the ranges, or an empty list when the affected entry has no ranges (the field is optional in the OSV
+     *     schema, an affected entry can instead enumerate the affected versions)
      */
     public List<RangeObject> getRanges()
     {
+        if (this.ranges == null) {
+            return List.of();
+        }
         return this.ranges;
     }
 

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/osv/model/response/VulnObject.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/osv/model/response/VulnObject.java
@@ -41,36 +41,33 @@ public class VulnObject
     private static final String CVSS_V3 = "CVSS_V3";
     private static final String CVSS_V2 = "CVSS_V2";
 
-    private List<AffectObject> affected;
+    private List<AffectObject> affected = new ArrayList<>();
 
     private String id;
 
-    private List<VulnReferenceObject> references;
+    private List<VulnReferenceObject> references = new ArrayList<>();
 
     private List<SeverityObject> severity;
 
-    private List<String> aliases;
+    private List<String> aliases = new ArrayList<>();
 
     /**
-     * @return the affected field, or an empty list when the vulnerability has none (the field is optional in the OSV
-     *     schema)
+     * @return the affected field, never {@code null} but empty when the vulnerability has none (the field is optional
+     *     in the OSV schema)
      * @see <a href="https://ossf.github.io/osv-schema/#affected-fields">affected doc</a>
      */
     public List<AffectObject> getAffected()
     {
-        if (this.affected == null) {
-            return List.of();
-        }
         return this.affected;
     }
 
     /**
-     * @param affected the affected field
+     * @param affected the affected field, {@code null} being stored as an empty list
      * @see <a href="https://ossf.github.io/osv-schema/#affected-fields">affected doc</a>
      */
     public void setAffected(List<AffectObject> affected)
     {
-        this.affected = affected;
+        this.affected = (affected == null) ? new ArrayList<>() : affected;
     }
 
     /**
@@ -90,23 +87,20 @@ public class VulnObject
     }
 
     /**
-     * @return the references field, or an empty list when the vulnerability has none (the field is optional in the OSV
-     *     schema)
+     * @return the references field, never {@code null} but empty when the vulnerability has none (the field is optional
+     *     in the OSV schema)
      */
     public List<VulnReferenceObject> getReferences()
     {
-        if (this.references == null) {
-            return List.of();
-        }
         return this.references;
     }
 
     /**
-     * @param references references field
+     * @param references references field, {@code null} being stored as an empty list
      */
     public void setReferences(List<VulnReferenceObject> references)
     {
-        this.references = references;
+        this.references = (references == null) ? new ArrayList<>() : references;
     }
 
     /**
@@ -187,24 +181,21 @@ public class VulnObject
     }
 
     /**
-     * @return the list of aliases associated with this vulnerability
+     * @return the list of aliases associated with this vulnerability, never {@code null} but empty when there is none
      */
     public List<String> getAliases()
     {
-        if (this.aliases == null) {
-            this.aliases = new ArrayList<>();
-        }
         return this.aliases;
     }
 
     /**
      * Sets the list of aliases associated with this vulnerability.
      *
-     * @param aliases the list of aliases to be set
+     * @param aliases the list of aliases to be set, {@code null} being stored as an empty list
      */
     public void setAliases(List<String> aliases)
     {
-        this.aliases = aliases;
+        this.aliases = (aliases == null) ? new ArrayList<>() : aliases;
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/osv/model/response/VulnObject.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/osv/model/response/VulnObject.java
@@ -52,11 +52,15 @@ public class VulnObject
     private List<String> aliases;
 
     /**
-     * @return the affected field
+     * @return the affected field, or an empty list when the vulnerability has none (the field is optional in the OSV
+     *     schema)
      * @see <a href="https://ossf.github.io/osv-schema/#affected-fields">affected doc</a>
      */
     public List<AffectObject> getAffected()
     {
+        if (this.affected == null) {
+            return List.of();
+        }
         return this.affected;
     }
 
@@ -86,10 +90,14 @@ public class VulnObject
     }
 
     /**
-     * @return the references field
+     * @return the references field, or an empty list when the vulnerability has none (the field is optional in the OSV
+     *     schema)
      */
     public List<VulnReferenceObject> getReferences()
     {
+        if (this.references == null) {
+            return List.of();
+        }
         return this.references;
     }
 
@@ -123,7 +131,7 @@ public class VulnObject
      */
     public String getMainURL()
     {
-        return this.references.stream()
+        return getReferences().stream()
             .filter(reference -> Objects.equals(reference.getType(), "WEB"))
             .findFirst()
             .map(VulnReferenceObject::getUrl)
@@ -168,7 +176,7 @@ public class VulnObject
      */
     public Optional<Version> getMaxFixVersion(Version currentVersion)
     {
-        return this.affected.stream()
+        return getAffected().stream()
             .flatMap(affect -> affect.getRanges().stream())
             .flatMap(range -> range.getEvents().stream())
             .map(EventObject::getFixed)

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/test/java/org/xwiki/extension/security/internal/analyzer/osv/OsvResponseAnalyzerTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/test/java/org/xwiki/extension/security/internal/analyzer/osv/OsvResponseAnalyzerTest.java
@@ -171,6 +171,38 @@ class OsvResponseAnalyzerTest
     }
 
     @Test
+    void analyzeOsvResponseWithoutRanges()
+    {
+        // An affected entry can enumerate the affected versions instead of declaring ranges, in which case no fix
+        // version can be computed.
+        OsvResponse osvResponse = readJson("osvResponseWithoutRanges.json");
+
+        ExtensionSecurityAnalysisResult expected = new ExtensionSecurityAnalysisResult();
+        SecurityVulnerabilityDescriptor securityVulnerabilityDescriptor = new SecurityVulnerabilityDescriptor();
+        securityVulnerabilityDescriptor.setId("CVE-1");
+        securityVulnerabilityDescriptor.setAliases(Set.of("VULN_ID"));
+        securityVulnerabilityDescriptor.setURL("https://main.ref/");
+        securityVulnerabilityDescriptor.setScore(7.5);
+        expected.setResults(List.of(securityVulnerabilityDescriptor));
+
+        assertEquals(expected, this.analyzer.analyzeOsvResponse("org.test:my-ext", "7.5", osvResponse));
+    }
+
+    @Test
+    void analyzeOsvResponseWithoutRangesPlatform()
+    {
+        // Extensions which are not on Maven Central are filtered by range, so an affected entry without ranges cannot
+        // match.
+        OsvResponse osvResponse = readJson("osvResponseWithoutRangesPlatform.json");
+
+        ExtensionSecurityAnalysisResult expected = new ExtensionSecurityAnalysisResult();
+        expected.setResults(List.of());
+
+        assertEquals(expected,
+            this.analyzer.analyzeOsvResponse("org.xwiki.platform:xwiki-platform-my-ext", "7.5", osvResponse));
+    }
+
+    @Test
     void analyzeCommonsHttpclientOsvResponse()
     {
         OsvResponse osvResponse = readJson("commons-httpclient-commons-httpclient-3.1.json");

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/test/java/org/xwiki/extension/security/internal/analyzer/osv/model/response/AffectObjectTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/test/java/org/xwiki/extension/security/internal/analyzer/osv/model/response/AffectObjectTest.java
@@ -1,0 +1,50 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.extension.security.internal.analyzer.osv.model.response;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test of {@link AffectObject}.
+ *
+ * @version $Id$
+ */
+class AffectObjectTest
+{
+    private final AffectObject affectObject = new AffectObject();
+
+    @Test
+    void getRangesNotSet()
+    {
+        assertEquals(List.of(), this.affectObject.getRanges());
+    }
+
+    @Test
+    void getRangesSet()
+    {
+        RangeObject rangeObject = new RangeObject();
+        this.affectObject.setRanges(List.of(rangeObject));
+        assertEquals(List.of(rangeObject), this.affectObject.getRanges());
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/test/java/org/xwiki/extension/security/internal/analyzer/osv/model/response/AffectObjectTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/test/java/org/xwiki/extension/security/internal/analyzer/osv/model/response/AffectObjectTest.java
@@ -47,4 +47,11 @@ class AffectObjectTest
         this.affectObject.setRanges(List.of(rangeObject));
         assertEquals(List.of(rangeObject), this.affectObject.getRanges());
     }
+
+    @Test
+    void getRangesSetToNull()
+    {
+        this.affectObject.setRanges(null);
+        assertEquals(List.of(), this.affectObject.getRanges());
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/test/java/org/xwiki/extension/security/internal/analyzer/osv/model/response/VulnObjectTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/test/java/org/xwiki/extension/security/internal/analyzer/osv/model/response/VulnObjectTest.java
@@ -56,6 +56,26 @@ class VulnObjectTest
     }
 
     @Test
+    void getListFieldsSetToNull()
+    {
+        this.vulnObject.setAffected(null);
+        this.vulnObject.setReferences(null);
+        this.vulnObject.setAliases(null);
+
+        assertEquals(List.of(), this.vulnObject.getAffected());
+        assertEquals(List.of(), this.vulnObject.getReferences());
+        assertEquals(List.of(), this.vulnObject.getAliases());
+    }
+
+    @Test
+    void getListFieldsNotSet()
+    {
+        assertEquals(List.of(), this.vulnObject.getAffected());
+        assertEquals(List.of(), this.vulnObject.getReferences());
+        assertEquals(List.of(), this.vulnObject.getAliases());
+    }
+
+    @Test
     void getMaxFixVersion()
     {
         EventObject eventObject = new EventObject();

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/test/java/org/xwiki/extension/security/internal/analyzer/osv/model/response/VulnObjectTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/test/java/org/xwiki/extension/security/internal/analyzer/osv/model/response/VulnObjectTest.java
@@ -1,0 +1,72 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.extension.security.internal.analyzer.osv.model.response;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.extension.version.internal.DefaultVersion;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test of {@link VulnObject}.
+ *
+ * @version $Id$
+ */
+class VulnObjectTest
+{
+    private final VulnObject vulnObject = new VulnObject();
+
+    @Test
+    void getMainURLWithoutReferences()
+    {
+        assertEquals("", this.vulnObject.getMainURL());
+    }
+
+    @Test
+    void getMaxFixVersionWithoutAffected()
+    {
+        assertEquals(Optional.empty(), this.vulnObject.getMaxFixVersion(new DefaultVersion("7.5")));
+    }
+
+    @Test
+    void getMaxFixVersionWithAffectedWithoutRanges()
+    {
+        this.vulnObject.setAffected(List.of(new AffectObject()));
+        assertEquals(Optional.empty(), this.vulnObject.getMaxFixVersion(new DefaultVersion("7.5")));
+    }
+
+    @Test
+    void getMaxFixVersion()
+    {
+        EventObject eventObject = new EventObject();
+        eventObject.setFixed("15.7");
+        RangeObject rangeObject = new RangeObject();
+        rangeObject.setEvents(List.of(eventObject));
+        AffectObject affectObject = new AffectObject();
+        affectObject.setRanges(List.of(rangeObject));
+        this.vulnObject.setAffected(List.of(affectObject));
+
+        assertEquals(Optional.of(new DefaultVersion("15.7")),
+            this.vulnObject.getMaxFixVersion(new DefaultVersion("7.5")));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/test/resources/osvResponseWithoutRanges.json
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/test/resources/osvResponseWithoutRanges.json
@@ -1,0 +1,32 @@
+{
+  "vulns": [
+    {
+      "affected": [
+        {
+          "package": {
+            "name": "org.test:my-ext",
+            "ecosystem": "Maven",
+            "purl": "pkg:maven/org.test/my-ext"
+          },
+          "versions": [
+            "7.5"
+          ]
+        }
+      ],
+      "id": "VULN_ID",
+      "aliases": ["CVE-1"],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "https://main.ref/"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:C/C:H/I:L/A:L"
+        }
+      ]
+    }
+  ]
+}

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/test/resources/osvResponseWithoutRangesPlatform.json
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/test/resources/osvResponseWithoutRangesPlatform.json
@@ -1,0 +1,32 @@
+{
+  "vulns": [
+    {
+      "affected": [
+        {
+          "package": {
+            "name": "org.xwiki.platform:xwiki-platform-my-ext",
+            "ecosystem": "Maven",
+            "purl": "pkg:maven/org.xwiki.platform/xwiki-platform-my-ext"
+          },
+          "versions": [
+            "7.5"
+          ]
+        }
+      ],
+      "id": "VULN_ID",
+      "aliases": ["CVE-1"],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "https://main.ref/"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.0/AV:N/AC:L/PR:H/UI:R/S:C/C:H/I:L/A:L"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Jira URL

N/A — `[Misc]` change, see
https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues

# Changes

## Description

The `ranges`, `affected` and `references` fields are all optional in the
[OSV schema](https://ossf.github.io/osv-schema/) — an `affected` entry can enumerate the affected versions instead of
declaring ranges, for example — but the response model kept them null and the analyzer streamed over them, so
analyzing such a vulnerability failed with:

```
Unexpected error [NullPointerException: Cannot invoke "java.util.List.stream()" because the return value of
"org.xwiki.extension.security.internal.analyzer.osv.model.response.AffectObject.getRanges()" is null]
```

* `AffectObject#ranges`, `VulnObject#affected` and `VulnObject#references` are now initialized to an empty list, so
  they are never null when the field is absent from the response. The getters keep returning the field directly.
* The corresponding setters store `null` as an empty list, so that an explicit `null` in the JSON response (which
  Jackson routes to the setter, bypassing the field initializer) cannot reintroduce the NPE.
* `VulnObject#getMainURL()` and `VulnObject#getMaxFixVersion()` go through the getters instead of reading the fields
  directly, for consistency.
* `VulnObject#getAliases()` is aligned on the same pattern, replacing its lazy initialization in the getter. Its
  observable behaviour is unchanged since it was already never returning null.
* The now-dead emptiness check in `OsvResponseAnalyzer#checkRanges()` goes away.

## Clarifications

* Found while running the flavor extension-security functional test, which logged the error above for a real OSV
  response while indexing the extensions of a standard flavor instance.
* Handling the absent field in the model (rather than at each call site) keeps the "optional in the schema" knowledge in
  one place; the getters are the only accessors used by the analyzer.
* Note that an `affected` entry without ranges yields no fix version, which is what the two new analyzer tests assert.
* `severity` is deliberately left nullable: making it never-null would change the observable contract of
  `getSeverity()` for any caller null-checking it, which is out of scope here.
* No signature changed, and these classes live in an `internal` package, so there is no API compatibility impact.
* `xwiki.jacoco.instructionRatio` goes from `0.41` to `0.49` for the new coverage brought by the tests below.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

```
mvn clean install -f xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/\
xwiki-platform-extension-security-index/pom.xml -Pquality
```

Green: 31 tests, including the new `AffectObjectTest`, `VulnObjectTest` and the two
`OsvResponseAnalyzerTest#analyzeOsvResponseWithoutRanges*` cases (which cover both a Maven Central extension and an
`org.xwiki.platform` one), plus checkstyle and the raised JaCoCo ratio check.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None
