### PR TITLE
[stable-17.10.x] [Misc] Fix the SonarQube-reported NPE risks blocking the quality gate

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/DefaultLiveDataConfigurationResolver.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/DefaultLiveDataConfigurationResolver.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -184,10 +185,18 @@ public class DefaultLiveDataConfigurationResolver implements LiveDataConfigurati
 
     private LiveDataConfiguration translate(LiveDataConfiguration config)
     {
-        config.getMeta().getLayouts().stream().filter(Objects::nonNull).forEach(this::translate);
-        config.getMeta().getFilters().stream().filter(Objects::nonNull).forEach(this::translate);
-        config.getMeta().getActions().stream().filter(Objects::nonNull).forEach(this::translate);
+        LiveDataMeta meta = config.getMeta();
+        if (meta != null) {
+            streamNonNull(meta.getLayouts()).forEach(this::translate);
+            streamNonNull(meta.getFilters()).forEach(this::translate);
+            streamNonNull(meta.getActions()).forEach(this::translate);
+        }
         return config;
+    }
+
+    private <T> Stream<T> streamNonNull(Collection<T> collection)
+    {
+        return collection == null ? Stream.empty() : collection.stream().filter(Objects::nonNull);
     }
 
     private void translate(LiveDataLayoutDescriptor layout)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -7737,6 +7737,10 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         com.xpn.xwiki.XWiki xwiki = context.getWiki();
         String language = "";
         XWikiDocument tdoc = (XWikiDocument) context.get(CKEY_TDOC);
+        // Fall back to this document when no translated document is set in the context.
+        if (tdoc == null) {
+            tdoc = this;
+        }
         String realLang = tdoc.getRealLanguage(context);
         if ((xwiki.isMultiLingual(context) == true) && (!realLang.equals(""))) {
             language = realLang;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -5484,7 +5484,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         DocumentInstanceOutputProperties documentProperties = new DocumentInstanceOutputProperties();
         XWikiContext xcontext = getXWikiContext();
         if (xcontext != null) {
-            documentProperties.setDefaultReference(getXWikiContext().getWikiReference());
+            documentProperties.setDefaultReference(xcontext.getWikiReference());
         }
 
         // Input

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -73,6 +73,7 @@ import org.dom4j.Element;
 import org.dom4j.dom.DOMDocument;
 import org.dom4j.io.DocumentResult;
 import org.dom4j.io.OutputFormat;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.suigeneris.jrcs.diff.Diff;
@@ -4876,12 +4877,13 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
      */
     private void copyAttachment(XWikiAttachment attachment, boolean reset) throws XWikiException
     {
-        XWikiAttachment newAttachment = attachment.cloneWithActualContent(getXWikiContext());
+        XWikiContext xcontext = getXWikiContext();
+        XWikiAttachment newAttachment = attachment.cloneWithActualContent(xcontext);
 
         if (reset) {
             // Reset the meta data that is specific to the original attachment (version, author, date).
             newAttachment.setRCSVersion(null);
-            newAttachment.setAuthorReference(getXWikiContext().getUserReference());
+            newAttachment.setAuthorReference(xcontext == null ? null : xcontext.getUserReference());
             newAttachment.setDate(new Date());
         }
 
@@ -8461,6 +8463,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
      *
      * @return the XWiki context for the current thread
      */
+    @Nullable
     private XWikiContext getXWikiContext()
     {
         Provider<XWikiContext> xcontextProvider = Utils.getComponent(XWikiContext.TYPE_PROVIDER);
@@ -9010,6 +9013,9 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
 
     public static void backupContext(Map<String, Object> backup, XWikiContext context)
     {
+        // There's nothing to back up without a context and all the data below is read from it.
+        Objects.requireNonNull(context);
+
         // The XWiki Context isn't recreated when the Execution Context is cloned so we have to backup some of its data.
         // Backup the current document on the XWiki Context.
         backup.put("doc", context.getDoc());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactory.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -63,6 +64,9 @@ public class FileSystemURLFactory extends XWikiServletURLFactory
 
     /** Segment separator used in the collision-free key generation. */
     private static final char SEPARATOR = '/';
+
+    /** Context key under which the resource-key-to-temporary-file mapping is stored during the export. */
+    private static final String FILE_MAPPING_KEY = "pdfexport-file-mapping";
 
     private LegacySpaceResolver legacySpaceResolver = Utils.getComponent(LegacySpaceResolver.class);
 
@@ -320,15 +324,21 @@ public class FileSystemURLFactory extends XWikiServletURLFactory
     }
 
     /**
-     * Retrieve the Map that relates resource keys to their corresponding temporary file.
+     * Retrieve the Map that relates resource keys to their corresponding temporary file, creating and storing it in the
+     * context when it's not there yet so that callers can always rely on a non-null, mutable mapping whose entries
+     * persist in the context.
      *
      * @param context the current request context
-     * @return the mapping as it was found in the context (read-write)
+     * @return the mapping stored in the context (read-write)
      */
     private Map<String, File> getFileMapping(XWikiContext context)
     {
         @SuppressWarnings("unchecked")
-        Map<String, File> usedFiles = (Map<String, File>) context.get("pdfexport-file-mapping");
+        Map<String, File> usedFiles = (Map<String, File>) context.get(FILE_MAPPING_KEY);
+        if (usedFiles == null) {
+            usedFiles = new HashMap<>();
+            context.put(FILE_MAPPING_KEY, usedFiles);
+        }
         return usedFiles;
     }
 

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-async/xwiki-platform-rendering-async-default/src/main/java/org/xwiki/rendering/async/internal/AsyncRendererCacheListener.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-async/xwiki-platform-rendering-async-default/src/main/java/org/xwiki/rendering/async/internal/AsyncRendererCacheListener.java
@@ -126,7 +126,9 @@ public class AsyncRendererCacheListener extends AbstractEventListener
                 obj = document.getXObject(objectEvent.getReference());
             }
 
-            this.cache.cleanCache(obj.getXClassReference());
+            if (obj != null) {
+                this.cache.cleanCache(obj.getXClassReference());
+            }
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/SchedulerPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/SchedulerPlugin.java
@@ -365,6 +365,10 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
 
     private void register(BaseObject jobObj, XWikiContext context) throws SchedulerPluginException
     {
+        if (jobObj == null) {
+            return;
+        }
+
         String status = jobObj.getStringValue("status");
         if (status.equals(JobState.STATE_NORMAL) || status.equals(JobState.STATE_PAUSED)) {
             scheduleJob(jobObj, context);

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/script/WysiwygEditorScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/script/WysiwygEditorScriptService.java
@@ -301,8 +301,11 @@ public class WysiwygEditorScriptService implements ScriptService
     @Deprecated
     public String toAnnotatedXHTML(String source, String syntaxId)
     {
-        XWikiContext xwikiContext = this.xcontextProvider.get();
-        return toAnnotatedXHTML(source, getSyntax(syntaxId), xwikiContext.getDoc().getDocumentReference());
+        XWikiDocument currentDocument = this.xcontextProvider.get().getDoc();
+        // Pass a null source reference when there's no current document and let the overload below handle it, so that
+        // the null case is handled in a single place.
+        EntityReference sourceReference = currentDocument == null ? null : currentDocument.getDocumentReference();
+        return toAnnotatedXHTML(source, getSyntax(syntaxId), sourceReference);
     }
 
     /**
@@ -336,6 +339,12 @@ public class WysiwygEditorScriptService implements ScriptService
      */
     public String toAnnotatedXHTML(String source, Syntax syntax, EntityReference sourceReference, boolean restricted)
     {
+        if (sourceReference == null) {
+            // Without a source reference, we can't resolve either the author to execute as, or the document to convert
+            // against. Thus we return the source unchanged, as is also done when the conversion fails below.
+            return source;
+        }
+
         XWikiDocument securityDocument = createSecurityDocument();
         XWikiDocument originalSecurityDocument = setSecurityDocument(securityDocument);
 


### PR DESCRIPTION
Backport of the SonarQube quality-gate fixes from `master` to `stable-17.10.x`.

## Why

The `stable-17.10.x` quality gate is red on two conditions:

| Condition | Threshold | Actual |
|---|---|---|
| `new_reliability_rating` | A | **C** |
| `new_security_rating` | A | **B** |

The reliability side is caused by exactly 4 new-code bugs, all `javabugs:S2259` (NPE) in
`XWikiDocument`:

| Line (17.10.x) | Method |
|---|---|
| 4884 | `copyAttachment` — `getXWikiContext().getUserReference()` on a nullable context |
| 5487 | `fromXML` — `getXWikiContext().getWikiReference()` re-called instead of the already null-checked local |
| 7740 | `getEditURL` — translated document taken from the context and dereferenced unchecked |
| 9011 | `backupContext` — `context.getDoc()` dereferenced unchecked |

All four are resolved as FIXED on `master`. This backports the three commits that fixed them.

The security side is not a code issue: the two `javasecurity:S5145` findings in
`ExtensionVersionFileRESTResource` were reviewed and marked Accepted on `master`, and that file is
byte-identical on both branches. They have now been marked Accepted on `stable-17.10.x` as well, so
there is nothing to backport for them.

## Cherry-picked commits

- `630fe598748` [Misc] Fix sonarqube-reported issues that block the quality gate
- `d33553c3cc4` [Misc] Fix additional SonarQube-reported NPE risks blocking the quality gate
- `de737018e98` [Misc] Fix remaining SonarQube-reported NPE risks blocking the quality gate

The `XWikiDocument` changes are byte-identical to master's.

## Adaptations to this branch

- **`SchedulerPlugin`**: uses the `"status"` literal instead of the `STATUS` constant, which this
  branch does not declare.
- **`DefaultLiveDataConfigurationResolver`**: kept the existing `Collectors` import alongside the
  new `Stream` one — this branch still uses `Collectors` elsewhere in the file.
- **The three JavaScript files** touched by `630fe598748` (`attachments.js`, `locationPicker.js`,
  `upload.js`) are **left out**. On this branch they are still in their pre-ES6 Prototype.js form,
  so the lines the original commit rewrote either do not exist here or sit in a differently-shaped
  function. Their changes are cosmetic rule cleanups (`parseInt` -> `Number.parseInt`,
  `replace` -> `replaceAll`) and play no part in this branch's quality gate.

The `@Nullable` on `XWikiDocument#getXWikiContext()` is kept: it is what lets the analyzer see the
`copyAttachment` guard as a fix, and `org.jspecify:jspecify:1.0.0` is already on oldcore's compile
classpath on this branch transitively.

## Verification

All 5 touched modules `test-compile` cleanly with **JDK 17** (this branch's Java level; master
targets 21), 0 errors:

- `xwiki-platform-livedata-api`
- `xwiki-platform-oldcore`
- `xwiki-platform-rendering-async-default`
- `xwiki-platform-scheduler-api`
- `xwiki-platform-wysiwyg-api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
