### PR TITLE
XWIKI-24578: Macro editor fails to render parameter modal when a macro parameter uses a List<String> type with a non-empty default value and has a custom picker that uses  select-multiple

### DIFF
--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-webjar/src/main/webjar/macro/macroEditor.js
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-webjar/src/main/webjar/macro/macroEditor.js
@@ -354,7 +354,6 @@ define('xwiki-wysiwyg-macro-parameter-tree-displayer', [
       return value.split(',');
     }
     return [value];
-
   },
 
   getParameterValue = function (valueInputs, originalValue, isCaseInsensitive) {

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-webjar/src/main/webjar/macro/macroEditor.js
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-webjar/src/main/webjar/macro/macroEditor.js
@@ -344,6 +344,19 @@ define('xwiki-wysiwyg-macro-parameter-tree-displayer', [
     return output;
   },
 
+  normalizeSelectValue = function (value, valueInputs) {
+    if (Array.isArray(value)) {
+      return value;
+    }
+
+    const isMultiSelect = valueInputs.prop('type') === 'select-multiple';
+    if (isMultiSelect) {
+      return value.split(',');
+    }
+    return [value];
+
+  },
+
   getParameterValue = function (valueInputs, originalValue, isCaseInsensitive) {
     let matchesParameterValue = function(value) {
       return function() {
@@ -370,7 +383,7 @@ define('xwiki-wysiwyg-macro-parameter-tree-displayer', [
       valueInputs = valueInputs.first();
       // For select inputs we should add the value to the list of options if it's missing.
       if (value && valueInputs.is('select')) {
-        value = valueInputs.prop('type') === 'select-multiple' ? value.split(',') : [value];
+        value = normalizeSelectValue(value, valueInputs);
         value.forEach(function (val, index) {
           let matchedOption = valueInputs.find('option').filter(matchesParameterValue(val));
           if (matchedOption.length > 0) {


### PR DESCRIPTION
# Jira URL
https://jira.xwiki.org/browse/XWIKI-24578

# Changes

## Description
Added a check for arrays and moved the code to a separate function.

# Executed Tests
mvn clean install -Pquality on the module

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:  
    * stable-18.6.x
    * stable-18.4.x
    * stable-17.10.x
    
