### PR TITLE
XWIKI-24632: The MySQL/MariaDB table row format can be updated in the wrong database

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/MySQLHibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/MySQLHibernateAdapter.java
@@ -107,10 +107,29 @@ public class MySQLHibernateAdapter extends AbstractHibernateAdapter
         String expectedRowFormat = compressed ? getCompressedRowFormat() : getDefaultRowFormat();
 
         if (!StringUtils.equalsIgnoreCase(rowFormat, expectedRowFormat)) {
-            return "ALTER TABLE " + tableName + " ROW_FORMAT=" + expectedRowFormat;
+            // Qualify the table with the database of the current wiki: the statement is executed on a session obtained
+            // straight from the session factory, whose pooled connection is still on the database selected by whoever
+            // used it last. An unqualified table would be resolved in that other database.
+            return "ALTER TABLE " + getQualifiedTableName(tableName) + " ROW_FORMAT=" + expectedRowFormat;
         }
 
         return null;
+    }
+
+    /**
+     * @param tableName the name of the table to qualify
+     * @return the table name prefixed with the database of the current wiki, so that the statement does not depend on
+     *         the database currently selected in the JDBC connection
+     */
+    private String getQualifiedTableName(String tableName)
+    {
+        String database = getDatabaseFromWikiName();
+
+        if (database == null) {
+            return tableName;
+        }
+
+        return escapeDatabaseName(database) + '.' + tableName;
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/store/hibernate/internal/MySQLHibernateAdapterTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/store/hibernate/internal/MySQLHibernateAdapterTest.java
@@ -33,7 +33,6 @@ import com.xpn.xwiki.internal.store.hibernate.HibernateConfiguration;
 import com.xpn.xwiki.internal.store.hibernate.HibernateStore;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 
 /**
@@ -65,15 +64,6 @@ class MySQLHibernateAdapterTest
     }
 
     @Test
-    void getAlterRowFormatStringWhenRowFormatMatches() throws Exception
-    {
-        when(this.wikis.getCurrentWikiId()).thenReturn("subwiki");
-
-        assertNull(this.adapter.getAlterRowFormatString("xwikircs", false, Map.of("xwikircs", "Dynamic"), null));
-        assertNull(this.adapter.getAlterRowFormatString("xwikircs", true, Map.of("xwikircs", "Compressed"), null));
-    }
-
-    @Test
     void getAlterRowFormatStringIsQualifiedWithTheCurrentWikiDatabase() throws Exception
     {
         when(this.wikis.getCurrentWikiId()).thenReturn("subwiki");
@@ -84,16 +74,6 @@ class MySQLHibernateAdapterTest
             this.adapter.getAlterRowFormatString("xwikircs", false, Map.of("xwikircs", "Compact"), null));
         assertEquals("ALTER TABLE `subwiki`.xwikircs ROW_FORMAT=Compressed",
             this.adapter.getAlterRowFormatString("xwikircs", true, Map.of(), null));
-    }
-
-    @Test
-    void getAlterRowFormatStringWhenMainWiki() throws Exception
-    {
-        when(this.wikis.getCurrentWikiId()).thenReturn("xwiki");
-        when(this.hibernateConfiguration.getDB()).thenReturn("maindb");
-
-        assertEquals("ALTER TABLE `maindb`.xwikircs ROW_FORMAT=Dynamic",
-            this.adapter.getAlterRowFormatString("xwikircs", false, Map.of(), null));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/store/hibernate/internal/MySQLHibernateAdapterTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/store/hibernate/internal/MySQLHibernateAdapterTest.java
@@ -1,0 +1,107 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.hibernate.internal;
+
+import java.util.Map;
+
+import org.hibernate.dialect.MySQLDialect;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.wiki.descriptor.WikiDescriptorManager;
+
+import com.xpn.xwiki.internal.store.hibernate.HibernateConfiguration;
+import com.xpn.xwiki.internal.store.hibernate.HibernateStore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+/**
+ * Validate {@link MySQLHibernateAdapter}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+class MySQLHibernateAdapterTest
+{
+    @InjectMockComponents
+    private MySQLHibernateAdapter adapter;
+
+    @MockComponent
+    private WikiDescriptorManager wikis;
+
+    @MockComponent
+    private HibernateStore hibernateStore;
+
+    @MockComponent
+    private HibernateConfiguration hibernateConfiguration;
+
+    @BeforeEach
+    void beforeEach()
+    {
+        when(this.hibernateStore.getDialect()).thenReturn(new MySQLDialect());
+        when(this.hibernateConfiguration.getDBPrefix()).thenReturn("");
+        when(this.wikis.getMainWikiId()).thenReturn("xwiki");
+    }
+
+    @Test
+    void getAlterRowFormatStringWhenRowFormatMatches() throws Exception
+    {
+        when(this.wikis.getCurrentWikiId()).thenReturn("subwiki");
+
+        assertNull(this.adapter.getAlterRowFormatString("xwikircs", false, Map.of("xwikircs", "Dynamic"), null));
+        assertNull(this.adapter.getAlterRowFormatString("xwikircs", true, Map.of("xwikircs", "Compressed"), null));
+    }
+
+    @Test
+    void getAlterRowFormatStringIsQualifiedWithTheCurrentWikiDatabase() throws Exception
+    {
+        when(this.wikis.getCurrentWikiId()).thenReturn("subwiki");
+
+        // The statement must name the database explicitly, otherwise it is executed against whichever database the
+        // pooled JDBC connection happens to be on.
+        assertEquals("ALTER TABLE `subwiki`.xwikircs ROW_FORMAT=Dynamic",
+            this.adapter.getAlterRowFormatString("xwikircs", false, Map.of("xwikircs", "Compact"), null));
+        assertEquals("ALTER TABLE `subwiki`.xwikircs ROW_FORMAT=Compressed",
+            this.adapter.getAlterRowFormatString("xwikircs", true, Map.of(), null));
+    }
+
+    @Test
+    void getAlterRowFormatStringWhenMainWiki() throws Exception
+    {
+        when(this.wikis.getCurrentWikiId()).thenReturn("xwiki");
+        when(this.hibernateConfiguration.getDB()).thenReturn("maindb");
+
+        assertEquals("ALTER TABLE `maindb`.xwikircs ROW_FORMAT=Dynamic",
+            this.adapter.getAlterRowFormatString("xwikircs", false, Map.of(), null));
+    }
+
+    @Test
+    void getAlterRowFormatStringWhenNoCurrentWiki() throws Exception
+    {
+        when(this.wikis.getCurrentWikiId()).thenReturn(null);
+
+        assertEquals("ALTER TABLE xwikircs ROW_FORMAT=Dynamic",
+            this.adapter.getAlterRowFormatString("xwikircs", false, Map.of(), null));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/it/org/xwiki/wiki/test/ui/WikiManagerRestIT.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/it/org/xwiki/wiki/test/ui/WikiManagerRestIT.java
@@ -25,34 +25,43 @@ import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.rest.model.jaxb.Wiki;
 import org.xwiki.rest.model.jaxb.Wikis;
 import org.xwiki.rest.resources.wikis.WikisResource;
+import org.xwiki.test.docker.junit5.TestConfiguration;
 import org.xwiki.test.docker.junit5.UITest;
+import org.xwiki.test.docker.junit5.database.Database;
 import org.xwiki.test.ui.TestUtils;
 import org.xwiki.wiki.rest.WikiManagerREST;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Tests for the Wiki manager REST API.
  *
  * @version $Id$
  */
-@UITest
+@UITest(properties = {
+    // The row format check below reads the store APIs from a Groovy script, in a page created by
+    // TestUtils#executeWikiPlain() which thus needs Programming Rights.
+    "xwikiPropertiesAdditionalProperties=test.prchecker.excludePattern=.*:Test\\.Execute\\..*"
+})
 class WikiManagerRestIT
 {
+    private static final String WIKI_ID = "foo";
+
     @Test
     @Order(1)
     void testCreateWiki(TestUtils setup) throws Exception
     {
         setup.createUser("CreateWikiTest", "CreateWikiTestPWD", null);
         setup.login("CreateWikiTest", "CreateWikiTestPWD");
-        String wikiId = "foo";
 
         Wiki wiki = new Wiki();
-        wiki.setId(wikiId);
+        wiki.setId(WIKI_ID);
         wiki.setName("test");
         wiki.setName("Some description");
         PostMethod postMethod = setup.rest().executePost(WikiManagerREST.class, wiki);
@@ -66,7 +75,7 @@ class WikiManagerRestIT
         try (InputStream stream = postMethod.getResponseBodyAsStream()) {
             wiki = setup.rest().toResource(stream);
         }
-        assertEquals(wikiId, wiki.getId());
+        assertEquals(WIKI_ID, wiki.getId());
 
         // Back to guest
         setup.setDefaultCredentials(null);
@@ -74,12 +83,69 @@ class WikiManagerRestIT
 
         boolean found = false;
         for (Wiki w : wikis.getWikis()) {
-            if (wikiId.equals(w.getId())) {
+            if (WIKI_ID.equals(w.getId())) {
                 found = true;
                 break;
             }
         }
 
         assertTrue(found);
+    }
+
+    /**
+     * Verify that the row format of the tables of a newly created wiki is updated in the database of that wiki. The
+     * statement is executed on a session taken straight from the session factory, so an unqualified table name is
+     * resolved against the database currently selected in the pooled JDBC connection, i.e. the database of whichever
+     * wiki borrowed that connection last.
+     * <p>
+     * This covers the case where the row format is silently applied to another wiki's table. The case where the other
+     * database has been dropped in the meantime, which makes the wiki initialization fail, depends on the state of the
+     * connection pool and is not covered.
+     * <p>
+     * A subwiki is required: the main wiki passes even when the table name is not qualified, since the catalog of a
+     * fresh connection comes from the JDBC URL and is already the right database.
+     */
+    @Test
+    @Order(2)
+    void checkTableRowFormat(TestUtils setup, TestConfiguration testConfiguration) throws Exception
+    {
+        // Only the MySQL and MariaDB adapters update the row formats. Note that the database cannot be forced with
+        // @UITest(database = ...) since -Dxwiki.test.ui.database takes precedence over it.
+        Database database = testConfiguration.getDatabase();
+        assumeTrue(database == Database.MYSQL || database == Database.MARIADB,
+            () -> String.format("The row format is not updated on [%s]", database));
+
+        setup.loginAsSuperAdmin();
+
+        // The script is executed in the main wiki, where the {{groovy}} macro is provisioned, and switches the context
+        // to the created wiki so that the store APIs target that wiki's database. The row formats are read through the
+        // store API so that the difference between the MySQL and the MariaDB information schema tables is handled, and
+        // they are compared with the format the configuration asks for rather than with a hardcoded one since
+        // compression can be disabled.
+        assertEquals("The row format of table [xwikircs] is the expected one.", setup.executeWikiPlain("""
+            {{groovy wiki="false"}}
+            import com.xpn.xwiki.internal.store.hibernate.HibernateStore
+
+            def store = services.component.getInstance(HibernateStore.class)
+            def adapter = store.getAdapter()
+            def context = xcontext.context
+            def previousWikiId = context.getWikiId()
+            context.setWikiId('%s')
+            def session = store.getSessionFactory().openSession()
+            try {
+              def rowFormat = adapter.getRowFormats(session).get('xwikircs')
+              def expectedRowFormat = adapter.isCompressionAllowed()
+                ? adapter.getCompressedRowFormat() : adapter.getDefaultRowFormat()
+              if (expectedRowFormat.equalsIgnoreCase(rowFormat)) {
+                print("The row format of table [xwikircs] is the expected one.")
+              } else {
+                print("The row format of table [xwikircs] is [${rowFormat}] instead of [${expectedRowFormat}].")
+              }
+            } finally {
+              session.close()
+              context.setWikiId(previousWikiId)
+            }
+            {{/groovy}}
+            """.formatted(WIKI_ID), Syntax.XWIKI_2_1));
     }
 }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24632

# Changes

## Description

* `MySQLHibernateAdapter#getAlterRowFormatString` now qualifies the statement with the database of
  the current wiki, so that it no longer depends on the database currently selected in the pooled
  JDBC connection:

  ```sql
  -- before
  ALTER TABLE xwikircs ROW_FORMAT=Dynamic
  -- after
  ALTER TABLE `subwiki`.xwikircs ROW_FORMAT=Dynamic
  ```
* Added a functional test (`WikiManagerRestIT#checkTableRowFormat`) asserting that the row format of
  `xwikircs` **in the created subwiki's database** is the expected one.
* Added `MySQLHibernateAdapterTest` covering the produced statement and the fallback when there is no
  current wiki.

## Clarifications

The statement runs on a session taken straight from the session factory
(`AbstractHibernateAdapter#updateDatabase` does `sessionFactory.openSession()`), so MySQL/MariaDB
resolved the unqualified table name against the catalog left on the pooled connection by whichever
wiki borrowed it last (DBCP2 does not reset it, no `defaultCatalog` is configured). Two consequences,
both fixed: the `ALTER TABLE` silently lands on another wiki's table, or — if that database has been
dropped — it aborts the whole wiki initialization with a misleading `The empty database <wiki> seems
to be not writable` error. The latter is what made
`org.xwiki.wiki.test.ui.AllIT$NestedWikiManagerRestIT#testCreateWiki` flicker on MariaDB; see the
[detailed analysis](https://github.com/xwiki/xwiki-platform/pull/6000#issuecomment-5104096015).

The database comes from `getDatabaseFromWikiName()`, which `getRowFormats()` already uses to read the
current row formats, so the read and the write now agree. It falls back to the unqualified name when
there is no current wiki, i.e. never worse than before. `AbstractResizeMigration`, the other caller,
gets the qualification for free.

The functional test needs a subwiki (the main wiki passes even unfixed, since a fresh connection's
catalog comes from the JDBC URL) and can only assert on MySQL/MariaDB, so it `assumeTrue`s on the
configured database — it runs on the MySQL/MariaDB CI jobs and is skipped on the default HSQLDB ones.
It covers the silent half of the bug; the loud half depends on pool state and is not chased.

Out of scope: `OracleHibernateAdapter#updateTableCompression` has the same unqualified `ALTER TABLE`
pattern, but is dormant since `isCompressionAllowed()` defaults to `false` for Oracle.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

* `xwiki-platform-oldcore`: `MySQLHibernateAdapterTest` green. Reverting the one-line fix makes it
  fail with ``expected: <ALTER TABLE `subwiki`.xwikircs …> but was: <ALTER TABLE xwikircs …>``.
* `xwiki-platform-wiki-test-docker`, `-Dit.test=WikiManagerRestIT`:
  * `-Dxwiki.test.ui.database=mariadb`, **without** the fix deployed → fails with
    `The row format of table [xwikircs] is [Dynamic] instead of [Compressed].`
  * `-Dxwiki.test.ui.database=mariadb`, **with** the fix → green; the server log shows
    ``ALTER TABLE `foo`.xwikircs ROW_FORMAT=Compressed``.
  * default (HSQLDB) → green, the row format test skipped.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * stable-18.4.x
  * stable-17.10.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)
