### PR TITLE
[Misc] Use isEmpty() instead of comparing length() to zero

### DIFF
--- a/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
@@ -691,7 +691,7 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
         StringBuffer categs = new StringBuffer("");
         if (categList != null) {
             for (SyndCategory categ : categList) {
-                if (categs.length() != 0) {
+                if (!categs.isEmpty()) {
                     categs.append(", ");
                 }
                 categs.append(categ.getName());
@@ -706,7 +706,7 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
         List<SyndContent> contentList = entry.getContents();
         if (contentList != null && !contentList.isEmpty()) {
             for (SyndContent content : contentList) {
-                if (contents.length() != 0) {
+                if (!contents.isEmpty()) {
                     contents.append("\n");
                 }
                 contents.append(content.getValue());

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/AbstractReader.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/AbstractReader.java
@@ -83,7 +83,7 @@ public abstract class AbstractReader
     {
         Locale locale = null;
         if (value != null) {
-            if (value.length() == 0) {
+            if (value.isEmpty()) {
                 locale = Locale.ROOT;
             } else {
                 locale = LocaleUtils.toLocale(value);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -4192,7 +4192,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
                     String data = display(propertyName, object, context);
                     data = data.trim();
                     data = data.replace("\n", " ");
-                    if (data.length() == 0) {
+                    if (data.isEmpty()) {
                         result.append("&nbsp;");
                     } else {
                         result.append(data);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/rcs/XWikiPatchUtils.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/rcs/XWikiPatchUtils.java
@@ -82,7 +82,7 @@ public class XWikiPatchUtils
         Object[] lines = ToString.stringToArray(diff);
         for (int it = 0; it < lines.length; it++) {
             String cmd = lines[it].toString();
-            if (cmd.length() == 0) {
+            if (cmd.isEmpty()) {
                 break;
             }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/export/html/HtmlPackager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/export/html/HtmlPackager.java
@@ -224,7 +224,7 @@ public class HtmlPackager
         // otherwise on some OS we wouldn't be able to unzip if there are pages having a path longer than 255 chars...
         String zipname = "pages/" + this.pathEntityReferenceSerializer.serialize(pageReference);
         String language = doc.getLanguage();
-        if (language != null && language.length() != 0) {
+        if (language != null && !language.isEmpty()) {
             zipname += POINT + language;
         }
         zipname += ".html";

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/cache/rendering/DefaultRenderingCache.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/cache/rendering/DefaultRenderingCache.java
@@ -245,7 +245,7 @@ public class DefaultRenderingCache implements RenderingCache, Initializable
             // If the parameter is the refresh parameter then ignore it
             if (!entry.getKey().equals(PARAMETER_REFRESH)) {
                 for (String value : entry.getValue()) {
-                    if (sb.length() > 0) {
+                    if (!sb.isEmpty()) {
                         sb.append('&');
                     }
                     try {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/cache/rendering/DefaultRenderingCacheConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/cache/rendering/DefaultRenderingCacheConfiguration.java
@@ -240,7 +240,7 @@ public class DefaultRenderingCacheConfiguration implements RenderingCacheConfigu
             StringBuffer patternBuffer = new StringBuffer();
 
             for (String patternString : configuration) {
-                if (patternBuffer.length() > 0) {
+                if (!patternBuffer.isEmpty()) {
                     patternBuffer.append('|');
                 }
                 patternBuffer.append('(');

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/export/DocumentSelectionResolver.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/export/DocumentSelectionResolver.java
@@ -210,7 +210,7 @@ public class DocumentSelectionResolver
 
             List<String> constraints = extendQuery(entry.getKey(), entry.getValue(), parameters);
             if (!constraints.isEmpty()) {
-                statement.append(statement.length() == 0 ? "where (" : " or (");
+                statement.append(statement.isEmpty() ? "where (" : " or (");
                 statement.append(StringUtils.join(constraints, " and "));
                 statement.append(')');
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/AbstractAsyncClassDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/AbstractAsyncClassDocumentInitializer.java
@@ -92,7 +92,7 @@ public abstract class AbstractAsyncClassDocumentInitializer extends AbstractMand
         }
         StringBuilder entriesString = new StringBuilder();
         for (String entry : contextEntries) {
-            if (entriesString.length() > 0) {
+            if (!entriesString.isEmpty()) {
                 entriesString.append('|');
             }
             entriesString.append(entry);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/model/reference/CompactStringEntityReferenceSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/model/reference/CompactStringEntityReferenceSerializer.java
@@ -89,7 +89,7 @@ public class CompactStringEntityReferenceSerializer extends DefaultStringEntityR
         // In addition an entity reference isn't printed only if all parent references are not printed either,
         // otherwise print it. For example "wiki:page" isn't allowed for a Document Reference.
 
-        if (isLastReference || representation.length() > 0) {
+        if (isLastReference || !representation.isEmpty()) {
             shouldPrint = true;
         } else {
             EntityReference defaultReference = resolveDefaultReference(currentReference.getType(), parameters);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
@@ -1250,7 +1250,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
 
     public boolean isCustomMappingValid(String custommapping, XWikiContext context) throws XWikiException
     {
-        if ((custommapping != null) && (custommapping.trim().length() > 0)) {
+        if ((custommapping != null) && (!custommapping.trim().isEmpty())) {
             return context.getWiki().getStore().isCustomMappingValid(this, custommapping, context);
         } else {
             return true;
@@ -1260,7 +1260,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
     public List<String> getCustomMappingPropertyList(XWikiContext context)
     {
         String custommapping1 = getCustomMapping();
-        if ((custommapping1 != null) && (custommapping1.trim().length() > 0)) {
+        if ((custommapping1 != null) && (!custommapping1.trim().isEmpty())) {
             return context.getWiki().getStore().getCustomMappingPropertyList(this);
         } else {
             return new ArrayList<>();

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DBTreeListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DBTreeListClass.java
@@ -294,7 +294,7 @@ public class DBTreeListClass extends DBListClass
     {
         for (ListItem tmpItem : treeList) {
             if (item.equals(tmpItem.getId())) {
-                if (tmpItem.getParent().length() > 0) {
+                if (!tmpItem.getParent().isEmpty()) {
                     getItemPath(tmpItem.getParent(), treeList, resList);
                 }
                 resList.add(tmpItem);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/rightsmanager/RightsManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/rightsmanager/RightsManager.java
@@ -751,7 +751,7 @@ public final class RightsManager
                 }
             } else if (currentPreference.getName().equals(SPACE_PREFERENCES)) {
                 String parentspace = currentPreference.getStringValue(WIKI_PREFERENCES, "parent");
-                if (parentspace.trim().length() > 0) {
+                if (!parentspace.trim().isEmpty()) {
                     parentPreferences =
                         context.getWiki().getDocument(parentspace + SPACEPAGENAME_SEP + SPACE_PREFERENCES, context);
                 } else {
@@ -981,8 +981,8 @@ public final class RightsManager
                 needUpdate |=
                     removeUserOrGroupFromRight(bobj, userOrGroupWiki, userOrGroupSpace, userOrGroupName, user, context);
 
-                if (needUpdate && bobj.getLargeStringValue(RIGHTSFIELD_USERS).trim().length() == 0
-                    && bobj.getLargeStringValue(RIGHTSFIELD_GROUPS).trim().length() == 0) {
+                if (needUpdate && bobj.getLargeStringValue(RIGHTSFIELD_USERS).trim().isEmpty()
+                    && bobj.getLargeStringValue(RIGHTSFIELD_GROUPS).trim().isEmpty()) {
                     rightsDocument.removeXObject(bobj);
                 }
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/rightsmanager/utils/AllowDeny.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/rightsmanager/utils/AllowDeny.java
@@ -44,7 +44,7 @@ public class AllowDeny
         StringBuilder sb = new StringBuilder();
 
         String allowString = this.allow.toString();
-        if (allowString.length() > 0) {
+        if (!allowString.isEmpty()) {
             sb.append('{');
             sb.append("allow : ");
             sb.append(this.allow);
@@ -52,7 +52,7 @@ public class AllowDeny
         }
 
         String denyString = this.deny.toString();
-        if (denyString.length() > 0) {
+        if (!denyString.isEmpty()) {
             sb.append('{');
             sb.append("deny : ");
             sb.append(this.deny);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/rightsmanager/utils/LevelTree.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/rightsmanager/utils/LevelTree.java
@@ -45,7 +45,7 @@ public class LevelTree
 
         if (this.inherited != null) {
             String heritedString = this.inherited.toString();
-            if (heritedString.length() > 0) {
+            if (!heritedString.isEmpty()) {
                 sb.append('{');
                 sb.append("inherited : ");
                 sb.append(this.inherited);
@@ -55,7 +55,7 @@ public class LevelTree
 
         if (this.direct != null) {
             String directString = this.direct.toString();
-            if (directString.length() > 0) {
+            if (!directString.isEmpty()) {
                 sb.append('{');
                 sb.append("direct : ");
                 sb.append(this.direct);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/stats/impl/xwiki/XWikiStatsReader.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/stats/impl/xwiki/XWikiStatsReader.java
@@ -131,7 +131,7 @@ public class XWikiStatsReader
      */
     private String getHqlValidDomain(String domain)
     {
-        if (domain == null || domain.trim().length() == 0) {
+        if (domain == null || domain.trim().isEmpty()) {
             return "%";
         }
 
@@ -426,7 +426,7 @@ public class XWikiStatsReader
         StringBuilder userListWhere = new StringBuilder();
         try {
             for (DocumentReference user : StatsUtil.getRequestFilteredUsers(context)) {
-                if (userListWhere.length() > 0) {
+                if (!userListWhere.isEmpty()) {
                     userListWhere.append(", ");
                 }
 
@@ -437,7 +437,7 @@ public class XWikiStatsReader
             LOGGER.error("Faild to get filter users list", e);
         }
 
-        if (userListWhere.length() > 0) {
+        if (!userListWhere.isEmpty()) {
             query.append(" name NOT IN (");
             query.append(userListWhere);
             query.append(") and ");

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/DBCPConnectionProvider.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/DBCPConnectionProvider.java
@@ -149,14 +149,14 @@ public class DBCPConnectionProvider implements ConnectionProvider, Configurable,
 
             // Isolation level
             String isolationLevel = (String) props.get(Environment.ISOLATION);
-            if ((isolationLevel != null) && (isolationLevel.trim().length() > 0)) {
+            if ((isolationLevel != null) && (!isolationLevel.trim().isEmpty())) {
                 dbcpProperties.put("defaultTransactionIsolation", isolationLevel);
             }
 
             // Turn off autocommit (unless autocommit property is set)
             // Note that this property will be overwritten below if the DBCP "defaultAutoCommit" property is defined.
             String autocommit = (String) props.get(AUTOCOMMIT);
-            if ((autocommit != null) && (autocommit.trim().length() > 0)) {
+            if ((autocommit != null) && (!autocommit.trim().isEmpty())) {
                 dbcpProperties.put("defaultAutoCommit", autocommit);
             } else {
                 dbcpProperties.put("defaultAutoCommit", String.valueOf(Boolean.FALSE));
@@ -164,7 +164,7 @@ public class DBCPConnectionProvider implements ConnectionProvider, Configurable,
 
             // Pool size
             String poolSize = (String) props.get(Environment.POOL_SIZE);
-            if ((poolSize != null) && (poolSize.trim().length() > 0) && (Integer.parseInt(poolSize) > 0)) {
+            if ((poolSize != null) && (!poolSize.trim().isEmpty()) && (Integer.parseInt(poolSize) > 0)) {
                 dbcpProperties.put("maxTotal", poolSize);
             }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/AbstractResizeMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/AbstractResizeMigration.java
@@ -275,7 +275,7 @@ public abstract class AbstractResizeMigration extends AbstractHibernateDataMigra
             throw new DataMigrationException("Error while extracting metadata", e);
         }
 
-        if (builder.length() > 0) {
+        if (!builder.isEmpty()) {
             String script = String.format("<changeSet author=\"xwiki\" id=\"R%s\">%s</changeSet>",
                 getVersion().getVersion(), builder.toString());
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/HibernateDataMigrationManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/HibernateDataMigrationManager.java
@@ -259,7 +259,7 @@ public class HibernateDataMigrationManager extends AbstractDataMigrationManager
             liquibaseChangeLogs = migration.getLiquibaseChangeLog();
         }
 
-        if (liquibaseChangeLogs == null || liquibaseChangeLogs.length() == 0) {
+        if (liquibaseChangeLogs == null || liquibaseChangeLogs.isEmpty()) {
             return;
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R130200000XWIKI17200DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R130200000XWIKI17200DataMigration.java
@@ -162,7 +162,7 @@ public class R130200000XWIKI17200DataMigration extends AbstractHibernateDataMigr
             throw new DataMigrationException("Error while extracting metadata", e);
         }
 
-        if (builder.length() > 0) {
+        if (!builder.isEmpty()) {
             return String.format("<changeSet author=\"xwiki\" id=\"R%s\">%s</changeSet>", getVersion().getVersion(),
                 builder.toString());
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R4359XWIKI1459DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R4359XWIKI1459DataMigration.java
@@ -133,7 +133,7 @@ public class R4359XWIKI1459DataMigration extends AbstractHibernateDataMigration
                         // In some weird cases it can happen that the XWD_ARCHIVE field is empty
                         // (that shouldn't happen but we've seen it happening).
                         // In this case just ignore the archive...
-                        if (sArchive.trim().length() != 0) {
+                        if (!sArchive.trim().isEmpty()) {
                             XWikiDocumentArchive docArchive =
                                 new XWikiDocumentArchive(context.getWikiReference(), docId);
                             try {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/util/TOCGenerator.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/util/TOCGenerator.java
@@ -97,7 +97,7 @@ public class TOCGenerator
 
                         // construct the string representation of the number
                         if (i <= level) {
-                            if ((number.length()) == 0) {
+                            if (number.isEmpty()) {
                                 // start new number
                                 number = num + number;
                                 currentNumber = num;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiMessageTool.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiMessageTool.java
@@ -326,7 +326,7 @@ public class XWikiMessageTool
     {
         List<XWikiDocument> list = new ArrayList<>();
 
-        if (documentName.length() != 0) {
+        if (!documentName.isEmpty()) {
             try {
                 XWikiContext context = getXWikiContext();
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/StaticListClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/StaticListClassTest.java
@@ -149,7 +149,7 @@ class StaticListClassTest
         staticListClass.setSize(7);
         StringBuilder values = new StringBuilder();
         for (String value : VALUES_WITH_HTML_SPECIAL_CHARS) {
-            if (values.length() > 0) {
+            if (!values.isEmpty()) {
                 values.append('|');
             }
             values.append(value).append('=').append(StringUtils.reverse(value));
@@ -269,7 +269,7 @@ class StaticListClassTest
         staticListClass.setSize(7);
         StringBuilder values = new StringBuilder();
         for (String value : VALUES_WITH_HTML_SPECIAL_CHARS) {
-            if (values.length() > 0) {
+            if (!values.isEmpty()) {
                 values.append('|');
             }
             values.append(value).append('=').append(StringUtils.reverse(value));

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrIndexAvailableLocalesListener.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrIndexAvailableLocalesListener.java
@@ -149,7 +149,7 @@ public class SolrIndexAvailableLocalesListener implements EventListener
 
                     for (Locale newLocale : newLocales) {
                         for (Locale locale : getParentLocales(newLocale)) {
-                            if (builder.length() > 0) {
+                            if (!builder.isEmpty()) {
                                 builder.append(" OR ");
                             }
                             builder.append(FieldUtils.DOCUMENT_LOCALE);

--- a/xwiki-platform-tools/xwiki-platform-tool-provision-plugin/src/main/java/org/xwiki/tool/provision/InstallMojo.java
+++ b/xwiki-platform-tools/xwiki-platform-tool-provision-plugin/src/main/java/org/xwiki/tool/provision/InstallMojo.java
@@ -190,7 +190,7 @@ public class InstallMojo extends AbstractMojo
 
         // Get the job status
         JobStatus jobStatus = (JobStatus) unmarshaller.unmarshal(putMethod.getResponseBodyAsStream());
-        if (jobStatus.getErrorMessage() != null && jobStatus.getErrorMessage().length() > 0) {
+        if (jobStatus.getErrorMessage() != null && !jobStatus.getErrorMessage().isEmpty()) {
             throw new MojoExecutionException(
                 String.format("Job execution failed. Reason [%s]", jobStatus.getErrorMessage()));
         }


### PR DESCRIPTION
## Summary

Fixes **37 SonarCloud issues** for rule [java:S7158](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&resolved=false&rules=java%3AS7158) — *"Use isEmpty() to check whether a StringBuilder is empty or not"* — across 26 files. This clears the remaining S7158 backlog in this repo.

The transformation is purely mechanical, single-line and behaviour-neutral:

- `X.length() == 0` → `X.isEmpty()`
- `X.length() > 0` / `X.length() != 0` → `!X.isEmpty()`

`isEmpty()` is available on every receiver involved here (`String` since Java 6, `CharSequence` since Java 15, `StringBuilder`/`StringBuffer`), and XWiki targets Java 17. Only the flagged comparison is rewritten — surrounding clauses such as `buffer.charAt(buffer.length() - 1)` are left untouched. No signature, visibility or API change, so no backward-compatibility impact.

Modules touched: `xwiki-platform-oldcore` (32 sites), `xwiki-platform-feed-api`, `xwiki-platform-filter-stream-xar`, `xwiki-platform-search-solr-api`, `xwiki-platform-tool-provision-plugin`.

## Test plan

- [x] `mvn clean install -Plegacy,quality` over all 5 modified modules — **BUILD SUCCESS** (Checkstyle, Spoon, Revapi, Enforcer and JaCoCo coverage gates included; full unit-test suites run, no failures).

## Related

Sibling PRs applying the same rule to the other repos: xwiki/xwiki-commons#1846 and xwiki/xwiki-rendering#387.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QEcsxtam1wCP6aLxwwbKbt)_