### PR TITLE
[Misc] Only check the programming right when reading a sensitive object property

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Property.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Property.java
@@ -80,17 +80,25 @@ public class Property extends Element
     }
 
     /**
-     * Returns the {@link BaseProperty#getObfuscatedValue()} or {@link BaseProperty#getValue()} if the content author
-     * has programming rights.
+     * Returns the {@link BaseProperty#getValue()} when the property is not sensitive or when the content author has
+     * programming rights, and the {@link BaseProperty#getObfuscatedValue()} otherwise.
      * @return the actual value of the property, as a String, Number or List.
      */
     public java.lang.Object getValue()
     {
-        if (getXWikiContext().getWiki().getRightService().hasProgrammingRights(getXWikiContext())) {
-            return getProperty().getValue();
-        } else {
-            return getBaseProperty().getObfuscatedValue();
+        BaseProperty<?> property = getBaseProperty();
+
+        // A property that is not sensitive has the same value in both branches below, which makes the programming
+        // right irrelevant for it. Since the vast majority of the properties are never sensitive, testing the
+        // sensitivity first (a lookup in the already loaded XClass) spares a full authorization evaluation to almost
+        // every property read.
+        if (!property.isSensitive(getXWikiContext())
+            || getXWikiContext().getWiki().getRightService().hasProgrammingRights(getXWikiContext()))
+        {
+            return property.getValue();
         }
+
+        return property.getObfuscatedValue();
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Property.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Property.java
@@ -80,17 +80,23 @@ public class Property extends Element
     }
 
     /**
-     * Returns the {@link BaseProperty#getObfuscatedValue()} or {@link BaseProperty#getValue()} if the content author
-     * has programming rights.
+     * Returns the {@link BaseProperty#getValue()} when the property is not sensitive or when the content author has
+     * programming rights, and the {@link BaseProperty#getObfuscatedValue()} otherwise. Prefer
+     * {@link #getObfuscatedValue()} when the value is only meant to be displayed, so that a sensitive property is
+     * never exposed by a page that happens to have the programming right.
+     *
      * @return the actual value of the property, as a String, Number or List.
      */
     public java.lang.Object getValue()
     {
-        if (getXWikiContext().getWiki().getRightService().hasProgrammingRights(getXWikiContext())) {
-            return getProperty().getValue();
-        } else {
-            return getBaseProperty().getObfuscatedValue();
+        // The programming right is only relevant for a sensitive property: for any other one both branches below
+        // return the same value. Testing the sensitivity first (a lookup in the already loaded XClass) thus spares a
+        // full authorization evaluation to almost every property read, without changing the result.
+        if (isSensitive() && !hasProgrammingRights()) {
+            return getObfuscatedValue();
         }
+
+        return getBaseProperty().getValue();
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/api/PropertyTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/api/PropertyTest.java
@@ -1,0 +1,133 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.api;
+
+import javax.mail.internet.InternetAddress;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xwiki.mail.EmailAddressObfuscator;
+import org.xwiki.mail.GeneralMailConfiguration;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import com.xpn.xwiki.objects.BaseObject;
+import com.xpn.xwiki.objects.classes.BaseClass;
+import com.xpn.xwiki.test.MockitoOldcore;
+import com.xpn.xwiki.test.junit5.mockito.InjectMockitoOldcore;
+import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link Property}.
+ *
+ * @version $Id$
+ */
+@OldcoreTest
+class PropertyTest
+{
+    private static final DocumentReference CLASS_REFERENCE = new DocumentReference("wiki", "Some", "Class");
+
+    private static final String TEXT_FIELD = "text";
+
+    private static final String PASSWORD_FIELD = "password";
+
+    private static final String EMAIL_FIELD = "email";
+
+    @InjectMockitoOldcore
+    private MockitoOldcore oldcore;
+
+    @MockComponent
+    private GeneralMailConfiguration mailConfiguration;
+
+    @MockComponent
+    private EmailAddressObfuscator emailAddressObfuscator;
+
+    private Object object;
+
+    @BeforeEach
+    void setUp()
+    {
+        BaseClass xclass = new BaseClass();
+        xclass.setDocumentReference(CLASS_REFERENCE);
+        xclass.addTextField(TEXT_FIELD, "Text", 30);
+        xclass.addPasswordField(PASSWORD_FIELD, "Password", 30);
+        xclass.addEmailField(EMAIL_FIELD, "Email", 30);
+
+        BaseObject xobject = new BaseObject();
+        xobject.setXClassReference(CLASS_REFERENCE);
+        xobject.setSourceXClass(xclass);
+        xobject.setStringValue(TEXT_FIELD, "some text");
+        xobject.setStringValue(PASSWORD_FIELD, "s3cr3t");
+        xobject.setStringValue(EMAIL_FIELD, "alice@example.com");
+
+        this.object = new Object(xobject, this.oldcore.getXWikiContext());
+    }
+
+    @Test
+    void getValueOfNonSensitivePropertyDoesNotCheckProgrammingRight()
+    {
+        assertEquals("some text", this.object.getProperty(TEXT_FIELD).getValue());
+
+        verifyNoInteractions(this.oldcore.getMockRightService());
+    }
+
+    @Test
+    void getValueOfSensitivePropertyWithoutProgrammingRight()
+    {
+        // PasswordClass doesn't override PropertyClass#getObfuscatedValue(Object), which returns null for safety,
+        // and BaseStringProperty turns that null into an empty string.
+        assertEquals("", this.object.getProperty(PASSWORD_FIELD).getValue());
+    }
+
+    @Test
+    void getValueOfSensitivePropertyWithProgrammingRight()
+    {
+        when(this.oldcore.getMockRightService().hasProgrammingRights(this.oldcore.getXWikiContext())).thenReturn(true);
+
+        assertEquals("s3cr3t", this.object.getProperty(PASSWORD_FIELD).getValue());
+    }
+
+    @Test
+    void getValueOfEmailPropertyWhenObfuscationIsDisabled()
+    {
+        when(this.mailConfiguration.shouldObfuscate()).thenReturn(false);
+
+        assertEquals("alice@example.com", this.object.getProperty(EMAIL_FIELD).getValue());
+
+        // An email address is only sensitive when the mail configuration asks for obfuscation, so the programming
+        // right is not relevant here either.
+        verifyNoInteractions(this.oldcore.getMockRightService());
+        verifyNoInteractions(this.emailAddressObfuscator);
+    }
+
+    @Test
+    void getValueOfEmailPropertyWhenObfuscationIsEnabled()
+    {
+        when(this.mailConfiguration.shouldObfuscate()).thenReturn(true);
+        when(this.emailAddressObfuscator.obfuscate(any(InternetAddress.class))).thenReturn("a...e@example.com");
+
+        assertEquals("a...e@example.com", this.object.getProperty(EMAIL_FIELD).getValue());
+    }
+}


### PR DESCRIPTION
# Jira URL

<!-- `[Misc]` commit, no JIRA issue. Happy to create one if reviewers prefer. -->

N/A — `[Misc]`

# Changes

## Description

* `Property#getValue()` evaluated the programming right *before* looking at the property:

  ```java
  if (getXWikiContext().getWiki().getRightService().hasProgrammingRights(getXWikiContext())) {
      return getProperty().getValue();
  } else {
      return getBaseProperty().getObfuscatedValue();
  }
  ```

  For a property that is not sensitive, `BaseProperty#getObfuscatedValue()` falls straight through to
  `getValue()`, so both branches return the very same value and the right is irrelevant. Only
  `PasswordClass`, `PasswordProperty` and `EmailClass` (the latter only when
  `GeneralMailConfiguration#shouldObfuscate()` is on) are ever sensitive; `PropertyInterface#isSensitive()`
  defaults to `false` for every other type.

  The check is now guarded by `isSensitive()`, so the authorization evaluation only happens when its outcome
  can change the result:

  ```java
  if (isSensitive() && !hasProgrammingRights()) {
      return getObfuscatedValue();
  }

  return getBaseProperty().getValue();
  ```

  Obfuscation stays entirely inside `getObfuscatedValue()` rather than being reimplemented here, and the
  right check goes through the inherited `Api#hasProgrammingRights()` instead of reaching for the right
  service directly.

* This also removes a second, redundant programming right evaluation: the privileged branch called
  `getProperty()`, which checks the right again. It now uses the unchecked `getBaseProperty()` accessor.

* The javadoc now points callers at `getObfuscatedValue()` when the value is only meant to be displayed.

* Added `PropertyTest`, which did not exist.

## Clarifications

* **No behaviour change.** For all four combinations the returned value is identical to before:

  |                     | not sensitive       | sensitive           |
  |---------------------|---------------------|---------------------|
  | with programming    | raw value           | raw value           |
  | without programming | raw value           | obfuscated value    |

  The only observable difference is that no programming right check is performed for non-sensitive
  properties. Edge cases behave the same too: a property whose `PropertyClass` cannot be resolved (no
  owning `BaseObject`) is never sensitive, so both versions return the raw value, and the reverse case —
  sensitive with a `null` `PropertyClass` — is unreachable since `BaseProperty#isSensitive()` requires a
  non-null one.

* **A latent NPE disappears as a side effect.** The old code evaluated the right on the refreshed context
  returned by `getXWikiContext()`, then called `getProperty()`, which evaluates it again on the possibly
  stale `Api#context` field. Had those two ever disagreed, `getProperty()` would have returned `null` and
  `getValue()` would have thrown. There is no second evaluation left. The context used is still the
  refreshed one, because `isSensitive()` goes through `getXWikiContext()` — which re-syncs `Api#context` —
  before `hasProgrammingRights()` can be reached.

* **Why it matters in practice.** Every `$object.getValue('field')` in wiki content currently triggers a
  full authorization evaluation that is then discarded. It also makes perfectly ordinary pages look like
  they require the programming right to `ProgrammingRightCheckerAuthorizationManager`, e.g. while running a
  functional test on any page:

  ```
  INFO ghtCheckerAuthorizationManager - PRChecker: Block programming right for page [xwiki:XWiki.Lightbox.WebHome]
  ```

  That one comes from `XWiki/Lightbox/WebHome.xml`, whose header UIX does
  `#if ($lightboxConfigObj.getValue('isLightboxEnabled').equals(1))` on every page view — a `BooleanClass`
  property, so the check could never have mattered. Nothing else on that path checks a right:
  `$obj.getValue('field')` goes through `Collection#getValue(String)` and `Collection#getProperty(String)`,
  which only wrap the `BaseProperty`, so for a non-sensitive property the `&&` short-circuits and the
  authorization manager never sees the page at all.

* **Cost.** Authorization evaluations per `$obj.getValue('field')` call:

  |                              | before | after |
  |------------------------------|--------|-------|
  | not sensitive, no programming|   1    | **0** |
  | not sensitive, programming   |   2    | **0** |
  | sensitive, no programming    |   1    |   1   |
  | sensitive, programming       |   2    |   1   |

  No extra work on the common path: `getObfuscatedValue()` already called `isSensitive()` there, so that
  call is merely hoisted. On the privileged path an XClass lookup (document-cache backed) replaces two
  right evaluations.

* **Out of scope.** The "raw value if programming right" rule in `getValue()` remains a footgun for
  privileged scripts — XWIKI-24298 already had to switch `LiveTableResultsMacros.xml` over to
  `getObfuscatedValue()` for exactly that reason. Whether `getValue()` should obfuscate unconditionally and
  have privileged callers opt in explicitly feels like a separate discussion; this PR only stops the
  probe from taxing every other caller.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

```
mvn test -f xwiki-platform-core/xwiki-platform-oldcore/pom.xml -Dtest=PropertyTest
mvn test -f xwiki-platform-core/xwiki-platform-oldcore/pom.xml
mvn checkstyle:check -f xwiki-platform-core/xwiki-platform-oldcore/pom.xml
```

* New `PropertyTest`: 5 tests, all passing. It covers a non-sensitive `StringClass` property (asserts
  `verifyNoInteractions` on the right service, which is what locks in the removal of the programming right
  check), a `PasswordClass` property with and without the programming right, and an `EmailClass` property
  with obfuscation both disabled and enabled.
* Full `xwiki-platform-oldcore` unit test suite: 1156 tests, 0 failures.
* Checkstyle: clean.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None — the behaviour being fixed was introduced by XWIKI-21402 (18.2.0RC1) and this is a
    performance/clarity fix rather than a functional one. Happy to add backport labels if reviewers want it
    on the stable branches.
