### PR TITLE
[Misc] Fix a NullPointerException reported by SonarQube in XWiki#parseTemplate()

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -2620,10 +2620,13 @@ public class XWiki implements EventListener
     {
         MutableRenderingContext mutableRenderingContext = getMutableRenderingContext();
 
-        Syntax currentTargetSyntax = mutableRenderingContext.getTargetSyntax();
+        Syntax currentTargetSyntax =
+            mutableRenderingContext != null ? mutableRenderingContext.getTargetSyntax() : null;
         try {
-            // Force rendering with XHTML 1.0 syntax for retro-compatibility
-            mutableRenderingContext.setTargetSyntax(Syntax.XHTML_1_0);
+            if (mutableRenderingContext != null) {
+                // Force rendering with XHTML 1.0 syntax for retro-compatibility
+                mutableRenderingContext.setTargetSyntax(Syntax.XHTML_1_0);
+            }
 
             Skin skin = getInternalSkinManager().getSkin(skinId);
             return getTemplateManager().renderFromSkin(template, skin);
@@ -2637,7 +2640,9 @@ public class XWiki implements EventListener
 
             return Util.getHTMLExceptionMessage(xe, context);
         } finally {
-            mutableRenderingContext.setTargetSyntax(currentTargetSyntax);
+            if (mutableRenderingContext != null) {
+                mutableRenderingContext.setTargetSyntax(currentTargetSyntax);
+            }
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/XWikiTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/XWikiTest.java
@@ -49,6 +49,7 @@ import org.xwiki.query.QueryExecutor;
 import org.xwiki.refactoring.ReferenceRenamer;
 import org.xwiki.refactoring.internal.ReferenceUpdater;
 import org.xwiki.rendering.syntax.Syntax;
+import org.xwiki.rendering.transformation.RenderingContext;
 import org.xwiki.rendering.wiki.WikiModel;
 import org.xwiki.test.annotation.AfterComponent;
 import org.xwiki.test.annotation.AllComponents;
@@ -311,6 +312,30 @@ class XWikiTest
         assertFalse(this.xwiki.getDocument(mySkinReference, this.oldcore.getXWikiContext()).isNew());
         assertEquals(skinDocument, this.xwiki.getDocument(mySkinReference, this.oldcore.getXWikiContext()));
         assertEquals("parsing a field", this.xwiki.parseTemplate("template.vm", this.oldcore.getXWikiContext()));
+    }
+
+    @Test
+    void parseTemplateFromSkinWhenRenderingContextIsNotMutable() throws Exception
+    {
+        // A RenderingContext which is not a MutableRenderingContext, i.e. for which the target syntax cannot be
+        // forced to XHTML 1.0.
+        this.oldcore.getMocker().registerMockComponent(RenderingContext.class);
+
+        DocumentReference skinReference =
+            new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "XWiki", "XWikiSkins");
+        XWikiDocument skinClass = new XWikiDocument(skinReference);
+        skinClass.getXClass().addTextAreaField("template.vm", "template", 80, 20);
+        this.xwiki.saveDocument(skinClass, this.oldcore.getXWikiContext());
+
+        DocumentReference mySkinReference =
+            new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "XWiki", "Skin");
+        XWikiDocument skinDocument = new XWikiDocument(mySkinReference);
+        BaseObject obj = skinDocument.newXObject(skinReference, this.oldcore.getXWikiContext());
+        obj.setLargeStringValue("template.vm", "parsing a field");
+        this.xwiki.saveDocument(skinDocument, this.oldcore.getXWikiContext());
+
+        assertEquals("parsing a field",
+            this.xwiki.parseTemplate("template.vm", "XWiki.Skin", this.oldcore.getXWikiContext()));
     }
 
     @Test


### PR DESCRIPTION
## Problem

SonarCloud issue [AZ-AMvTBpN28pifR1L_l](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&open=AZ-AMvTBpN28pifR1L_l) (`javabugs:S2259`, MAJOR): *Fix this access that will throw a NullPointerException when executed.*

`XWiki#getMutableRenderingContext()` returns `null` when the `RenderingContext` component is not a `MutableRenderingContext`, but its only caller, `parseTemplate(String template, String skinId, XWikiContext context)`, dereferenced it unconditionally — both when reading the current target syntax and when restoring it in the `finally` block.

## Solution

Guard both accesses with a null check, so that when the rendering context is not mutable the template is still rendered, simply without forcing the XHTML 1.0 target syntax. This mirrors the pattern already used in `XWikiAction#renderInit()` in the same module.

## Verification

Added `XWikiTest#parseTemplateFromSkinWhenRenderingContextIsNotMutable`, which registers a non-mutable `RenderingContext` and renders a skin template. Without the fix it fails with exactly the NPE SonarCloud reports; with the fix the template renders. `mvn test -Dtest=XWikiTest` passes in `xwiki-platform-oldcore` (43 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)