### PR TITLE
XWIKI-22786: Update or mark method User#isUserInGroup as deprecated

### DIFF
--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-extension-handler-xar/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-extension-handler-xar/pom.xml
@@ -45,6 +45,12 @@
       <artifactId>xwiki-platform-extension-handler-xar</artifactId>
       <version>${project.version}</version>
       <type>pom</type>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xwiki.platform</groupId>
+          <artifactId>xwiki-platform-oldcore</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.xwiki.platform</groupId>
@@ -52,6 +58,20 @@
       <version>${project.version}</version>
       <!-- We don't want to draw this dependency since we're wrapping it. -->
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xwiki.platform</groupId>
+          <artifactId>xwiki-platform-oldcore</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- Used in place of xwiki-platform-oldcore, so that the deprecated APIs that only the legacy version provides
+         are the ones seen by this module. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-legacy-oldcore</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <!-- Needed for backward compatibility Aspects -->
@@ -88,6 +108,35 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+        <configuration>
+          <analysisConfiguration combine.children="append">
+            <revapi.differences>
+              <justification>
+                This module depends on xwiki-platform-legacy-oldcore while the previous version it is compared against
+                depended on xwiki-platform-oldcore. The compared APIs thus differ by the deprecated APIs that the
+                legacy module weaves back in, which are not new APIs. These entries can be dropped once the compared
+                version also depends on xwiki-platform-legacy-oldcore.
+              </justification>
+              <criticality>allowed</criticality>
+              <differences>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.addedToInterface</code>
+                  <new>method void com.xpn.xwiki.objects.classes.PropertyClassInterface::displaySearch(java.lang.StringBuffer, java.lang.String, java.lang.String, com.xpn.xwiki.plugin.query.XWikiCriteria, com.xpn.xwiki.XWikiContext)</new>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.addedToInterface</code>
+                  <new>method com.xpn.xwiki.objects.classes.BaseClass com.xpn.xwiki.objects.CompatibilityObjectInterface::getxWikiClass(com.xpn.xwiki.XWikiContext) throws com.xpn.xwiki.XWikiException @ com.xpn.xwiki.objects.classes.PropertyClassInterface</new>
+                </item>
+              </differences>
+            </revapi.differences>
+          </analysisConfiguration>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-messagestream/xwiki-platform-legacy-messagestream-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-messagestream/xwiki-platform-legacy-messagestream-api/pom.xml
@@ -58,9 +58,10 @@
       <artifactId>xwiki-platform-model-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- We depend on the legacy version of oldcore since this module uses deprecated APIs that only it provides. -->
     <dependency>
       <groupId>org.xwiki.platform</groupId>
-      <artifactId>xwiki-platform-oldcore</artifactId>
+      <artifactId>xwiki-platform-legacy-oldcore</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/api/UserCompatibilityAspect.aj
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/api/UserCompatibilityAspect.aj
@@ -1,0 +1,58 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.api;
+
+import java.text.MessageFormat;
+
+/**
+ * Add a backward compatibility layer to the {@link User} class.
+ *
+ * @version $Id$
+ * @since 18.7.0RC1
+ */
+public privileged aspect UserCompatibilityAspect
+{
+    /**
+     * Check if the user belongs to a group or not. This method only check direct membership (no recursive checking) in
+     * the current wiki.
+     *
+     * @param groupName The group to check.
+     * @return {@code true} if the user does belong to the specified group, false otherwise or if an exception occurs.
+     * @deprecated use the org.xwiki.user.group.GroupManager component instead (or its {@code user.group} script
+     *             service). Unlike this method, it takes a group reference (and is thus not restricted to the current
+     *             wiki) and it can optionally take sub-groups into account
+     */
+    @Deprecated(since = "18.7.0RC1")
+    public boolean User.isUserInGroup(String groupName)
+    {
+        boolean result = false;
+        try {
+            if (this.user == null) {
+                User.LOGGER.warn("User considered not part of group [{}] since user is null", groupName);
+            } else {
+                result = this.user.isUserInGroup(groupName, getXWikiContext());
+            }
+        } catch (Exception ex) {
+            User.LOGGER.warn(new MessageFormat("Unhandled exception while checking if user {0}"
+                + " belongs to group {1}").format(new java.lang.Object[] { this.user, groupName }), ex);
+        }
+        return result;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/user/api/XWikiUserCompatibilityAspect.aj
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/user/api/XWikiUserCompatibilityAspect.aj
@@ -1,0 +1,69 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.user.api;
+
+import java.util.Collection;
+
+import org.apache.commons.lang3.StringUtils;
+import org.xwiki.model.reference.DocumentReference;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+
+/**
+ * Add a backward compatibility layer to the {@link XWikiUser} class.
+ *
+ * @version $Id$
+ * @since 18.7.0RC1
+ */
+public privileged aspect XWikiUserCompatibilityAspect
+{
+    /**
+     * Check if the user belongs to a group or not. This method only check direct membership (no recursive checking) in
+     * the current wiki.
+     *
+     * @param groupName The group to check.
+     * @param context The current {@link XWikiContext context}.
+     * @return {@code true} if the user does belong to the specified group, false otherwise or if an exception occurs.
+     * @throws XWikiException If an error occurs when checking the groups.
+     * @since 1.3
+     * @deprecated use the org.xwiki.user.group.GroupManager component instead. Unlike this method, it takes a group
+     *             reference (and is thus not restricted to the current wiki) and it can optionally take sub-groups
+     *             into account
+     */
+    @Deprecated(since = "18.7.0RC1")
+    public boolean XWikiUser.isUserInGroup(String groupName, XWikiContext context) throws XWikiException
+    {
+        if (!StringUtils.isEmpty(getUser())) {
+            XWikiGroupService groupService = context.getWiki().getGroupService(context);
+
+            DocumentReference groupReference = getCurrentMixedDocumentReferenceResolver().resolve(groupName);
+
+            Collection<DocumentReference> groups =
+                groupService.getAllGroupsReferencesForMember(getUserReference(), 0, 0, context);
+
+            if (groups.contains(groupReference)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/api/UserTest.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/api/UserTest.java
@@ -1,0 +1,59 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.api;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.test.annotation.AllComponents;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
+import com.xpn.xwiki.user.api.XWikiUser;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Unit tests for the deprecated methods of {@link User} that are re-added by
+ * {@code UserCompatibilityAspect}.
+ *
+ * @version $Id$
+ * @since 18.7.0RC1
+ */
+@OldcoreTest
+@AllComponents
+class UserTest
+{
+    /**
+     * Checks that XWIKI-2040 remains fixed.
+     */
+    @Test
+    void isUserInGroupDoesNotThrowNPE()
+    {
+        User u = new User(null, null);
+        assertFalse(u.isUserInGroup("XWiki.InexistentGroupName"));
+
+        XWikiUser xu = new XWikiUser((String) null);
+        u = new User(xu, null);
+        assertFalse(u.isUserInGroup("XWiki.InexistentGroupName"));
+
+        XWikiContext c = new XWikiContext();
+        u = new User(xu, c);
+        assertFalse(u.isUserInGroup("XWiki.InexistentGroupName"));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/User.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/User.java
@@ -19,8 +19,6 @@
  */
 package com.xpn.xwiki.api;
 
-import java.text.MessageFormat;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.model.EntityType;
@@ -104,29 +102,6 @@ public class User extends Api
     public boolean isDisabled()
     {
         return this.user.isDisabled(getXWikiContext());
-    }
-
-    /**
-     * Check if the user belongs to a group or not. This method only check direct membership (no recursive checking) in
-     * the current wiki.
-     *
-     * @param groupName The group to check.
-     * @return {@code true} if the user does belong to the specified group, false otherwise or if an exception occurs.
-     */
-    public boolean isUserInGroup(String groupName)
-    {
-        boolean result = false;
-        try {
-            if (this.user == null) {
-                LOGGER.warn("User considered not part of group [{}] since user is null", groupName);
-            } else {
-                result = this.user.isUserInGroup(groupName, getXWikiContext());
-            }
-        } catch (Exception ex) {
-            LOGGER.warn(new MessageFormat("Unhandled exception while checking if user {0}"
-                + " belongs to group {1}").format(new java.lang.Object[] { this.user, groupName }), ex);
-        }
-        return result;
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/api/XWikiUser.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/api/XWikiUser.java
@@ -19,10 +19,8 @@
  */
 package com.xpn.xwiki.user.api;
 
-import java.util.Collection;
 import java.util.Objects;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.localization.ContextualLocalizationManager;
@@ -400,34 +398,6 @@ public class XWikiUser
 
         this.userReference = null;
         this.userReferenceSet = false;
-    }
-
-    /**
-     * Check if the user belongs to a group or not. This method only check direct membership (no recursive checking) in
-     * the current wiki.
-     *
-     * @param groupName The group to check.
-     * @param context The current {@link XWikiContext context}.
-     * @return {@code true} if the user does belong to the specified group, false otherwise or if an exception occurs.
-     * @throws XWikiException If an error occurs when checking the groups.
-     * @since 1.3
-     */
-    public boolean isUserInGroup(String groupName, XWikiContext context) throws XWikiException
-    {
-        if (!StringUtils.isEmpty(getUser())) {
-            XWikiGroupService groupService = context.getWiki().getGroupService(context);
-
-            DocumentReference groupReference = getCurrentMixedDocumentReferenceResolver().resolve(groupName);
-
-            Collection<DocumentReference> groups =
-                groupService.getAllGroupsReferencesForMember(getUserReference(), 0, 0, context);
-
-            if (groups.contains(groupReference)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/api/UserTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/api/UserTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.test.annotation.AllComponents;
 
-import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.objects.classes.BaseClass;
@@ -33,7 +32,6 @@ import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
 import com.xpn.xwiki.user.api.XWikiUser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
@@ -47,24 +45,6 @@ class UserTest
 {
     @InjectMockitoOldcore
     private MockitoOldcore oldcore;
-
-    /**
-     * Checks that XWIKI-2040 remains fixed.
-     */
-    @Test
-    void isUserInGroupDoesNotThrowNPE()
-    {
-        User u = new User(null, null);
-        assertFalse(u.isUserInGroup("XWiki.InexistentGroupName"));
-
-        XWikiUser xu = new XWikiUser((String)null);
-        u = new User(xu, null);
-        assertFalse(u.isUserInGroup("XWiki.InexistentGroupName"));
-
-        XWikiContext c = new XWikiContext();
-        u = new User(xu, c);
-        assertFalse(u.isUserInGroup("XWiki.InexistentGroupName"));
-    }
 
     @Test
     void getEmail() throws Exception

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getusersandgroups.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getusersandgroups.vm
@@ -177,8 +177,11 @@ $response.setContentType("application/json")
     #set($discard = $row.put("userDisplayer",
       "#displayGroup($user.documentReference, {'displayLink': $isLocalUser, 'showAlias': true})"))
   #end
-  #if ($uorg == "groups")
-    #set($discard = $row.put("isuseringroup", $xwiki.getUser().isUserInGroup($user.fullName)))
+  ## Only direct members are considered, so that a user listed as a member of a sub-group of this group is not reported
+  ## as a member of this group.
+  #if ($uorg == "groups" && $xcontext.userReference)
+    #set($discard = $row.put("isuseringroup",
+      $services.user.group.getMembers($user.documentReference, false).contains($xcontext.userReference)))
   #else
     #set($discard = $row.put("isuseringroup", false))
   #end


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22786

# Changes

## Description

* Deprecate `com.xpn.xwiki.api.User#isUserInGroup(String)` and
  `com.xpn.xwiki.user.api.XWikiUser#isUserInGroup(String, XWikiContext)` (`@Deprecated(since = "18.7.0RC1")`), and move
  them out of `xwiki-platform-oldcore` into `xwiki-platform-legacy-oldcore`, which re-adds them by weaving oldcore with
  two new privileged inter-type declaration aspects (`UserCompatibilityAspect`, `XWikiUserCompatibilityAspect`).
* Migrate the only non-legacy caller, `getusersandgroups.vm`, to the `user.group` script service.
* Move the `isUserInGroupDoesNotThrowNPE` test from oldcore's `UserTest` to a new `UserTest` in legacy-oldcore.
* Make `xwiki-platform-legacy-messagestream-api` and `xwiki-platform-legacy-extension-handler-xar` depend on
  `xwiki-platform-legacy-oldcore` instead of `xwiki-platform-oldcore`.

## Clarifications

* **Why deprecate rather than fix the implementation.** The issue offered both. `XWikiUser#isUserInGroup` is not stuck
  on a deprecated API — it is stuck on a deliberately non-recursive, current-wiki-only *contract*, documented as such in
  both Javadocs. "Fixing" it would mean making it recursive, silently changing behaviour for every existing caller. The
  signature is unfixable anyway (a `String` group name carries no wiki, a `boolean` return cannot report errors), which
  is why XWIKI-12292 was closed as won't-fix.
* **No behaviour change intended.** Callers were migrated with `recurse = false` to preserve the current semantics.
* **The Javadoc names `org.xwiki.user.group.GroupManager` as prose, not as a `{@link}`**, because oldcore has no
  dependency on `xwiki-platform-user-api`. This matches the existing `RightsManager` precedent in oldcore.
* **`GroupMessageStreamNotificationFilter` is deliberately left calling the deprecated method.** It is itself legacy
  code, and legacy code calling a legacy API is the point rather than a problem — rewriting it would risk breaking
  working code for no benefit. Only its module's dependency was swapped.
* **One behaviour difference worth reviewing.** In `getusersandgroups.vm`, the old code resolved `$user.fullName`
  (unprefixed, e.g. `XWiki.XWikiAdminGroup`) with the current-wiki resolver, while the new code passes
  `$user.documentReference`. These differ only when a subwiki lists **global** groups: the old code checked the *local*
  group of the same name (a latent bug), the new code checks the real global group. The correct behaviour was chosen
  deliberately, but it is a deviation from a strictly zero-delta change. Happy to make it byte-faithful instead (via
  `$services.model.resolveDocument($user.fullName)`) if preferred.
* **On the Revapi configuration.** `xwiki-platform-oldcore` skips Revapi because `xwiki-platform-legacy-oldcore` wraps
  it and runs the check on the woven jar, which still exposes both methods. Modules *depending* on oldcore are checked
  against the unwoven jar though, and `xwiki-platform-legacy-extension-handler-xar` turned out to be the one module
  exposing both classes in its own API, so it reported the two methods as removed. It now depends on legacy-oldcore too.
  That comparison is asymmetric until the next release, since 18.5.0 still depends on the unwoven jar — hence the two
  ignores in that module's pom for inter-type declarations that only the woven jar has. They can be dropped once the
  compared-against version also depends on legacy-oldcore.
* **A convenience API is wanted but out of scope here.** `GroupManager` has no `isMember`, so the replacement idiom is
  `getMembers(group, false).contains(member)` — verbose next to the one-liner it replaces. A proposal to add
  `GroupManager#isMember(member, group, recurse)` as a `default` method will go to the forum separately; this PR
  deliberately adds no new API.

# Screenshots & Video

No intended UI change. `getusersandgroups.vm` feeds the Rights administration livetable; the `isuseringroup` flag it
produces is consumed only by `usersandgroups.js`, which uses it to show a confirmation dialog when you deny or clear a
right on a group you belong to. That behaviour is unchanged except in the subwiki/global-group case described above.

# Executed Tests

## Unit tests, Checkstyle, Revapi, JaCoCo

```bash
# oldcore + legacy-oldcore + the legacy messagestream caller (68 tests in messagestream)
mvn clean install -B -ntp -Plegacy,quality \
  -pl xwiki-platform-core/xwiki-platform-oldcore,\
xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore,\
xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-messagestream/xwiki-platform-legacy-messagestream-api

# the legacy module whose Revapi check needed the dependency swap
mvn clean install -B -ntp -Plegacy,quality \
  -pl xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-extension-handler-xar
```

Both BUILD SUCCESS, with Checkstyle, JaCoCo and Revapi green (`-Pquality` is what runs Revapi and the JaCoCo check).

Verified with `javap` that the move actually happened: `com.xpn.xwiki.api.User` and `com.xpn.xwiki.user.api.XWikiUser`
in oldcore's jar no longer declare `isUserInGroup`, while the same classes in the woven legacy-oldcore jar do.

An exhaustive `grep` for `isUserInGroup`/`isuseringroup` leaves only the two declarations, the internal delegation, the
legacy messagestream filter, and unrelated JS/JSON field names.

## Functional (Docker) tests

`UsersGroupsRightsManagementIT` is the one IT that exercises `getusersandgroups.vm` end to end: `rightsUI.vm` fetches
`xpage=getusersandgroups` to populate the `usersandgroupstable` livetable, and `EditRightsPane` (plus its
`RightsEditPage` subclass) drives that table. The Users & Groups *administration* tables have since moved to Live Data
and no longer use this template, so the Rights UI is the only remaining consumer.

```bash
mvn verify -B -ntp -Plegacy,integration-tests,docker \
  -f xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker \
  -Dit.test=UsersGroupsRightsManagementIT
```

**Tests run: 17, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS** (`hsqldb_embedded` / `jetty_standalone` /
`firefox`). This covers `rightsShowUsersAndGroups` (which asserts the `usersandgroupstable` renders both users and
groups, at wiki level and at page level), `groupRights`, `allowGroupRightsAtPageLevelWhenUserRightDeniedAtWikiLevel`,
`renameUserUpdatesGroupAndRights`, `renameGroupUpdatesGroupsAndRights`, `setExtensionRightsForPage{Only,AndChildren}`
and the group/user create-edit-delete tests. The XWiki server log for the run contains no Velocity error, no
`GroupException` and no unresolved-method warning from the template.

Two notes on how this was verified, since both are easy to get wrong when reproducing locally:

* **The template reaches the test WAR through the `xwiki-platform-web-war` overlay, not through
  `xwiki-platform-web-templates`.** Installing only the changed modules is not enough — `xwiki-platform-web-war` must be
  rebuilt and installed too, and the framework's cached expanded WAR
  (`target/<db>-<servlet>-<browser>/jetty/webapps/xwiki`) deleted, or the run silently uses the previous snapshot's
  template. I confirmed on the actual deployed WAR that `templates/getusersandgroups.vm` contained the new
  `$services.user.group.getMembers(...)` code and that the deployed `xwiki-platform-oldcore` jar no longer declares
  `isUserInGroup`.
* **The Docker framework's minimal WAR contains plain `oldcore`, not `legacy-oldcore`.** So this IT runs against a
  runtime where the method is genuinely gone, which is exactly what makes it a meaningful check of the template
  migration. The flip side is that no IT exercises the legacy aspects at runtime; those are covered by the `UserTest`
  moved into legacy-oldcore and by Revapi on the woven jar.

**Not run:** the Users & Groups / Rights administration UI was not additionally checked by hand in a browser, and no IT
asserts the `isuseringroup` value itself (it only drives a client-side confirmation dialog), so the subwiki/global-group
difference described above is not covered by an automated test.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None — this is an API deprecation targeting 18.7.0RC1.
