### PR TITLE
XWIKI-24621: Notification watch settings can silently fail to be saved

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
@@ -169,27 +169,32 @@
     }
   };
   
+  // Applies the second change only once the first one has succeeded, so that both changes are not sent concurrently
+  // and so that the page is not reloaded before the second one is done.
+  var performChainedChanges = function (firstOption, secondOption) {
+    var firstPromise = performChange(firstOption);
+    if (firstPromise) {
+      return firstPromise.then(function () {
+        return performChange(secondOption);
+      });
+    }
+  };
+
   var handleSubmit = function () {
     var chosenOption = $('#watchModal input[type="radio"]:checked').val();
     var promise;
     if (chosenOption == 'unwatchPageWatchSpace') {
-      var firstPromise = performChange('unwatchPage');
-      if (firstPromise !== 'undefined') {
-        promise = firstPromise.pipe(performChange('watchSpace'))
-      }
+      promise = performChainedChanges('unwatchPage', 'watchSpace');
     } else if (chosenOption == 'unblockPageBlockSpace') {
-      var firstPromise = performChange('unblockPage');
-      if (firstPromise !== 'undefined') {
-        promise = firstPromise.pipe(performChange('blockSpace'))
-      }
+      promise = performChainedChanges('unblockPage', 'blockSpace');
     } else {
       promise = performChange(chosenOption);
     }
-    if (promise !== 'undefined') {
+    if (promise) {
       promise.done(function () {
         removeAnySelection();
         window.location.reload();
-      }).error(function (data) {
+      }).fail(function (data) {
         removeAnySelection();
         console.error("Error when processing the request: " + data);
       });

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
@@ -159,41 +159,39 @@
       var url = restUrl.replace(/\/spaces.*/, "");
       queryParams.append("ignore", "true");
     } else {
-      console.error("Option " + chosenOption + " is not yet supported!");
+      return Promise.reject(new Error("Option " + chosenOption + " is not yet supported!"));
     }
-    if (url) {
-      var ajaxUrl = url + "/notificationsWatches?" + queryParams.toString();
-      return $.ajax(ajaxUrl, {
-          method: method
-      });
-    }
+    var ajaxUrl = url + "/notificationsWatches?" + queryParams.toString();
+    return $.ajax(ajaxUrl, {
+      method: method
+    });
   };
   
+  // Applies the specified changes one after another: the next change is sent only once the previous one has succeeded,
+  // so that the changes are not sent concurrently and the page is not reloaded before the last one is done.
+  async function performChainedChanges(...changes) {
+    for (const change of changes) {
+      await performChange(change);
+    }
+  }
+
   var handleSubmit = function () {
     var chosenOption = $('#watchModal input[type="radio"]:checked').val();
     var promise;
-    if (chosenOption == 'unwatchPageWatchSpace') {
-      var firstPromise = performChange('unwatchPage');
-      if (firstPromise !== 'undefined') {
-        promise = firstPromise.pipe(performChange('watchSpace'))
-      }
-    } else if (chosenOption == 'unblockPageBlockSpace') {
-      var firstPromise = performChange('unblockPage');
-      if (firstPromise !== 'undefined') {
-        promise = firstPromise.pipe(performChange('blockSpace'))
-      }
+    if (chosenOption === 'unwatchPageWatchSpace') {
+      promise = performChainedChanges('unwatchPage', 'watchSpace');
+    } else if (chosenOption === 'unblockPageBlockSpace') {
+      promise = performChainedChanges('unblockPage', 'blockSpace');
     } else {
       promise = performChange(chosenOption);
     }
-    if (promise !== 'undefined') {
-      promise.done(function () {
-        removeAnySelection();
-        window.location.reload();
-      }).error(function (data) {
-        removeAnySelection();
-        console.error("Error when processing the request: " + data);
-      });
-    }
+    promise.then(function () {
+      removeAnySelection();
+      window.location.reload();
+    }).catch(function (data) {
+      removeAnySelection();
+      console.error("Error when processing the request: " + data);
+    });
   };
   
   var removeAnySelection = function() {


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24621

# Changes

## Description

Fixes the submit handler of the notification watch modal (`XWiki.Notifications.Code.NotificationsWatchUIX`), which had two independent problems:

* It registered its failure callback with `jqXHR.error()`. That callback was removed in jQuery 3.0; jQuery Migrate 3 restored it but Migrate 4 does not, so since 18.3.0 (upgrade to jQuery 4.0.0 + Migrate 4.0.2, XWIKI-23979) every submission threw `TypeError: promise.done(...).error is not a function`. The success path kept working by accident — the request had already been sent and the `done()` callback already registered when the exception was thrown — so this only showed up when a request actually failed: nothing happened at all, the modal stayed open with the option still selected, the page did not reload and nothing was reported, leaving the user to believe their watch or block choice had been saved. Replaced by `fail()`.
* For the two combined options ("Unwatch this page and watch the space instead" and its block equivalent), it called `firstPromise.pipe(performChange('watchSpace'))`. `performChange()` is *invoked* there, so its request left at the same time as the first one, and `pipe()` received a jqXHR instead of a callback (jQuery ignores non-function arguments). The two requests therefore raced, and the resulting promise resolved as soon as the *first* one completed, so `window.location.reload()` could fire while the space-level request was still in flight — the browser then cancelled it and the space-level watch or block was silently dropped. The second change is now chained with `then()` in a `performChainedChanges()` helper.

Also replaced the two `promise !== 'undefined'` guards, which compared against the *string* `'undefined'` and hence never triggered, by truthy checks — so an unsupported option now does nothing instead of throwing `Cannot read properties of undefined (reading 'done')`.

## Clarifications

* The fix deliberately does not rely on jQuery Migrate: Migrate is bundled only as a temporary compatibility layer for extensions not yet migrated to jQuery 4 (see the flavor's optional dependency), so platform code must not depend on the APIs it restores.
* `Deferred.pipe()` is also one of the last JQMIGRATE console messages produced by platform code, so this removes one item from XWIKI-23202. The remaining ones come from the `bootstrap-switch` and `bootstrap-tour` WebJars — see the analysis in XWIKI-23202.

# Screenshots & Video

No visual change: the modal, its options and the successful path look exactly the same. The change is behavioural and concerns the failure and the request-ordering paths, so it is shown below as measured behaviour instead.

Reproduced and verified with the exact versions the platform ships (jQuery 4.0.0 + jQuery Migrate 4.0.2, driven from jsdom against a real HTTP server), running the old and the new handler side by side. The page-level request is made slower than the space-level one so the ordering is observable:

```
=== jqXHR API surface under jQuery 4.0.0 + Migrate 4.0.2 ===
{"error":"undefined","fail":"function","success":"undefined","done":"function"}

=== BEFORE ===
exception thrown by the submit handler : TypeError: chain.error is not a function
requests (sentAt/doneAt ms):
   DELETE page: sent@10 done@32
   PUT space: sent@10 done@161
page reload would fire at   : 37 (last request completed at 161)
reload happens before the space-level request completed: true
space request chained after the page one: false
JQMIGRATE messages: INFO: JQMIGRATE: deferred.pipe() is deprecated

=== AFTER ===
exception thrown by the submit handler : none
requests (sentAt/doneAt ms):
   DELETE page: sent@2 done@23
   PUT space: sent@31 done@182
page reload would fire at   : 185 (last request completed at 182)
reload happens before the space-level request completed: false
space request chained after the page one: true
JQMIGRATE messages: none
```

# Executed Tests

```
mvn clean install -B -ntp -pl xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui -Plegacy

mvn clean verify -B -ntp \
  -pl xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker \
  -Plegacy,docker,integration-tests -Dit.test=NotificationsSettingsIT
```

`NotificationsSettingsIT` covers the watch modal, including the `UNWATCH_PAGE_WATCH_SPACE` combined option whose resulting filter it asserts right after the modal is submitted — which is exactly the path whose request ordering this PR makes deterministic. 5 of its 6 tests pass.

The 6th, `watchAndRename:874`, fails — but it fails **identically on unmodified master** in the same environment (`expected: <true> but was: <false>`, HSQLDB embedded / Jetty standalone / Firefox on macOS), so it is pre-existing and unrelated: it never opens the watch modal, it only exercises autowatch and the renaming of notification filters. I ran the whole class twice, once with this fix and once with the `master` version of the file put back in place, and got the same single failure both times.

The failure path (a request that does not succeed) is not covered by an automated test; it was verified with the harness above.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * To be decided. Note that the `error()` regression only concerns 18.3.0+ (jQuery 4): the LTS lines still ship jQuery Migrate 3, which restores `error()`, so they are only affected by the `pipe()` request-ordering part.
