### PR TITLE
[XWIKI-24637] First and last column has padding

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/container/columns.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/container/columns.css
@@ -24,6 +24,8 @@
    as if they didn't exist, which breaks the layout */
 .container-columns .column {
   min-height: 10px;
+  padding-right: $columnPadding%;
+  padding-left: $columnPadding%;
 }
 
 .container-columns .first-column {
@@ -41,8 +43,6 @@
   #set($computedColumnWidth = $mathtool.roundTo(2, $rawComputedColumnWidth))
   .container-columns-$columns .column{
     width: $computedColumnWidth%;
-    padding-right: $columnPadding%;
-    padding-left: $columnPadding%;
   }
 #end
 


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24637

# Changes

## Description

The rules work again because the padding is defined beforehand and is now being applied.

## Clarifications

In CSS, specificity is the first factor to consider. Next comes the order of the rules. In this case, the rules that come later take precedence.

*.container-columns .first-column* and *.container-columns .last-column* have the same specificity like *.container-columns-2 .column*: 0 2 0

But *.container-columns-2 .column* will be defined later, so these rules are always right. *.container-columns .first-column* and *.container-columns .last-column* have no effect.

Although *.container-columns .column* has the same specificity, it works because it is now the only rule applied here, and the other rules *.container-columns .first-column* and *.container-columns .last-column* come after it.

I just don't understand why these were defined again for each rule; that was the idea in 2015? It's not good practice to define properties multiple times.

# Expected merging strategy
Prefers squash: Yes
