### PR TITLE
XWIKI-24634: The Oracle table compression is checked and updated in the wrong schema

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/OracleHibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/OracleHibernateAdapter.java
@@ -73,10 +73,10 @@ public class OracleHibernateAdapter extends AbstractHibernateAdapter
             boolean compressed = isCompressed(entity);
 
             // Compute the query statement
-            if (compressedTables.contains(tableName) != compressed) {
+            String statement = getAlterCompressionString(tableName, compressed, compressedTables);
+            if (statement != null) {
                 // Create the query
-                NativeQuery<?> query = session
-                    .createNativeQuery("ALTER TABLE " + tableName + " " + (compressed ? "COMPRESS" : "NOCOMPRESS"));
+                NativeQuery<?> query = session.createNativeQuery(statement);
 
                 // Execute the query
                 session.getTransaction().begin();
@@ -87,15 +87,67 @@ public class OracleHibernateAdapter extends AbstractHibernateAdapter
     }
 
     /**
+     * @param tableName the name of the table to modify
+     * @param compressed true if the table should be compressed
+     * @param compressedTables the tables which are currently compressed
+     * @return the SQL statement to execute, or null if the table compression already matches the configuration
+     */
+    public String getAlterCompressionString(String tableName, boolean compressed, Set<String> compressedTables)
+    {
+        if (compressedTables.contains(tableName) == compressed) {
+            return null;
+        }
+
+        // Qualify the table with the schema of the current wiki: the statement is executed on a session obtained
+        // straight from the session factory, whose pooled connection is still on the schema selected by whoever used
+        // it last. An unqualified table would be resolved in that other schema.
+        return "ALTER TABLE " + getQualifiedTableName(tableName) + " " + (compressed ? "COMPRESS" : "NOCOMPRESS");
+    }
+
+    /**
+     * @param tableName the name of the table to qualify
+     * @return the table name prefixed with the schema of the current wiki, so that the statement does not depend on
+     *         the schema currently selected in the JDBC connection
+     */
+    private String getQualifiedTableName(String tableName)
+    {
+        String schema = getDatabaseFromWikiName();
+
+        if (schema == null) {
+            return tableName;
+        }
+
+        return escapeDatabaseName(schema) + '.' + tableName;
+    }
+
+    /**
      * @param session the session in which to execute the query
-     * @return the tables which are configured to be compressed
+     * @return the tables of the current wiki which are configured to be compressed
      */
     public Set<String> getCompressedTables(Session session)
     {
-        NativeQuery<String> query =
-            session.createNativeQuery("SELECT DISTINCT table_name FROM user_tables WHERE compression = 'ENABLED'");
+        NativeQuery<String> query = session.createNativeQuery(getCompressedTablesStatement());
 
         return query.list().stream().map(String::toUpperCase).collect(Collectors.toSet());
+    }
+
+    /**
+     * @return the SQL statement listing the compressed tables of the current wiki
+     */
+    public String getCompressedTablesStatement()
+    {
+        // ALL_TABLES restricted to the schema of the current wiki, and not USER_TABLES: USER_TABLES only lists the
+        // tables owned by the connected user, while XWiki connects with a single user and reaches each wiki by
+        // switching the schema of the session.
+        StringBuilder statement =
+            new StringBuilder("SELECT DISTINCT table_name FROM all_tables WHERE compression = 'ENABLED'");
+
+        String schema = getDatabaseFromWikiName();
+        if (schema != null) {
+            statement.append(" AND owner = '").append(schema).append('\'');
+        }
+
+        return statement.toString();
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/store/hibernate/internal/OracleHibernateAdapterTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/store/hibernate/internal/OracleHibernateAdapterTest.java
@@ -1,0 +1,132 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.hibernate.internal;
+
+import java.util.List;
+import java.util.Set;
+
+import org.hibernate.Session;
+import org.hibernate.query.NativeQuery;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.wiki.descriptor.WikiDescriptorManager;
+
+import com.xpn.xwiki.internal.store.hibernate.HibernateConfiguration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Validate {@link OracleHibernateAdapter}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+class OracleHibernateAdapterTest
+{
+    @InjectMockComponents
+    private OracleHibernateAdapter adapter;
+
+    @MockComponent
+    private WikiDescriptorManager wikis;
+
+    @MockComponent
+    private HibernateConfiguration hibernateConfiguration;
+
+    @BeforeEach
+    void beforeEach()
+    {
+        when(this.hibernateConfiguration.getDBPrefix()).thenReturn("");
+        when(this.wikis.getMainWikiId()).thenReturn("xwiki");
+        when(this.wikis.getCurrentWikiId()).thenReturn("subwiki");
+    }
+
+    @Test
+    void getAlterCompressionStringWhenCompressionMatches()
+    {
+        assertNull(this.adapter.getAlterCompressionString("XWIKIRCS", true, Set.of("XWIKIRCS")));
+        assertNull(this.adapter.getAlterCompressionString("XWIKIRCS", false, Set.of()));
+    }
+
+    @Test
+    void getAlterCompressionStringIsQualifiedWithTheCurrentWikiSchema()
+    {
+        // The statement must name the schema explicitly, otherwise it is executed against whichever schema the pooled
+        // JDBC connection happens to be on.
+        assertEquals("ALTER TABLE SUBWIKI.XWIKIRCS COMPRESS",
+            this.adapter.getAlterCompressionString("XWIKIRCS", true, Set.of()));
+        assertEquals("ALTER TABLE SUBWIKI.XWIKIRCS NOCOMPRESS",
+            this.adapter.getAlterCompressionString("XWIKIRCS", false, Set.of("XWIKIRCS")));
+    }
+
+    @Test
+    void getAlterCompressionStringWhenMainWiki()
+    {
+        when(this.wikis.getCurrentWikiId()).thenReturn("xwiki");
+        when(this.hibernateConfiguration.getDB()).thenReturn("mainschema");
+
+        assertEquals("ALTER TABLE MAINSCHEMA.XWIKIRCS COMPRESS",
+            this.adapter.getAlterCompressionString("XWIKIRCS", true, Set.of()));
+    }
+
+    @Test
+    void getAlterCompressionStringWhenNoCurrentWiki()
+    {
+        when(this.wikis.getCurrentWikiId()).thenReturn(null);
+
+        assertEquals("ALTER TABLE XWIKIRCS COMPRESS",
+            this.adapter.getAlterCompressionString("XWIKIRCS", true, Set.of()));
+    }
+
+    @Test
+    void getCompressedTablesStatementIsRestrictedToTheCurrentWikiSchema()
+    {
+        // USER_TABLES would list the tables owned by the connected user instead of those of the wiki being updated.
+        assertEquals("SELECT DISTINCT table_name FROM all_tables WHERE compression = 'ENABLED' AND owner = 'SUBWIKI'",
+            this.adapter.getCompressedTablesStatement());
+    }
+
+    @Test
+    void getCompressedTablesStatementWhenNoCurrentWiki()
+    {
+        when(this.wikis.getCurrentWikiId()).thenReturn(null);
+
+        assertEquals("SELECT DISTINCT table_name FROM all_tables WHERE compression = 'ENABLED'",
+            this.adapter.getCompressedTablesStatement());
+    }
+
+    @Test
+    void getCompressedTables()
+    {
+        Session session = mock(Session.class);
+        NativeQuery<String> query = mock(NativeQuery.class);
+        when(session.createNativeQuery(
+            "SELECT DISTINCT table_name FROM all_tables WHERE compression = 'ENABLED' AND owner = 'SUBWIKI'"))
+                .thenReturn(query);
+        when(query.list()).thenReturn(List.of("xwikircs", "XWikiDoc"));
+
+        assertEquals(Set.of("XWIKIRCS", "XWIKIDOC"), this.adapter.getCompressedTables(session));
+    }
+}


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24634

# Changes

## Description

`OracleHibernateAdapter#updateDatabaseAfter` makes sure the tables configured as compressed in the
Hibernate mapping really are compressed. Both halves of that check addressed the wrong schema:

* The `ALTER TABLE` statement is now qualified with the schema of the current wiki, so that it no
  longer depends on the schema currently selected in the pooled JDBC connection:

  ```sql
  -- before
  ALTER TABLE XWIKIRCS COMPRESS
  -- after
  ALTER TABLE SUBWIKI.XWIKIRCS COMPRESS
  ```

* The compression status is now read from `ALL_TABLES` restricted to that same schema instead of from
  `USER_TABLES`:

  ```sql
  -- before
  SELECT DISTINCT table_name FROM user_tables WHERE compression = 'ENABLED'
  -- after
  SELECT DISTINCT table_name FROM all_tables WHERE compression = 'ENABLED' AND owner = 'SUBWIKI'
  ```

* Extracted `getAlterCompressionString()` and `getCompressedTablesStatement()` so that both
  statements can be asserted, and added `OracleHibernateAdapterTest`.

## Clarifications

**Why the `ALTER TABLE` reached the wrong schema.** The statement is executed on a session obtained
straight from the session factory (`AbstractHibernateAdapter#updateDatabase` does
`sessionFactory.openSession()`) and nothing sets the schema on that session, so Oracle resolves an
unqualified table name against the `current_schema` of the pooled JDBC connection. XWiki selects the
schema through `HibernateStore#setWiki` → `alter session set current_schema = …`, and DBCP2 does not
reset it when the connection returns to the pool. The statement therefore lands on whichever schema
the previous borrower of that connection was working on — compressing another wiki's table while the
wiki being updated keeps its wrong setting, or failing with `ORA-00942` if that schema is gone.

**Why the lookup read the wrong schema.** `USER_TABLES` lists the tables *owned by the connected
user*, which is not the schema the wiki data lives in as soon as there is more than one wiki: XWiki
connects with a single user and reaches each wiki by switching the session schema. So the previous
code read the compression status of schema A to decide whether to alter a table in schema B.

**Why `getDatabaseFromWikiName()` is the right schema name.** It is the very value
`HibernateStore#setWiki` passes to `alter session set current_schema` for that wiki, so on any
working Oracle install it necessarily names an existing schema — a deployment where it did not would
already fail on every wiki switch, not just here. Note that Oracle's `escapeDatabaseName()`
intentionally returns the name unquoted (Oracle upper-cases unquoted identifiers, and
`cleanDatabaseName()` already upper-cases it), so the qualified name is plain `SUBWIKI.XWIKIRCS`.

**`ALL_TABLES` vs `USER_TABLES`.** `ALL_TABLES` is granted to PUBLIC and lists the tables the
connected user has privileges on, which includes its own. For a single-wiki install where the login
user owns the tables, `all_tables WHERE owner = '<schema>'` returns exactly what `user_tables`
returned, so there is no behaviour change there. `DBA_TABLES` was not used since it needs DBA
privileges.

**Impact.** Limited but real: `isCompressionAllowed()` returns `false` unless
`xwiki.compressionAllowed` is explicitly set (`AbstractHibernateAdapter`), and unlike the MySQL
adapter Oracle does not override that default, so this code only runs on Oracle installs that opted
in to compression. On those, the compression configuration of subwiki tables was never correctly
applied.

**Relation to XWIKI-24632.** This is the Oracle counterpart of the unqualified-`ALTER TABLE` problem
fixed for MySQL/MariaDB in #6000. The two PRs are independent and can be merged in any order; each
carries its own small private `getQualifiedTableName()` helper so that neither depends on the other.
Once both have landed, those two identical helpers are worth hoisting into
`AbstractHibernateAdapter` — happy to do that as a follow-up.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

Full module build (unit tests, Checkstyle, license check, JaCoCo ratio), green:

```
cd xwiki-platform-core/xwiki-platform-oldcore
mvn install -B -ntp
=> Tests run: 1147, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
```

Both halves of the fix were verified to be actually covered by the new tests:

* reverting only the qualification fails 2 tests —
  `expected: <ALTER TABLE SUBWIKI.XWIKIRCS COMPRESS> but was: <ALTER TABLE XWIKIRCS COMPRESS>`
* reverting only the lookup back to `USER_TABLES` fails 3 tests —
  `expected: <… FROM all_tables … AND owner = 'SUBWIKI'> but was: <… FROM user_tables …>`

No functional test: the code path is Oracle-only and additionally gated behind
`xwiki.compressionAllowed`, so it is not exercised by the CI test environments. The statements are
therefore asserted directly by unit tests.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None requested yet — the bug is present since 17.1.0 on `stable-17.10.x` and `stable-18.4.x`, so
    the same backports as XWIKI-24632 would make sense. Add the labels if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
