### PR TITLE
[Misc] Remove the obsolete "functional-test" packaging TODO from the functional test poms

### DIFF
--- a/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-test/xwiki-platform-activeinstalls2-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-test/xwiki-platform-activeinstalls2-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-activeinstalls2-test-docker</artifactId>
   <name>XWiki Platform - Active Installs 2 - Tests - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - Active Installs 2 - Tests - Functional Tests in Docker</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-administration-test-docker</artifactId>
   <name>XWiki Platform - Administration - Tests - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - Administration - Tests - Functional Tests in Docker</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-test/xwiki-platform-annotation-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-test/xwiki-platform-annotation-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-annotation-test-docker</artifactId>
   <name>XWiki Platform - Annotation - Test - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - Annotation - Functional Tests in Docker</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-appwithinminutes-test-docker</artifactId>
   <name>XWiki Platform - AppWithinMinutes - Tests - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - AppWithinMinutes - Tests - Functional Tests in Docker</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-picker/xwiki-platform-attachment-picker-test/xwiki-platform-attachment-picker-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-picker/xwiki-platform-attachment-picker-test/xwiki-platform-attachment-picker-test-docker/pom.xml
@@ -30,8 +30,6 @@
   <artifactId>xwiki-platform-attachment-picker-test-docker</artifactId>
   <name>XWiki Platform - Attachment - Picker - Tests - Functional Tests in Docker</name>
   <description>XWiki Platform - Attachment - Picker - Tests - Functional Tests in Docker</description>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <properties>
     <!-- Functional tests are allowed to output content to the console -->

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-test/xwiki-platform-attachment-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-test/xwiki-platform-attachment-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-attachment-test-docker</artifactId>
   <name>XWiki Platform - Attachment - Tests - Functional Tests in Docker</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <description>XWiki Platform - Attachment - Tests - Functional Tests in Docker</description>
   <packaging>jar</packaging>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-validation/xwiki-platform-attachment-validation-test/xwiki-platform-attachment-validation-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-validation/xwiki-platform-attachment-validation-test/xwiki-platform-attachment-validation-test-docker/pom.xml
@@ -30,8 +30,6 @@
   <artifactId>xwiki-platform-attachment-validation-test-docker</artifactId>
   <name>XWiki Platform - Attachment - Validation - Tests - Functional Tests in Docker</name>
   <description>XWiki Platform - Attachment - Validation - Tests - Functional Tests in Docker</description>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <properties>
     <!-- Functional tests are allowed to output content to the console -->

--- a/xwiki-platform-core/xwiki-platform-blocknote/xwiki-platform-blocknote-test/xwiki-platform-blocknote-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-blocknote/xwiki-platform-blocknote-test/xwiki-platform-blocknote-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-blocknote-test-docker</artifactId>
   <name>XWiki Platform - BlockNote Integration - Tests - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>Functional Docker Tests for the BlockNote Integration</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-ckeditor-test-docker</artifactId>
   <name>XWiki Platform - CKEditor - Tests - Docker</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see http://jira.xwiki.org/jira/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <properties>
     <!-- Functional tests are allowed to output content to the console -->

--- a/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-test/xwiki-platform-dashboard-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-test/xwiki-platform-dashboard-test-docker/pom.xml
@@ -30,8 +30,6 @@
   <artifactId>xwiki-platform-dashboard-test-docker</artifactId>
   <name>XWiki Platform - Dashboard - Test - Functional Docker Tests</name>
   <description>XWiki Platform - Dashboard - Test - Functional Docker Tests</description>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-        see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <properties>
     <!-- Functional tests are allowed to output content to the console -->

--- a/xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-test/xwiki-platform-edit-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-test/xwiki-platform-edit-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-edit-test-docker</artifactId>
   <name>XWiki Platform - Edit - Tests - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>Docker-based functional tests for the Edit module.</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-test/xwiki-platform-export-pdf-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-test/xwiki-platform-export-pdf-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-export-pdf-test-docker</artifactId>
   <name>XWiki Platform - Export - PDF - Test - Functional Tests in Docker</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>Functional Docker-based tests for PDF Export</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-test/xwiki-platform-filter-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-test/xwiki-platform-filter-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-filter-test-docker</artifactId>
   <name>XWiki Platform - Filter - Tests - Functional Tests in Docker</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <description>XWiki Platform - Filter - Tests - Functional Tests in Docker</description>
   <packaging>jar</packaging>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-flamingo-skin-test-docker</artifactId>
   <name>XWiki Platform - Flamingo - Skin - Test - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - Flamingo - Skin - Functional Tests in Docker</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-flamingo-theme-test-docker</artifactId>
   <name>XWiki Platform - Flamingo - Theme - Tests  - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - Flamingo - Theme - Tests  - Functional Tests in Docker</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-test/xwiki-platform-help-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-test/xwiki-platform-help-test-docker/pom.xml
@@ -28,8 +28,6 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>xwiki-platform-help-test-docker</artifactId>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <name>XWiki Platform - Help - Tests - Functional Docker Tests</name>
   <description>XWiki Platform - Help - Tests - Functional Tests in Docker</description>

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-test/xwiki-platform-icon-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-test/xwiki-platform-icon-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-icon-test-docker</artifactId>
   <name>XWiki Platform - Icon - Tests - Functional Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-         see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - Icon - Tests - Functional Tests</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-image-lightbox-test-docker</artifactId>
   <name>XWiki Platform - Image - Lightbox - Tests - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see http://jira.xwiki.org/jira/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <properties>
     <!-- Functional tests are allowed to output content to the console -->

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-test/xwiki-platform-image-style-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-test/xwiki-platform-image-style-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-image-style-test-docker</artifactId>
   <name>XWiki Platform - Image - Style - Tests - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see http://jira.xwiki.org/jira/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <properties>
     <!-- Functional tests are allowed to output content to the console -->

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-index-test-docker</artifactId>
   <name>XWiki Platform - Index - Tests - Functional Tests in Docker</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <description>XWiki Platform - Index - Tests - Functional Tests in Docker</description>
   <packaging>jar</packaging>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-test/xwiki-platform-invitation-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-test/xwiki-platform-invitation-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-invitation-test-docker</artifactId>
   <name>XWiki Platform - Invitation - Test - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - Invitation - Test - Functional Tests in Docker</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-test/xwiki-platform-like-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-test/xwiki-platform-like-test-docker/pom.xml
@@ -27,8 +27,6 @@
   </parent>
   <artifactId>xwiki-platform-like-test-docker</artifactId>
   <name>XWiki Platform - Like - Test - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>Functional docker tests for the Like Application.</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-linkchecker/xwiki-platform-linkchecker-test/xwiki-platform-linkchecker-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-linkchecker/xwiki-platform-linkchecker-test/xwiki-platform-linkchecker-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-linkchecker-test-docker</artifactId>
   <name>XWiki Platform - LinkChecker - Tests - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>Functional Docker tests for the Link Checker feature.</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-livedata-test-docker</artifactId>
   <name>XWiki Platform - Live Data - Tests - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>Functional Docker Tests for the Live Data Application</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-test/xwiki-platform-localization-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-test/xwiki-platform-localization-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-localization-test-docker</artifactId>
   <name>XWiki Platform - Localization - Tests - Functional Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - Localization - Tests - Functional Tests</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-test/xwiki-platform-logging-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-test/xwiki-platform-logging-test-docker/pom.xml
@@ -30,8 +30,6 @@
   <artifactId>xwiki-platform-logging-test-docker</artifactId>
   <name>XWiki Platform - Logging - Tests - Functional Tests in Docker</name>
   <description>XWiki Platform - Logging - Tests - Functional Tests in Docker</description>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <properties>
     <!-- Functional tests are allowed to output content to the console -->

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-test/xwiki-platform-mail-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-test/xwiki-platform-mail-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-mail-test-docker</artifactId>
   <name>XWiki Platform - Mail - Tests - Functional Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - Mail - Tests - Functional Tests in Docker</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-test/xwiki-platform-mentions-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-test/xwiki-platform-mentions-test-docker/pom.xml
@@ -27,8 +27,6 @@
   </parent>
   <artifactId>xwiki-platform-mentions-test-docker</artifactId>
   <name>XWiki Platform - Mentions - Test - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>Functional docker tests for the Mentions Application.</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-test/xwiki-platform-menu-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-test/xwiki-platform-menu-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-menu-test-docker</artifactId>
   <name>XWiki Platform - Menu - Tests - Functional Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - Menu - Functional Tests in Docker</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/xwiki-platform-model-validation-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/xwiki-platform-model-validation-test-docker/pom.xml
@@ -30,8 +30,6 @@
   <artifactId>xwiki-platform-model-validation-test-docker</artifactId>
   <name>XWiki Platform - Model - Validation - Tests - Functional Tests in Docker</name>
   <description>XWiki Platform - Model - Validation - Tests - Functional Tests in Docker</description>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <properties>
     <!-- Functional tests are allowed to output content to the console -->

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/pom.xml
@@ -28,8 +28,6 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>xwiki-platform-panels-test-docker</artifactId>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <name>XWiki Platform - Panels - Tests - Functional Docker Tests</name>
   <description>XWiki Platform - Panels - Tests - Functional Tests in Docker</description>

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wiki/xwiki-platform-realtime-wiki-test/xwiki-platform-realtime-wiki-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wiki/xwiki-platform-realtime-wiki-test/xwiki-platform-realtime-wiki-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-realtime-wiki-test-docker</artifactId>
   <name>XWiki Platform - Realtime - Wiki - Test - Functional Tests in Docker</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>Functional Docker-based tests for the Realtime Wiki Editor</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wysiwyg/xwiki-platform-realtime-wysiwyg-test/xwiki-platform-realtime-wysiwyg-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wysiwyg/xwiki-platform-realtime-wysiwyg-test/xwiki-platform-realtime-wysiwyg-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-realtime-wysiwyg-test-docker</artifactId>
   <name>XWiki Platform - Realtime - WYSIWYG - Test - Functional Tests in Docker</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>Functional Docker-based tests for the Realtime WYSIWYG Editor</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-release/xwiki-platform-release-test/xwiki-platform-release-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-release/xwiki-platform-release-test/xwiki-platform-release-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-release-test-docker</artifactId>
   <name>XWiki Platform - Release - Test - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>Functional docker tests for the Release Application.</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-test/xwiki-platform-resource-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-test/xwiki-platform-resource-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-resource-test-docker</artifactId>
   <name>XWiki Platform - Resource - Tests - Functional Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>Tests for the Resource feature</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-rest-test-docker</artifactId>
   <name>XWiki Platform - REST - Tests - Functional Tests in Docker</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <description>XWiki Platform - REST - Tests - Functional Tests in Docker</description>
   <packaging>jar</packaging>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-test/xwiki-platform-scheduler-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-test/xwiki-platform-scheduler-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-scheduler-test-docker</artifactId>
   <name>XWiki Platform - Scheduler - Tests - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - Scheduler - Tests - Functional Tests in Docker</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-test/xwiki-platform-security-authentication-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-test/xwiki-platform-security-authentication-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-security-authentication-test-docker</artifactId>
   <name>XWiki Platform - Security - Authentication - Tests - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - Security - Authentication - Tests - Functional Tests in Docker</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-test/xwiki-platform-security-requiredrights-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-test/xwiki-platform-security-requiredrights-test-docker/pom.xml
@@ -28,8 +28,6 @@
   </parent>
   <artifactId>xwiki-platform-security-requiredrights-test-docker</artifactId>
   <name>XWiki Platform - Security - Required Rights - Tests - Functional Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - Security - Required Rights - Tests - Functional Tests</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-sharepage/xwiki-platform-sharepage-test/xwiki-platform-sharepage-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-sharepage/xwiki-platform-sharepage-test/xwiki-platform-sharepage-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-sharepage-test-docker</artifactId>
   <name>XWiki Platform - Share Page - Tests - Functional Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - Share Page - Functional Tests in Docker</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-test/xwiki-platform-skin-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-test/xwiki-platform-skin-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-skin-test-docker</artifactId>
   <name>XWiki Platform - Skin - Tests - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - Skin - Tests - Functional Tests in Docker</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-test/xwiki-platform-tag-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-test/xwiki-platform-tag-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-tag-test-docker</artifactId>
   <name>XWiki Platform - Tag - Test - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>Function docker tests for the Tag extension.</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-test/xwiki-platform-tour-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-test/xwiki-platform-tour-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-tour-test-docker</artifactId>
   <name>XWiki Platform - Tour - Tests - Functional Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - Tour - Tests - Functional Tests in Docker</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-uiextension/xwiki-platform-uiextension-test/xwiki-platform-uiextension-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-uiextension/xwiki-platform-uiextension-test/xwiki-platform-uiextension-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-uiextension-test-docker</artifactId>
   <name>XWiki Platform - UI Extension - Tests - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - UI Extension - Tests - Functional Docker Tests</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-directory/xwiki-platform-user-directory-test/xwiki-platform-user-directory-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-directory/xwiki-platform-user-directory-test/xwiki-platform-user-directory-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-user-directory-test-docker</artifactId>
   <name>XWiki Platform - User - Directory - Tests - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - User - Directory - Tests - Functional Tests in Docker</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-user-profile-test-docker</artifactId>
   <name>XWiki Platform - User - Profile - Tests - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>Functional Docker Tests for the User Profile Application</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-test/xwiki-platform-user-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-test/xwiki-platform-user-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-user-test-docker</artifactId>
   <name>XWiki Platform - User - Tests - Functional Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - User - Functional Tests in Docker</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-test/xwiki-platform-vfs-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-test/xwiki-platform-vfs-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-vfs-test-docker</artifactId>
   <name>XWiki Platform - VFS - Tests - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - VFS - Tests - Functional Docker Tests</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-whatsnew/xwiki-platform-whatsnew-test/xwiki-platform-whatsnew-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-whatsnew/xwiki-platform-whatsnew-test/xwiki-platform-whatsnew-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-whatsnew-test-docker</artifactId>
   <name>XWiki Platform - What's New - Tests - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - What's New - Tests - Functional Tests in Docker</description>
   <properties>

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/pom.xml
@@ -29,8 +29,6 @@
   </parent>
   <artifactId>xwiki-platform-wiki-test-docker</artifactId>
   <name>XWiki Platform - Wiki - Tests - Functional Docker Tests</name>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <description>XWiki Platform - Wiki - Functional Tests in Docker</description>
   <properties>

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-docker/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-docker/pom.xml
@@ -30,8 +30,6 @@
   <artifactId>xwiki-platform-distribution-flavor-test-docker</artifactId>
   <name>XWiki Platform - Distribution - Flavor - Functional Tests - Docker</name>
   <description>XWiki Platform - Distribution - Flavor - Functional Tests - Docker</description>
-  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
-       see https://jira.xwiki.org/browse/XWIKI-7683 -->
   <packaging>jar</packaging>
   <properties>
     <!-- Functional tests are allowed to output content to the console -->


### PR DESCRIPTION
# Jira URL

N/A — `[Misc]` change (comment removal, no functional impact), see
https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues

# Changes

## Description

Remove this two-line comment from the 51 functional test module poms that carry it:

```xml
<!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
     see https://jira.xwiki.org/browse/XWIKI-7683 -->
```

The comment expressed the hope of one day declaring a `functional-test` packaging provided by a lifecycle mapping
plugin (`xwiki-platform-tool-functional-test-lifecycle`) instead of `jar`. Both things it waited on are gone:

* `MNG-1911` no longer lives at `jira.codehaus.org` — that tracker was shut down. Its current incarnation,
  https://github.com/apache/maven/issues/4475, is closed as **won't fix**, so there is nothing left to hope for.
* `XWIKI-7683`, the XWiki issue it pointed at, was closed as Fixed back in 2012 (the lifecycle module was dropped
  rather than generalised).

So the comment tells a reader to wait for something that will not happen, and points at two dead ends. Nothing else
changes: the modules keep `<packaging>jar</packaging>`, which is what they already used.

## Clarifications

* Purely a comment deletion: **102 deleted lines, 0 added**, spread over 51 poms — one occurrence per file, always the
  two lines directly above `<packaging>jar</packaging>`.
* Three of the files spelled the second line as `http://jira.xwiki.org/jira/browse/XWIKI-7683` instead of
  `https://jira.xwiki.org/browse/XWIKI-7683`; both spellings are removed.
* Other `jira.codehaus.org` links in the tree (`MWAR-281`, `PLX-461`) are about different, still-relevant workarounds
  and are deliberately left alone.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

Since this only deletes XML comments, validation focused on the poms still being readable:

* All 51 modified poms parse as well-formed XML.
* `mvn -B -ntp -o validate -f <pom>` on each of the 51 modules: 48 reach `BUILD SUCCESS`. The 3 others
  (`attachment-test-docker`, `realtime-wiki-test-docker`, `release-test-docker`) fail only at dependency collection
  because the local repository lacks some `18.7.0-SNAPSHOT` sibling poms and the run was offline — Maven had already
  read the modified poms successfully by then, so this is unrelated to the change.
* No functional test was re-run: the deleted lines are comments and the effective poms are unchanged.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None — cosmetic cleanup, no need to carry it to maintenance branches.
