### PR TITLE
XWIKI-24624: Impossible to use the current user REST endpoint with superadmin

### DIFF
--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-api/src/main/java/org/xwiki/user/rest/internal/UserReferenceModelSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-api/src/main/java/org/xwiki/user/rest/internal/UserReferenceModelSerializer.java
@@ -47,7 +47,7 @@ public interface UserReferenceModelSerializer
      * @return a user summary
      * @throws XWikiException if there was a problem during serialization
      * @since 18.4.3
-     * @since 18.7RC1
+     * @since 18.7.0RC1
      */
     UserSummary toRestUserSummary(URI baseUri, UserReference userReference) throws XWikiException;
 
@@ -60,7 +60,7 @@ public interface UserReferenceModelSerializer
      * @return a user
      * @throws XWikiException if there was a problem during serialization
      * @since 18.4.3
-     * @since 18.7RC1
+     * @since 18.7.0RC1
      */
     User toRestUser(URI baseUri, UserReference userReference, boolean preferences) throws XWikiException;
 }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-api/src/main/java/org/xwiki/user/rest/internal/UserReferenceModelSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-api/src/main/java/org/xwiki/user/rest/internal/UserReferenceModelSerializer.java
@@ -46,7 +46,7 @@ public interface UserReferenceModelSerializer
      * @param userReference the user reference to serialize
      * @return a user summary
      * @throws XWikiException if there was a problem during serialization
-     * @since 18.4.3
+     * @since 18.4.4
      * @since 18.7.0RC1
      */
     UserSummary toRestUserSummary(URI baseUri, UserReference userReference) throws XWikiException;
@@ -59,7 +59,7 @@ public interface UserReferenceModelSerializer
      * @param preferences whether to include user preferences in the output
      * @return a user
      * @throws XWikiException if there was a problem during serialization
-     * @since 18.4.3
+     * @since 18.4.4
      * @since 18.7.0RC1
      */
     User toRestUser(URI baseUri, UserReference userReference, boolean preferences) throws XWikiException;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-api/src/main/java/org/xwiki/user/rest/internal/UserReferenceModelSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-api/src/main/java/org/xwiki/user/rest/internal/UserReferenceModelSerializer.java
@@ -43,22 +43,24 @@ public interface UserReferenceModelSerializer
      * Return a summary of the user's information to include in, e.g., user lists.
      *
      * @param baseUri the base URL of the current instance
-     * @param userId the id of the user (e.g., "wikiName:Space.Page" for a user stored as a document)
      * @param userReference the user reference to serialize
      * @return a user summary
      * @throws XWikiException if there was a problem during serialization
+     * @since 18.4.3
+     * @since 18.7RC1
      */
-    UserSummary toRestUserSummary(URI baseUri, String userId, UserReference userReference) throws XWikiException;
+    UserSummary toRestUserSummary(URI baseUri, UserReference userReference) throws XWikiException;
 
     /**
      * Return all the information available on the user.
      *
      * @param baseUri the base URL of the current instance
-     * @param userId the id of the user (e.g., "wikiName:Space.Page" for a user stored as a document)
      * @param userReference the user reference to serialize
      * @param preferences whether to include user preferences in the output
      * @return a user
      * @throws XWikiException if there was a problem during serialization
+     * @since 18.4.3
+     * @since 18.7RC1
      */
-    User toRestUser(URI baseUri, String userId, UserReference userReference, boolean preferences) throws XWikiException;
+    User toRestUser(URI baseUri, UserReference userReference, boolean preferences) throws XWikiException;
 }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-default/src/main/java/org/xwiki/user/rest/internal/AbstractUserReferenceModelSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-default/src/main/java/org/xwiki/user/rest/internal/AbstractUserReferenceModelSerializer.java
@@ -33,7 +33,7 @@ import org.xwiki.user.rest.model.jaxb.UserPreferences;
 import com.xpn.xwiki.XWikiContext;
 
 /**
- * Abstract implementation of {@link UserReferenceModelSerializer} to handle pseudo-users, like Guest.
+ * Abstract implementation of {@link UserReferenceModelSerializer}, providing some common helpers.
  *
  * @since 18.2.0RC1
  * @version $Id$

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-default/src/main/java/org/xwiki/user/rest/internal/AbstractUserReferenceModelSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-default/src/main/java/org/xwiki/user/rest/internal/AbstractUserReferenceModelSerializer.java
@@ -23,17 +23,14 @@ import java.util.Objects;
 
 import javax.inject.Provider;
 
-import org.xwiki.user.GuestUserReference;
+import jakarta.inject.Inject;
+
 import org.xwiki.user.UserProperties;
 import org.xwiki.user.UserPropertiesResolver;
 import org.xwiki.user.rest.model.jaxb.ObjectFactory;
-import org.xwiki.user.rest.model.jaxb.User;
 import org.xwiki.user.rest.model.jaxb.UserPreferences;
 
 import com.xpn.xwiki.XWikiContext;
-import com.xpn.xwiki.user.api.XWikiRightService;
-
-import jakarta.inject.Inject;
 
 /**
  * Abstract implementation of {@link UserReferenceModelSerializer} to handle pseudo-users, like Guest.
@@ -73,29 +70,5 @@ public abstract class AbstractUserReferenceModelSerializer implements UserRefere
         userPreferences.setAdvanced("Advanced".equals(userProperties.getProperty("usertype")));
 
         return userPreferences;
-    }
-
-    protected User guestToRestUser(boolean preferences)
-    {
-        User user = this.userObjectFactory.createUser();
-
-        UserProperties userProperties = this.userPropertiesResolver.resolve(GuestUserReference.INSTANCE);
-
-        user.setId(XWikiRightService.GUEST_USER_FULLNAME);
-        user.setGlobal(GuestUserReference.INSTANCE.isGlobal());
-        user.setFirstName(userProperties.getFirstName());
-        user.setLastName(userProperties.getLastName());
-        user.setDisplayName("Guest");
-
-        XWikiContext xcontext = this.xcontextProvider.get();
-
-        String defaultAvatarUrl = xcontext.getWiki().getSkinFile("icons/xwiki/noavatar.png", xcontext);
-        user.setAvatarUrl(defaultAvatarUrl);
-
-        if (preferences) {
-            user.setPreferences(toRestUserPreferences(userProperties, xcontext));
-        }
-
-        return user;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-default/src/main/java/org/xwiki/user/rest/internal/document/DocumentUserReferenceModelSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-default/src/main/java/org/xwiki/user/rest/internal/document/DocumentUserReferenceModelSerializer.java
@@ -65,7 +65,7 @@ import com.xpn.xwiki.doc.XWikiDocument;
 public class DocumentUserReferenceModelSerializer extends AbstractUserReferenceModelSerializer
 {
     @Inject
-    private UserReferenceSerializer<DocumentReference> userReferenceResolver;
+    private UserReferenceSerializer<DocumentReference> userReferenceSerializer;
 
     @Inject
     private UserReferenceSerializer<String> stringUserReferenceSerializer;
@@ -85,7 +85,9 @@ public class DocumentUserReferenceModelSerializer extends AbstractUserReferenceM
         userSummary.setLastName(userProperties.getLastName());
 
         XWikiContext xcontext = this.xcontextProvider.get();
+
         String avatarFileName = null;
+        // The DocumentReference might be null (guest user)
         if (userReference != null) {
             XWikiDocument xwikiDocument = xcontext.getWiki().getDocument(userReference, xcontext);
             avatarFileName = userProperties.getProperty("avatar");
@@ -125,7 +127,7 @@ public class DocumentUserReferenceModelSerializer extends AbstractUserReferenceM
     @Override
     public UserSummary toRestUserSummary(URI baseUri, UserReference userReference) throws XWikiException
     {
-        DocumentReference documentUserReference = this.userReferenceResolver.serialize(userReference);
+        DocumentReference documentUserReference = this.userReferenceSerializer.serialize(userReference);
         String userId = this.stringUserReferenceSerializer.serialize(userReference);
 
         UserProperties userProperties = this.userPropertiesResolver.resolve(userReference);
@@ -133,6 +135,7 @@ public class DocumentUserReferenceModelSerializer extends AbstractUserReferenceM
         toRestUserSummary(baseUri, userSummary, userId, documentUserReference, userReference.isGlobal(),
             userProperties);
 
+        // The DocumentReference might be null (guest user)
         if (documentUserReference != null) {
             String historyUri =
                 Utils.createURI(baseUri, UserResource.class, documentUserReference.getWikiReference().getName(), userId)
@@ -154,7 +157,7 @@ public class DocumentUserReferenceModelSerializer extends AbstractUserReferenceM
             throw new NotFoundException();
         }
 
-        DocumentReference documentUserReference = this.userReferenceResolver.serialize(userReference);
+        DocumentReference documentUserReference = this.userReferenceSerializer.serialize(userReference);
         String userId = this.stringUserReferenceSerializer.serialize(userReference);
 
         User user = this.userObjectFactory.createUser();
@@ -166,6 +169,7 @@ public class DocumentUserReferenceModelSerializer extends AbstractUserReferenceM
         String oldWikiId = xcontext.getWikiId();
 
         try {
+            // The DocumentReference might be null (guest user)
             if (documentUserReference != null) {
                 // We switch the context's wiki to the fetched user's to access wiki-specific preferences.
                 xcontext.setWikiId(documentUserReference.getWikiReference().getName());

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-default/src/main/java/org/xwiki/user/rest/internal/document/DocumentUserReferenceModelSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-default/src/main/java/org/xwiki/user/rest/internal/document/DocumentUserReferenceModelSerializer.java
@@ -22,22 +22,25 @@ package org.xwiki.user.rest.internal.document;
 import java.net.URI;
 import java.util.Objects;
 
-import javax.inject.Provider;
 import javax.ws.rs.NotFoundException;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.mail.EmailAddressObfuscator;
 import org.xwiki.mail.GeneralMailConfiguration;
+import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.rest.Relations;
 import org.xwiki.rest.internal.Utils;
 import org.xwiki.rest.model.jaxb.Link;
 import org.xwiki.rest.resources.pages.PageHistoryResource;
 import org.xwiki.rest.resources.pages.PageResource;
-import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
-import org.xwiki.user.GuestUserReference;
 import org.xwiki.user.UserProperties;
 import org.xwiki.user.UserReference;
+import org.xwiki.user.UserReferenceSerializer;
 import org.xwiki.user.internal.document.DocumentUserReference;
 import org.xwiki.user.rest.internal.AbstractUserReferenceModelSerializer;
 import org.xwiki.user.rest.internal.UserReferenceModelSerializer;
@@ -49,10 +52,6 @@ import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiAttachment;
 import com.xpn.xwiki.doc.XWikiDocument;
-
-import jakarta.inject.Inject;
-import jakarta.inject.Named;
-import jakarta.inject.Singleton;
 
 /**
  * Implementation of {@link UserReferenceModelSerializer} for instances of {@link DocumentUserReference}.
@@ -66,7 +65,10 @@ import jakarta.inject.Singleton;
 public class DocumentUserReferenceModelSerializer extends AbstractUserReferenceModelSerializer
 {
     @Inject
-    private Provider<ContextualAuthorizationManager> authorizationManagerProvider;
+    private UserReferenceSerializer<DocumentReference> userReferenceResolver;
+
+    @Inject
+    private UserReferenceSerializer<String> stringUserReferenceSerializer;
 
     @Inject
     private GeneralMailConfiguration mailConfiguration;
@@ -74,119 +76,128 @@ public class DocumentUserReferenceModelSerializer extends AbstractUserReferenceM
     @Inject
     private EmailAddressObfuscator emailAddressObfuscator;
 
-    private void toRestUserSummary(URI baseUri, UserSummary userSummary, String userId,
-        DocumentUserReference userReference, UserProperties userProperties) throws XWikiException
+    private void toRestUserSummary(URI baseUri, UserSummary userSummary, String userId, DocumentReference userReference,
+        boolean global, UserProperties userProperties) throws XWikiException
     {
         userSummary.setId(userId);
-        userSummary.setGlobal(userReference.isGlobal());
+        userSummary.setGlobal(global);
         userSummary.setFirstName(userProperties.getFirstName());
         userSummary.setLastName(userProperties.getLastName());
 
         XWikiContext xcontext = this.xcontextProvider.get();
-        XWikiDocument xwikiDocument = xcontext.getWiki().getDocument(userReference.getReference(), xcontext);
-        String avatarFileName = userProperties.getProperty("avatar");
+        String avatarFileName = null;
+        if (userReference != null) {
+            XWikiDocument xwikiDocument = xcontext.getWiki().getDocument(userReference, xcontext);
+            avatarFileName = userProperties.getProperty("avatar");
+            if (avatarFileName != null) {
+                XWikiAttachment avatarAttachment = xwikiDocument.getAttachment(avatarFileName);
+                userSummary.setAvatarUrl(xcontext.getWiki().getURL(avatarAttachment.getReference(), xcontext));
+            }
 
-        if (avatarFileName != null) {
-            XWikiAttachment avatarAttachment = xwikiDocument.getAttachment(avatarFileName);
-            userSummary.setAvatarUrl(xcontext.getWiki().getURL(avatarAttachment.getReference(), xcontext));
-        } else {
+            userSummary.setXwikiRelativeUrl(xwikiDocument.getURL(Right.VIEW.getName(), xcontext));
+            userSummary.setXwikiAbsoluteUrl(xwikiDocument.getExternalURL(Right.VIEW.getName(), xcontext));
+
+            String pageUri = Utils.createURI(baseUri, PageResource.class,
+                xwikiDocument.getDocumentReference().getWikiReference().getName(),
+                Utils.getSpacesURLElements(xwikiDocument.getDocumentReference()),
+                xwikiDocument.getDocumentReference().getName()).toString();
+            Link pageLink = this.xwikiObjectFactory.createLink();
+            pageLink.setHref(pageUri);
+            pageLink.setRel(Relations.PAGE);
+            userSummary.withLinks(pageLink);
+
+            String historyUri = Utils.createURI(baseUri, PageHistoryResource.class,
+                xwikiDocument.getDocumentReference().getWikiReference().getName(),
+                Utils.getSpacesURLElements(xwikiDocument.getDocumentReference()),
+                xwikiDocument.getDocumentReference().getName()).toString();
+            Link historyLink = this.xwikiObjectFactory.createLink();
+            historyLink.setHref(historyUri);
+            historyLink.setRel(Relations.HISTORY);
+            userSummary.withLinks(historyLink);
+        }
+
+        if (avatarFileName == null) {
             String defaultAvatarUrl = xcontext.getWiki().getSkinFile("icons/xwiki/noavatar.png", xcontext);
             userSummary.setAvatarUrl(defaultAvatarUrl);
         }
-        userSummary.setXwikiRelativeUrl(xwikiDocument.getURL(Right.VIEW.getName(), xcontext));
-        userSummary.setXwikiAbsoluteUrl(xwikiDocument.getExternalURL(Right.VIEW.getName(), xcontext));
-
-        String pageUri = Utils.createURI(baseUri, PageResource.class,
-                xwikiDocument.getDocumentReference().getWikiReference().getName(),
-                Utils.getSpacesURLElements(xwikiDocument.getDocumentReference()),
-                xwikiDocument.getDocumentReference().getName())
-            .toString();
-        Link pageLink = this.xwikiObjectFactory.createLink();
-        pageLink.setHref(pageUri);
-        pageLink.setRel(Relations.PAGE);
-        userSummary.withLinks(pageLink);
-
-        String historyUri = Utils.createURI(baseUri, PageHistoryResource.class,
-                xwikiDocument.getDocumentReference().getWikiReference().getName(),
-                Utils.getSpacesURLElements(xwikiDocument.getDocumentReference()),
-                xwikiDocument.getDocumentReference().getName())
-            .toString();
-        Link historyLink = this.xwikiObjectFactory.createLink();
-        historyLink.setHref(historyUri);
-        historyLink.setRel(Relations.HISTORY);
-        userSummary.withLinks(historyLink);
     }
 
     @Override
-    public UserSummary toRestUserSummary(URI baseUri, String userId, UserReference userReference) throws XWikiException
+    public UserSummary toRestUserSummary(URI baseUri, UserReference userReference) throws XWikiException
     {
-        DocumentUserReference documentUserReference = (DocumentUserReference) userReference;
+        DocumentReference documentUserReference = this.userReferenceResolver.serialize(userReference);
+        String userId = this.stringUserReferenceSerializer.serialize(userReference);
 
         UserProperties userProperties = this.userPropertiesResolver.resolve(userReference);
         UserSummary userSummary = this.userObjectFactory.createUserSummary();
-        toRestUserSummary(baseUri, userSummary, userId, documentUserReference, userProperties);
+        toRestUserSummary(baseUri, userSummary, userId, documentUserReference, userReference.isGlobal(),
+            userProperties);
 
-        String historyUri = Utils.createURI(baseUri, UserResource.class,
-                documentUserReference.getReference().getWikiReference().getName(), userId)
-            .toString();
-        Link userLink = this.xwikiObjectFactory.createLink();
-        userLink.setHref(historyUri);
-        userLink.setRel(Relations.USER);
-        userSummary.withLinks(userLink);
+        if (documentUserReference != null) {
+            String historyUri =
+                Utils.createURI(baseUri, UserResource.class, documentUserReference.getWikiReference().getName(), userId)
+                    .toString();
+            Link userLink = this.xwikiObjectFactory.createLink();
+            userLink.setHref(historyUri);
+            userLink.setRel(Relations.USER);
+            userSummary.withLinks(userLink);
+        }
 
         return userSummary;
     }
 
     @Override
-    public User toRestUser(URI baseUri, String userId, UserReference userReference, boolean preferences)
-        throws XWikiException
+    public User toRestUser(URI baseUri, UserReference userReference, boolean preferences) throws XWikiException
     {
-        if (userReference == GuestUserReference.INSTANCE) {
-            return guestToRestUser(preferences);
-        }
-
-        DocumentUserReference documentUserReference = (DocumentUserReference) userReference;
-
         UserProperties userProperties = this.userPropertiesResolver.resolve(userReference);
         if (userProperties.isEmpty()) {
             throw new NotFoundException();
         }
 
+        DocumentReference documentUserReference = this.userReferenceResolver.serialize(userReference);
+        String userId = this.stringUserReferenceSerializer.serialize(userReference);
+
         User user = this.userObjectFactory.createUser();
-        toRestUserSummary(baseUri, user, userId, documentUserReference, userProperties);
+        toRestUserSummary(baseUri, user, userId, documentUserReference, userReference.isGlobal(), userProperties);
 
         XWikiContext xcontext = this.xcontextProvider.get();
 
-        // We switch the context's wiki to the fetched user's to access wiki-specific preferences.
+        // Remember the context's wiki
         String oldWikiId = xcontext.getWikiId();
-        xcontext.setWikiId(documentUserReference.getReference().getWikiReference().getName());
 
-        // Handle email obfuscation based on wiki's configuration.
-        String emailAddress = "";
-        if (userProperties.getEmail() != null) {
-            if (this.mailConfiguration.shouldObfuscate()) {
-                emailAddress = this.emailAddressObfuscator.obfuscate(userProperties.getEmail());
-            } else {
-                emailAddress = userProperties.getEmail().toString();
+        try {
+            if (documentUserReference != null) {
+                // We switch the context's wiki to the fetched user's to access wiki-specific preferences.
+                xcontext.setWikiId(documentUserReference.getWikiReference().getName());
             }
+
+            // Handle email obfuscation based on wiki's configuration.
+            String emailAddress = "";
+            if (userProperties.getEmail() != null) {
+                if (this.mailConfiguration.shouldObfuscate()) {
+                    emailAddress = this.emailAddressObfuscator.obfuscate(userProperties.getEmail());
+                } else {
+                    emailAddress = userProperties.getEmail().toString();
+                }
+            }
+            user.setEmail(emailAddress);
+
+            user.setDisplayName(xcontext.getWiki().getUserName(documentUserReference, null, false, true, xcontext));
+
+            user.setCompany(Objects.toString(userProperties.getProperty("company"), ""));
+            user.setAbout(Objects.toString(userProperties.getProperty("comment"), ""));
+            user.setPhone(Objects.toString(userProperties.getProperty("phone"), ""));
+            user.setAddress(Objects.toString(userProperties.getProperty("address"), ""));
+            user.setBlog(Objects.toString(userProperties.getProperty("blog"), ""));
+            user.setBlogFeed(Objects.toString(userProperties.getProperty("blogfeed"), ""));
+
+            if (preferences) {
+                user.setPreferences(toRestUserPreferences(userProperties, xcontext));
+            }
+        } finally {
+            // We reset the context's wiki.
+            xcontext.setWikiId(oldWikiId);
         }
-        user.setEmail(emailAddress);
-
-        user.setDisplayName(xcontext.getWiki().getUserName(documentUserReference.getReference(), null, false, true,
-            xcontext));
-        user.setCompany(Objects.toString(userProperties.getProperty("company"), ""));
-        user.setAbout(Objects.toString(userProperties.getProperty("comment"), ""));
-        user.setPhone(Objects.toString(userProperties.getProperty("phone"), ""));
-        user.setAddress(Objects.toString(userProperties.getProperty("address"), ""));
-        user.setBlog(Objects.toString(userProperties.getProperty("blog"), ""));
-        user.setBlogFeed(Objects.toString(userProperties.getProperty("blogfeed"), ""));
-
-        if (preferences) {
-            user.setPreferences(toRestUserPreferences(userProperties, xcontext));
-        }
-
-        // We reset the context's wiki.
-        xcontext.setWikiId(oldWikiId);
 
         return user;
     }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-default/src/main/java/org/xwiki/user/rest/internal/resources/CurrentUserResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-default/src/main/java/org/xwiki/user/rest/internal/resources/CurrentUserResourceImpl.java
@@ -24,6 +24,10 @@ import java.net.URI;
 import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.core.Response;
 
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Provider;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.localization.ContextualLocalizationManager;
 import org.xwiki.model.reference.DocumentReference;
@@ -31,16 +35,11 @@ import org.xwiki.rest.XWikiResource;
 import org.xwiki.rest.XWikiRestException;
 import org.xwiki.user.UserReference;
 import org.xwiki.user.UserReferenceResolver;
-import org.xwiki.user.UserReferenceSerializer;
 import org.xwiki.user.rest.internal.UserReferenceModelSerializer;
 import org.xwiki.user.rest.model.jaxb.User;
 import org.xwiki.user.rest.resources.CurrentUserResource;
 
 import com.xpn.xwiki.XWikiException;
-
-import jakarta.inject.Inject;
-import jakarta.inject.Named;
-import jakarta.inject.Provider;
 
 /**
  * @since 18.2.0RC1
@@ -53,9 +52,6 @@ public class CurrentUserResourceImpl extends XWikiResource implements CurrentUse
     @Inject
     @Named("document")
     private UserReferenceResolver<DocumentReference> userReferenceResolver;
-
-    @Inject
-    private UserReferenceSerializer<String> stringUserReferenceSerializer;
 
     @Inject
     private Provider<UserReferenceModelSerializer> userReferenceModelSerializerProvider;
@@ -72,16 +68,15 @@ public class CurrentUserResourceImpl extends XWikiResource implements CurrentUse
         UserReferenceModelSerializer userReferenceModelSerializer = this.userReferenceModelSerializerProvider.get();
         if (userReferenceModelSerializer == null) {
             throw new ServerErrorException(Response.status(Response.Status.NOT_IMPLEMENTED).entity(
-                this.contextualLocalizationManager.getTranslationPlain(
-                    "rest.exception.userResource.unsupportedStore")).build());
+                this.contextualLocalizationManager.getTranslationPlain("rest.exception.userResource.unsupportedStore"))
+                .build());
         }
 
         DocumentReference userDocumentReference = getXWikiContext().getUserReference();
         try {
             UserReference userReference = this.userReferenceResolver.resolve(userDocumentReference);
 
-            return userReferenceModelSerializer.toRestUser(baseUri,
-                this.stringUserReferenceSerializer.serialize(userReference), userReference, preferences);
+            return userReferenceModelSerializer.toRestUser(baseUri, userReference, preferences);
         } catch (XWikiException e) {
             throw new XWikiRestException(e);
         }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-default/src/main/java/org/xwiki/user/rest/internal/resources/UserResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-default/src/main/java/org/xwiki/user/rest/internal/resources/UserResourceImpl.java
@@ -25,6 +25,10 @@ import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Provider;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.localization.ContextualLocalizationManager;
 import org.xwiki.rest.XWikiResource;
@@ -34,16 +38,11 @@ import org.xwiki.user.CurrentUserReference;
 import org.xwiki.user.UserManager;
 import org.xwiki.user.UserReference;
 import org.xwiki.user.UserReferenceResolver;
-import org.xwiki.user.UserReferenceSerializer;
 import org.xwiki.user.rest.internal.UserReferenceModelSerializer;
 import org.xwiki.user.rest.model.jaxb.User;
 import org.xwiki.user.rest.resources.UserResource;
 
 import com.xpn.xwiki.XWikiException;
-
-import jakarta.inject.Inject;
-import jakarta.inject.Named;
-import jakarta.inject.Provider;
 
 /**
  * @since 18.2.0RC1
@@ -55,9 +54,6 @@ public class UserResourceImpl extends XWikiResource implements UserResource
 {
     @Inject
     private UserReferenceResolver<String> userReferenceResolver;
-
-    @Inject
-    private UserReferenceSerializer<String> stringUserReferenceSerializer;
 
     @Inject
     private Provider<UserReferenceModelSerializer> userReferenceModelSerializerProvider;
@@ -89,8 +85,7 @@ public class UserResourceImpl extends XWikiResource implements UserResource
                 throw new WebApplicationException(Response.Status.UNAUTHORIZED);
             }
 
-            return userReferenceModelSerializer.toRestUser(baseUri,
-                this.stringUserReferenceSerializer.serialize(userReference), userReference, preferences);
+            return userReferenceModelSerializer.toRestUser(baseUri, userReference, preferences);
         } catch (XWikiException e) {
             throw new XWikiRestException(e);
         }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-default/src/test/java/org/xwiki/user/rest/internal/document/DocumentUserReferenceModelSerializerTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-default/src/test/java/org/xwiki/user/rest/internal/document/DocumentUserReferenceModelSerializerTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.stubbing.Answer;
+import org.xwiki.localization.ContextualLocalizationManager;
 import org.xwiki.mail.EmailAddressObfuscator;
 import org.xwiki.mail.GeneralMailConfiguration;
 import org.xwiki.model.reference.AttachmentReference;
@@ -37,22 +38,27 @@ import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
 import org.xwiki.user.GuestUserReference;
+import org.xwiki.user.SuperAdminUserReference;
 import org.xwiki.user.UserProperties;
 import org.xwiki.user.UserPropertiesResolver;
 import org.xwiki.user.UserReference;
+import org.xwiki.user.UserReferenceSerializer;
 import org.xwiki.user.internal.document.DocumentUserReference;
 import org.xwiki.user.rest.model.jaxb.User;
 import org.xwiki.user.rest.model.jaxb.UserSummary;
 
 import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiAttachment;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.test.MockitoOldcore;
+import com.xpn.xwiki.test.junit5.mockito.InjectMockitoOldcore;
 import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -78,6 +84,18 @@ class DocumentUserReferenceModelSerializerTest
     @MockComponent
     private EmailAddressObfuscator emailAddressObfuscator;
 
+    @MockComponent
+    private UserReferenceSerializer<DocumentReference> userReferenceResolver;
+
+    @MockComponent
+    private UserReferenceSerializer<String> userReferenceStringResolver;
+
+    @MockComponent
+    private ContextualLocalizationManager contextualLocalizationManager;
+
+    @InjectMockitoOldcore
+    private MockitoOldcore oldcore;
+
     @Captor
     private ArgumentCaptor<InternetAddress> emailAddressCaptor;
 
@@ -91,10 +109,19 @@ class DocumentUserReferenceModelSerializerTest
         when(this.emailAddressObfuscator.obfuscate(this.emailAddressCaptor.capture()))
             .then((Answer<String>) invocationOnMock -> this.emailAddressCaptor.getValue().getAddress() + " OBFUSCATED");
 
-        doReturn("avatar.default.url")
-            .when(oldcore.getSpyXWiki()).getSkinFile("icons/xwiki/noavatar.png", this.xcontext);
+        doReturn("avatar.default.url").when(oldcore.getSpyXWiki()).getSkinFile("icons/xwiki/noavatar.png",
+            this.xcontext);
 
         when(this.mailConfiguration.shouldObfuscate()).thenReturn(true);
+
+        when(this.contextualLocalizationManager.getTranslationPlain(any())).thenAnswer(new Answer<String>()
+        {
+            @Override
+            public String answer(org.mockito.invocation.InvocationOnMock invocation) throws Throwable
+            {
+                return invocation.getArgument(0);
+            }
+        });
     }
 
     @Test
@@ -103,8 +130,8 @@ class DocumentUserReferenceModelSerializerTest
         URI baseUri = URI.create("localhost.uri");
         String userId = "xwiki:XWiki.testuser";
 
-        UserSummary userSummary =
-            this.documentUserReferenceModelSerializer.toRestUserSummary(baseUri, userId, createTestUser());
+        UserSummary userSummary = this.documentUserReferenceModelSerializer.toRestUserSummary(baseUri,
+            createTestUser("xwiki:XWiki.testuser"));
 
         assertEquals(userId, userSummary.getId());
         assertEquals("First", userSummary.getFirstName());
@@ -123,13 +150,41 @@ class DocumentUserReferenceModelSerializerTest
         UserProperties guestUserReference = mock(UserProperties.class);
         when(guestUserReference.getFirstName()).thenReturn("Guest");
         when(this.userPropertiesResolver.resolve(GuestUserReference.INSTANCE)).thenReturn(guestUserReference);
+        when(this.userReferenceStringResolver.serialize(GuestUserReference.INSTANCE)).thenReturn("XWiki.XWikiGuest");
 
-        User user =
-            this.documentUserReferenceModelSerializer.toRestUser(baseUri, "", GuestUserReference.INSTANCE, false);
+        User user = this.documentUserReferenceModelSerializer.toRestUser(baseUri, GuestUserReference.INSTANCE, false);
 
         assertEquals("XWiki.XWikiGuest", user.getId());
         assertEquals("Guest", user.getFirstName());
-        assertEquals("Guest", user.getDisplayName());
+        assertNull(user.getLastName());
+        assertEquals("core.users.unknownUser", user.getDisplayName());
+        assertEquals("avatar.default.url", user.getAvatarUrl());
+        assertTrue(user.isGlobal());
+    }
+
+    @Test
+    void testSuperAdminUser() throws Exception
+    {
+        URI baseUri = URI.create("localhost.uri");
+
+        UserProperties superadminUserProperties = mock(UserProperties.class);
+        when(superadminUserProperties.getFirstName()).thenReturn("SuperAdmin");
+        when(this.userPropertiesResolver.resolve(SuperAdminUserReference.INSTANCE))
+            .thenReturn(superadminUserProperties);
+        when(this.userReferenceStringResolver.serialize(SuperAdminUserReference.INSTANCE))
+            .thenReturn("XWiki.superadmin");
+        DocumentReference superadminDocumentReference = new DocumentReference("xwiki", "XWiki", "superadmin");
+        when(this.userReferenceResolver.serialize(SuperAdminUserReference.INSTANCE))
+            .thenReturn(superadminDocumentReference);
+        mockDocument(superadminDocumentReference);
+
+        User user =
+            this.documentUserReferenceModelSerializer.toRestUser(baseUri, SuperAdminUserReference.INSTANCE, false);
+
+        assertEquals("XWiki.superadmin", user.getId());
+        assertEquals("SuperAdmin", user.getFirstName());
+        assertNull(user.getLastName());
+        assertEquals(superadminDocumentReference.getName(), user.getDisplayName());
         assertEquals("avatar.default.url", user.getAvatarUrl());
         assertTrue(user.isGlobal());
     }
@@ -141,8 +196,7 @@ class DocumentUserReferenceModelSerializerTest
         URI baseUri = URI.create("localhost.uri");
         String userId = "xwiki:XWiki.testuser";
 
-        User user =
-            this.documentUserReferenceModelSerializer.toRestUser(baseUri, userId, createTestUser(), preferences);
+        User user = this.documentUserReferenceModelSerializer.toRestUser(baseUri, createTestUser(userId), preferences);
 
         assertEquals(userId, user.getId());
         assertEquals("First", user.getFirstName());
@@ -170,10 +224,10 @@ class DocumentUserReferenceModelSerializerTest
         }
     }
 
-    private UserReference createTestUser() throws Exception
+    private UserReference createTestUser(String userId) throws Exception
     {
-        DocumentReference testUser = new DocumentReference("xwiki", "XWiki", "testuser");
-        UserReference testUserReference = new DocumentUserReference(testUser, true);
+        DocumentReference testUserDocumentReference = new DocumentReference("xwiki", "XWiki", "testuser");
+        UserReference testUserReference = new DocumentUserReference(testUserDocumentReference, true);
 
         UserProperties testUserProperties = mock(UserProperties.class);
         when(testUserProperties.getFirstName()).thenReturn("First");
@@ -193,19 +247,31 @@ class DocumentUserReferenceModelSerializerTest
         when(testUserProperties.getProperty("usertype")).thenReturn("Advanced");
         when(this.userPropertiesResolver.resolve(testUserReference)).thenReturn(testUserProperties);
 
-        XWikiDocument testUserDocument = mock(XWikiDocument.class);
-        when(testUserDocument.getDocumentReference()).thenReturn(testUser);
-        when(testUserDocument.getURL("view", this.xcontext)).thenReturn("view.url");
-        when(testUserDocument.getExternalURL("view", this.xcontext)).thenReturn("view.external.url");
-        doReturn(testUserDocument).when(this.xcontext.getWiki()).getDocument(testUser, this.xcontext);
+        when(this.userReferenceResolver.serialize(testUserReference)).thenReturn(testUserDocumentReference);
 
-        AttachmentReference testAvatarReference = new AttachmentReference("mycoolavatar.png", testUser);
+        when(this.userReferenceStringResolver.serialize(testUserReference)).thenReturn(userId);
+
+        XWikiDocument testUserDocument = mockDocument(testUserDocumentReference);
+
+        AttachmentReference testAvatarReference =
+            new AttachmentReference("mycoolavatar.png", testUserDocumentReference);
         XWikiAttachment testAvatarAttachment = mock(XWikiAttachment.class);
         when(testAvatarAttachment.getReference()).thenReturn(testAvatarReference);
         when(testUserDocument.getAttachment(testAvatarReference.getName())).thenReturn(testAvatarAttachment);
-        doReturn("avatar.mycoolavatar.png.url").when(this.xcontext.getWiki())
-            .getURL(testAvatarReference, this.xcontext);
+        doReturn("avatar.mycoolavatar.png.url").when(this.xcontext.getWiki()).getURL(testAvatarReference,
+            this.xcontext);
 
         return testUserReference;
+    }
+
+    private XWikiDocument mockDocument(DocumentReference testUserDocumentReference) throws XWikiException
+    {
+        XWikiDocument testUserDocument = mock(XWikiDocument.class);
+        when(testUserDocument.getDocumentReference()).thenReturn(testUserDocumentReference);
+        when(testUserDocument.getURL("view", this.xcontext)).thenReturn("view.url");
+        when(testUserDocument.getExternalURL("view", this.xcontext)).thenReturn("view.external.url");
+        doReturn(testUserDocument).when(this.xcontext.getWiki()).getDocument(testUserDocumentReference, this.xcontext);
+
+        return testUserDocument;
     }
 }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24624

# Changes

## Description

Mainly refactored the code manipulating user reference to treat special and document users with more generic code, instead of specific code, as much as possible.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Updated DocumentUserReferenceModelSerializerTest to cover superadmin use case too.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: 18.4.x