### PR TITLE
XWIKI-24636: Create a multi location/space picker

### DIFF
--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-html/src/main/java/org/xwiki/rendering/display/html/internal/DefaultTemplateHTMLDisplayer.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-html/src/main/java/org/xwiki/rendering/display/html/internal/DefaultTemplateHTMLDisplayer.java
@@ -21,12 +21,15 @@ package org.xwiki.rendering.display.html.internal;
 
 import java.io.StringWriter;
 import java.io.Writer;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -183,6 +186,15 @@ public class DefaultTemplateHTMLDisplayer implements HTMLDisplayer<Object>
             if (aClass.isEnum()) {
                 typeNames.add("enum");
             }
+        } else if (type instanceof ParameterizedType ptype) {
+            StringBuilder typeName = new StringBuilder();
+            typeName.append(((Class<?>) ptype.getRawType()).getSimpleName().toLowerCase());
+            typeName.append('(');
+            typeName.append(Arrays.stream(ptype.getActualTypeArguments())
+                .map(t -> t instanceof Class ? ((Class<?>) t).getSimpleName() : ReflectionUtils.serializeType(t))
+                .collect(Collectors.joining(",")).toLowerCase());
+            typeName.append(')');
+            typeNames.add(typeName.toString());
         } else if (type != null) {
             typeNames.add(ReflectionUtils.serializeType(type).toLowerCase());
         }

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-html/src/main/java/org/xwiki/rendering/display/html/internal/DefaultTemplateHTMLDisplayer.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-html/src/main/java/org/xwiki/rendering/display/html/internal/DefaultTemplateHTMLDisplayer.java
@@ -195,6 +195,8 @@ public class DefaultTemplateHTMLDisplayer implements HTMLDisplayer<Object>
                 .collect(Collectors.joining(",")).toLowerCase());
             typeName.append(')');
             typeNames.add(typeName.toString());
+            // Keep the previous fully qualified naming as a fallback for backwards compatibility
+            typeNames.add(ReflectionUtils.serializeType(type).toLowerCase());
         } else if (type != null) {
             typeNames.add(ReflectionUtils.serializeType(type).toLowerCase());
         }

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-html/src/main/java/org/xwiki/rendering/display/html/internal/DefaultTemplateHTMLDisplayer.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-html/src/main/java/org/xwiki/rendering/display/html/internal/DefaultTemplateHTMLDisplayer.java
@@ -130,7 +130,12 @@ public class DefaultTemplateHTMLDisplayer implements HTMLDisplayer<Object>
      * <li>html_displayer/[mode].vm
      * <li>html_displayer/default.vm
      * </ul>
-     * Please note that the following special characters: &gt;, &lt;, ? and spaces will be replaced by "." in the path.
+     * For a parameterized type, [type] is first the fully qualified type name and then a short name built from the
+     * simple names of the raw type and of its type arguments. For instance
+     * {@code java.util.List<org.xwiki.rendering.block.Block>} is looked up as
+     * {@code java.util.list(org.xwiki.rendering.block.block)} and then as {@code list(block)}.
+     * Please note that in those paths &lt; and &gt; are replaced by parentheses, ? is replaced by "_" and spaces are
+     * removed.
      *
      * @return the template name used to make the rendering
      */
@@ -187,16 +192,17 @@ public class DefaultTemplateHTMLDisplayer implements HTMLDisplayer<Object>
                 typeNames.add("enum");
             }
         } else if (type instanceof ParameterizedType ptype) {
-            StringBuilder typeName = new StringBuilder();
-            typeName.append(((Class<?>) ptype.getRawType()).getSimpleName().toLowerCase());
-            typeName.append('(');
-            typeName.append(Arrays.stream(ptype.getActualTypeArguments())
+            // The fully qualified name is looked up first so that a template can always target one precise type, even
+            // when several types share the same short name.
+            typeNames.add(ReflectionUtils.serializeType(type).toLowerCase());
+            StringBuilder shortName = new StringBuilder();
+            shortName.append(((Class<?>) ptype.getRawType()).getSimpleName().toLowerCase());
+            shortName.append('(');
+            shortName.append(Arrays.stream(ptype.getActualTypeArguments())
                 .map(t -> t instanceof Class ? ((Class<?>) t).getSimpleName() : ReflectionUtils.serializeType(t))
                 .collect(Collectors.joining(",")).toLowerCase());
-            typeName.append(')');
-            typeNames.add(typeName.toString());
-            // Keep the previous fully qualified naming as a fallback for backwards compatibility
-            typeNames.add(ReflectionUtils.serializeType(type).toLowerCase());
+            shortName.append(')');
+            typeNames.add(shortName.toString());
         } else if (type != null) {
             typeNames.add(ReflectionUtils.serializeType(type).toLowerCase());
         }

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-html/src/test/java/org/xwiki/rendering/display/html/internal/DefaultTemplateHTMLDisplayerTest.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-html/src/test/java/org/xwiki/rendering/display/html/internal/DefaultTemplateHTMLDisplayerTest.java
@@ -126,6 +126,10 @@ class DefaultTemplateHTMLDisplayerTest
         verify(this.templateManager)
             .getTemplate("html_displayer/list(block)/view.vm");
         verify(this.templateManager).getTemplate("html_displayer/list(block).vm");
+        verify(this.templateManager)
+            .getTemplate("html_displayer/java.util.list(org.xwiki.rendering.block.block)/view.vm");
+        verify(this.templateManager)
+            .getTemplate("html_displayer/java.util.list(org.xwiki.rendering.block.block).vm");
         verify(this.templateManager).getTemplate("html_displayer/view.vm");
         verify(this.templateManager).getTemplate("html_displayer/default.vm");
         this.defaultTemplateHTMLDisplayer.display(new Type()

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-html/src/test/java/org/xwiki/rendering/display/html/internal/DefaultTemplateHTMLDisplayerTest.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-html/src/test/java/org/xwiki/rendering/display/html/internal/DefaultTemplateHTMLDisplayerTest.java
@@ -20,6 +20,7 @@
 package org.xwiki.rendering.display.html.internal;
 
 import java.io.StringWriter;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -123,10 +124,31 @@ class DefaultTemplateHTMLDisplayerTest
     {
         this.defaultTemplateHTMLDisplayer.display(new DefaultParameterizedType(null, List.class, Block.class), null);
         verify(this.templateManager)
-            .getTemplate("html_displayer/java.util.list(org.xwiki.rendering.block.block)/view.vm");
-        verify(this.templateManager).getTemplate("html_displayer/java.util.list(org.xwiki.rendering.block.block).vm");
+            .getTemplate("html_displayer/list(block)/view.vm");
+        verify(this.templateManager).getTemplate("html_displayer/list(block).vm");
         verify(this.templateManager).getTemplate("html_displayer/view.vm");
         verify(this.templateManager).getTemplate("html_displayer/default.vm");
+        this.defaultTemplateHTMLDisplayer.display(new Type()
+        {
+            @Override
+            public String getTypeName()
+            {
+                return "unknownType";
+            }
+        }, null);
+        verify(this.templateManager).getTemplate("html_displayer/unknowntype.vm");
+    }
+
+    @Test
+    void getTemplateWithNestedParameterizedTypeTest() throws Exception
+    {
+        // A type argument that isn't a plain Class (here, List<Block> nested inside another List) must not be cast
+        // directly to Class, but fall back to serializing its type name.
+        this.defaultTemplateHTMLDisplayer.display(
+            new DefaultParameterizedType(null, List.class, new DefaultParameterizedType(null, List.class,
+                Block.class)), null);
+        verify(this.templateManager).getTemplate("html_displayer/list(java.util.list(org.xwiki.rendering.block."
+            + "block))/view.vm");
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-html/src/test/java/org/xwiki/rendering/display/html/internal/DefaultTemplateHTMLDisplayerTest.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-html/src/test/java/org/xwiki/rendering/display/html/internal/DefaultTemplateHTMLDisplayerTest.java
@@ -28,6 +28,7 @@ import javax.script.ScriptContext;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.xwiki.component.util.DefaultParameterizedType;
 import org.xwiki.displayer.HTMLDisplayerException;
 import org.xwiki.model.EntityType;
@@ -45,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -123,15 +125,17 @@ class DefaultTemplateHTMLDisplayerTest
     void getTemplateWithNullValueAndSpecialTypeTest() throws Exception
     {
         this.defaultTemplateHTMLDisplayer.display(new DefaultParameterizedType(null, List.class, Block.class), null);
-        verify(this.templateManager)
-            .getTemplate("html_displayer/list(block)/view.vm");
-        verify(this.templateManager).getTemplate("html_displayer/list(block).vm");
-        verify(this.templateManager)
+        // The fully qualified type name is looked up before the short one, so that a template targeting one precise
+        // type wins over a template sharing its short name.
+        InOrder inOrder = inOrder(this.templateManager);
+        inOrder.verify(this.templateManager)
             .getTemplate("html_displayer/java.util.list(org.xwiki.rendering.block.block)/view.vm");
-        verify(this.templateManager)
+        inOrder.verify(this.templateManager)
             .getTemplate("html_displayer/java.util.list(org.xwiki.rendering.block.block).vm");
-        verify(this.templateManager).getTemplate("html_displayer/view.vm");
-        verify(this.templateManager).getTemplate("html_displayer/default.vm");
+        inOrder.verify(this.templateManager).getTemplate("html_displayer/list(block)/view.vm");
+        inOrder.verify(this.templateManager).getTemplate("html_displayer/list(block).vm");
+        inOrder.verify(this.templateManager).getTemplate("html_displayer/view.vm");
+        inOrder.verify(this.templateManager).getTemplate("html_displayer/default.vm");
         this.defaultTemplateHTMLDisplayer.display(new Type()
         {
             @Override
@@ -151,6 +155,8 @@ class DefaultTemplateHTMLDisplayerTest
         this.defaultTemplateHTMLDisplayer.display(
             new DefaultParameterizedType(null, List.class, new DefaultParameterizedType(null, List.class,
                 Block.class)), null);
+        verify(this.templateManager).getTemplate("html_displayer/java.util.list(java.util.list(org.xwiki.rendering."
+            + "block.block))/view.vm");
         verify(this.templateManager).getTemplate("html_displayer/list(java.util.list(org.xwiki.rendering.block."
             + "block))/view.vm");
     }

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/SpacePickerIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/SpacePickerIT.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Functional tests for the Space Picker.
  *
  * @version $Id$
- * @since 18.7.0RC1
+ * @since 18.8.0RC1
  */
 @UITest
 class SpacePickerIT

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/SpacePickerIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/SpacePickerIT.java
@@ -1,0 +1,202 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.flamingo.test.docker;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openqa.selenium.By;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.SpaceReference;
+import org.xwiki.test.docker.junit5.TestReference;
+import org.xwiki.test.docker.junit5.UITest;
+import org.xwiki.test.ui.TestUtils;
+import org.xwiki.test.ui.po.SuggestInputElement;
+import org.xwiki.test.ui.po.SuggestInputElement.SuggestionElement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Functional tests for the Space Picker.
+ *
+ * @version $Id$
+ * @since 18.7.0RC1
+ */
+@UITest
+class SpacePickerIT
+{
+    private static final String PICKER_ID = "spacePickerTest";
+
+    private static final String PICKER_TEMPLATE =
+        "{{velocity}}{{html}}#spacePicker({'id': '%s', 'multiple': true}){{/html}}{{/velocity}}";
+
+    private static final String WEB_HOME = "WebHome";
+
+    /**
+     * A space is displayed with the title of the page backing it, so it must also be possible to find it by that title.
+     */
+    @Test
+    @Order(1)
+    void suggestsSpaceByTheTitleOfItsHomePage(TestUtils setup, TestReference reference) throws Exception
+    {
+        setup.loginAsSuperAdmin();
+        // The name of the space doesn't contain the searched text, so that we know the suggestion was matched on the
+        // title of its home page.
+        SpaceReference spaceReference = new SpaceReference("Container", reference.getLastSpaceReference());
+        String title = reference.getLastSpaceReference().getName() + "TitleOnly";
+        setup.rest().savePage(new DocumentReference(WEB_HOME, spaceReference), "", title);
+
+        SuggestInputElement picker = displayPicker(setup, reference);
+
+        List<SuggestionElement> suggestions = picker.sendKeys(title).waitForNonTypedSuggestions().getSuggestions();
+        assertEquals(1, suggestions.size());
+        assertEquals(title, suggestions.get(0).getLabel());
+
+        // The value is the reference of the space, not the reference of the page backing it.
+        picker.selectByVisibleText(title);
+        assertEquals(List.of(setup.serializeLocalReference(spaceReference)), picker.getValues());
+    }
+
+    /**
+     * Searching for pages can't match the name of a space, because the page backing a space is always named WebHome,
+     * which is why the picker also searches for spaces. See XWIKI-23834.
+     */
+    @Test
+    @Order(2)
+    void suggestsSpaceByItsName(TestUtils setup, TestReference reference) throws Exception
+    {
+        setup.loginAsSuperAdmin();
+        String spaceName = reference.getLastSpaceReference().getName() + "NameOnly";
+        SpaceReference spaceReference = new SpaceReference(spaceName, reference.getLastSpaceReference());
+        // The title of the home page doesn't contain the name of the space, so that we know the suggestion was matched
+        // on the name of the space.
+        setup.rest().savePage(new DocumentReference(WEB_HOME, spaceReference), "", "Unrelated Title");
+
+        SuggestInputElement picker = displayPicker(setup, reference);
+
+        List<SuggestionElement> suggestions = picker.sendKeys(spaceName).waitForNonTypedSuggestions().getSuggestions();
+        assertEquals(List.of(setup.serializeLocalReference(spaceReference)),
+            suggestions.stream().map(SuggestionElement::getValue).toList());
+    }
+
+    /**
+     * Only the pages backing a space are spaces, so the terminal pages must not be suggested.
+     */
+    @Test
+    @Order(3)
+    void doesNotSuggestTerminalPages(TestUtils setup, TestReference reference) throws Exception
+    {
+        setup.loginAsSuperAdmin();
+        String searchedText = reference.getLastSpaceReference().getName() + "Terminal";
+        // A terminal page is not a space, so it must not be suggested, even though its title matches.
+        setup.rest().savePage(new DocumentReference(searchedText, reference.getLastSpaceReference()), "", searchedText);
+        // A nested page is a space, so it must be suggested.
+        SpaceReference spaceReference =
+            new SpaceReference(searchedText + "Nested", reference.getLastSpaceReference());
+        setup.rest().savePage(new DocumentReference(WEB_HOME, spaceReference), "", searchedText + "Nested");
+
+        SuggestInputElement picker = displayPicker(setup, reference);
+
+        List<SuggestionElement> suggestions =
+            picker.sendKeys(searchedText).waitForNonTypedSuggestions().getSuggestions();
+        assertEquals(List.of(setup.serializeLocalReference(spaceReference)),
+            suggestions.stream().map(SuggestionElement::getValue).toList());
+    }
+
+    /**
+     * The hierarchy of a space is displayed as a hint, so that two spaces with the same name can be told apart.
+     */
+    @Test
+    @Order(4)
+    void showsTheHierarchyOfTheSuggestedSpace(TestUtils setup, TestReference reference) throws Exception
+    {
+        setup.loginAsSuperAdmin();
+        String parentTitle = reference.getLastSpaceReference().getName() + "ParentTitle";
+        SpaceReference parentReference = new SpaceReference("Parent", reference.getLastSpaceReference());
+        setup.rest().savePage(new DocumentReference(WEB_HOME, parentReference), "", parentTitle);
+        String childTitle = reference.getLastSpaceReference().getName() + "ChildTitle";
+        SpaceReference childReference = new SpaceReference("Child", parentReference);
+        setup.rest().savePage(new DocumentReference(WEB_HOME, childReference), "", childTitle);
+
+        SuggestInputElement picker = displayPicker(setup, reference);
+
+        List<SuggestionElement> suggestions = picker.sendKeys(childTitle).waitForNonTypedSuggestions().getSuggestions();
+        assertEquals(1, suggestions.size());
+        assertEquals(childTitle, suggestions.get(0).getLabel());
+        // The hint is the hierarchy of the space, without the space itself.
+        String hint = suggestions.get(0).getHint();
+        assertTrue(hint.contains(parentTitle), "The hint [%s] doesn't contain the parent [%s].".formatted(hint,
+            parentTitle));
+        assertFalse(hint.contains(childTitle), "The hint [%s] contains the space itself.".formatted(hint));
+    }
+
+    /**
+     * No suggestion should be displayed, and no error raised, when nothing matches the searched text.
+     */
+    @Test
+    @Order(5)
+    void suggestsNothingWhenNoMatch(TestUtils setup, TestReference reference) throws Exception
+    {
+        setup.loginAsSuperAdmin();
+        String searchedText = reference.getLastSpaceReference().getName() + "NoMatch";
+
+        SuggestInputElement picker = displayPicker(setup, reference);
+
+        List<SuggestionElement> suggestions =
+            picker.sendKeys(searchedText).waitForNonTypedSuggestions().getSuggestions();
+        assertEquals(0, suggestions.size());
+    }
+
+    /**
+     * Verify that spaces with unicode names/titles can be found regardless of case and diacritics, just like pages.
+     * See {@code PagePickerIT#searchCaseInsensitiveUnicode}.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { "ähm", "töst", "école", "hôtelière" })
+    @Order(6)
+    void searchCaseInsensitiveUnicode(String searchText, TestUtils setup, TestReference reference) throws Exception
+    {
+        setup.loginAsSuperAdmin();
+        String title = "École hôtelière";
+        SpaceReference spaceReference = new SpaceReference("ÄhmTöst", reference.getLastSpaceReference());
+        setup.rest().savePage(new DocumentReference(WEB_HOME, spaceReference), "", title);
+
+        SuggestInputElement picker = displayPicker(setup, reference);
+
+        List<SuggestionElement> suggestions = picker.sendKeys(searchText).waitForNonTypedSuggestions().getSuggestions();
+        assertEquals(1, suggestions.size(), "Didn't find anything searching for %s".formatted(searchText));
+        assertEquals(title, suggestions.get(0).getLabel());
+    }
+
+    /**
+     * Displays the picker on the test page and returns it, ready to be used.
+     */
+    private SuggestInputElement displayPicker(TestUtils setup, TestReference reference)
+    {
+        setup.createPage(reference, String.format(PICKER_TEMPLATE, PICKER_ID),
+            reference.getLastSpaceReference().getName());
+        return new SuggestInputElement(setup.getDriver().findElementWithoutWaiting(By.id(PICKER_ID)));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/SpacePickerIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/SpacePickerIT.java
@@ -59,7 +59,7 @@ class SpacePickerIT
      */
     @Test
     @Order(1)
-    void suggestsSpaceByTheTitleOfItsHomePage(TestUtils setup, TestReference reference) throws Exception
+    void suggestsSpaceByHomepageTitle(TestUtils setup, TestReference reference) throws Exception
     {
         setup.loginAsSuperAdmin();
         // The name of the space doesn't contain the searched text, so that we know the suggestion was matched on the

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/SpacePickerIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/SpacePickerIT.java
@@ -165,7 +165,7 @@ class SpacePickerIT
         SuggestInputElement picker = displayPicker(setup, reference);
 
         List<SuggestionElement> suggestions =
-            picker.sendKeys(searchedText).waitForNonTypedSuggestions().getSuggestions();
+            picker.sendKeys(searchedText).waitForSuggestionsLoaded().getSuggestions();
         assertEquals(0, suggestions.size());
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -918,6 +918,9 @@ core.documentPicker.title=Select Page
 core.documentPicker.select=Select
 core.documentPicker.cancel=Cancel
 
+### Multiple Location Picker
+core.widgets.multiLocationPicker.browse=Browse the locations
+
 ### Export
 core.export.pdf.options.title=PDF Export Options
 core.export.pdf.options.language.hint=Choose the translation you want to export.
@@ -1430,6 +1433,8 @@ core.widgets.suggest.classPicker.single.title=Pick a class.
 core.widgets.suggest.classPicker.multi.title=Pick classes.
 core.widgets.suggest.pagePicker.single.title=Pick a page.
 core.widgets.suggest.pagePicker.multi.title=Pick pages.
+core.widgets.suggest.spacePicker.single.title=Pick a space.
+core.widgets.suggest.spacePicker.multi.title=Pick spaces.
 core.widgets.suggest.userPicker.single.title=Pick a user.
 core.widgets.suggest.userPicker.multi.title=Pick users.
 core.widgets.suggest.xpropertyPicker.single.title=Pick a property value.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -918,6 +918,9 @@ core.documentPicker.title=Select Page
 core.documentPicker.select=Select
 core.documentPicker.cancel=Cancel
 
+### Multiple Location Picker
+core.widgets.multiLocationPicker.browse=Browse the locations
+
 ### Export
 core.export.pdf.options.title=PDF Export Options
 core.export.pdf.options.language.hint=Choose the translation you want to export.
@@ -1428,6 +1431,8 @@ core.widgets.suggest.classPicker.single.title=Pick a class.
 core.widgets.suggest.classPicker.multi.title=Pick classes.
 core.widgets.suggest.pagePicker.single.title=Pick a page.
 core.widgets.suggest.pagePicker.multi.title=Pick pages.
+core.widgets.suggest.spacePicker.single.title=Pick a space.
+core.widgets.suggest.spacePicker.multi.title=Pick spaces.
 core.widgets.suggest.userPicker.single.title=Pick a user.
 core.widgets.suggest.userPicker.multi.title=Pick users.
 core.widgets.suggest.xpropertyPicker.single.title=Pick a property value.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -918,9 +918,6 @@ core.documentPicker.title=Select Page
 core.documentPicker.select=Select
 core.documentPicker.cancel=Cancel
 
-### Multiple Location Picker
-core.widgets.multiLocationPicker.browse=Browse the locations
-
 ### Export
 core.export.pdf.options.title=PDF Export Options
 core.export.pdf.options.language.hint=Choose the translation you want to export.
@@ -1437,6 +1434,8 @@ core.widgets.suggest.userPicker.single.title=Pick a user.
 core.widgets.suggest.userPicker.multi.title=Pick users.
 core.widgets.suggest.xpropertyPicker.single.title=Pick a property value.
 core.widgets.suggest.xpropertyPicker.multi.title=Pick property values.
+
+core.widgets.multiLocationPicker.browse=Browse the locations
 
 web.uicomponents.suggest.selectTypedText=Select {0} ...
 web.uicomponents.suggest.attachments.upload=Upload a file ...

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -918,9 +918,6 @@ core.documentPicker.title=Select Page
 core.documentPicker.select=Select
 core.documentPicker.cancel=Cancel
 
-### Multiple Location Picker
-core.widgets.multiLocationPicker.browse=Browse the locations
-
 ### Export
 core.export.pdf.options.title=PDF Export Options
 core.export.pdf.options.language.hint=Choose the translation you want to export.
@@ -1439,6 +1436,8 @@ core.widgets.suggest.userPicker.single.title=Pick a user.
 core.widgets.suggest.userPicker.multi.title=Pick users.
 core.widgets.suggest.xpropertyPicker.single.title=Pick a property value.
 core.widgets.suggest.xpropertyPicker.multi.title=Pick property values.
+
+core.widgets.multiLocationPicker.browse=Browse the locations
 
 web.uicomponents.suggest.selectTypedText=Select {0} ...
 web.uicomponents.suggest.attachments.upload=Upload a file ...

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/SuggestInputElement.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/SuggestInputElement.java
@@ -346,7 +346,7 @@ public class SuggestInputElement extends BaseElement
      * suggestion to be displayed, so it can be used when the search is expected to return no results.
      *
      * @return the current suggest input element
-     * @since 18.7.0RC1
+     * @since 18.8.0RC1
      */
     public SuggestInputElement waitForSuggestionsLoaded()
     {
@@ -361,7 +361,7 @@ public class SuggestInputElement extends BaseElement
      * @param remote whether the suggestions are loaded from a remote source or not, which can be used to adjust the
      *            waiting
      * @return the current suggest input element
-     * @since 18.7.0RC1
+     * @since 18.8.0RC1
      */
     public SuggestInputElement waitForSuggestionsLoaded(boolean remote)
     {

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/SuggestInputElement.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/SuggestInputElement.java
@@ -341,6 +341,36 @@ public class SuggestInputElement extends BaseElement
     }
 
     /**
+     * Waits until the suggestions have been loaded, whether or not any suggestion actually matched the current input.
+     * Unlike {@link #waitForSuggestions()} and {@link #waitForNonTypedSuggestions()}, this doesn't require any
+     * suggestion to be displayed, so it can be used when the search is expected to return no results.
+     *
+     * @return the current suggest input element
+     * @since 18.7.0RC1
+     */
+    public SuggestInputElement waitForSuggestionsLoaded()
+    {
+        return waitForSuggestionsLoaded(this.shouldWaitForRemoteSuggestions);
+    }
+
+    /**
+     * Waits until the suggestions have been loaded, whether or not any suggestion actually matched the current input.
+     * Unlike {@link #waitForSuggestions(boolean)} and {@link #waitForNonTypedSuggestions(boolean)}, this doesn't
+     * require any suggestion to be displayed, so it can be used when the search is expected to return no results.
+     *
+     * @param remote whether the suggestions are loaded from a remote source or not, which can be used to adjust the
+     *            waiting
+     * @return the current suggest input element
+     * @since 18.7.0RC1
+     */
+    public SuggestInputElement waitForSuggestionsLoaded(boolean remote)
+    {
+        waitForDropdownReload(remote);
+        getDriver().waitUntilCondition(driver -> !isLoading());
+        return this;
+    }
+
+    /**
      * Waits until the suggestions have disappeared.
      *
      * @return the current suggest input element

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/html_displayer/list(spacereference)/edit.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/html_displayer/list(spacereference)/edit.vm
@@ -1,0 +1,24 @@
+## ---------------------------------------------------------------------------
+## See the NOTICE file distributed with this work for additional
+## information regarding copyright ownership.
+##
+## This is free software; you can redistribute it and/or modify it
+## under the terms of the GNU Lesser General Public License as
+## published by the Free Software Foundation; either version 2.1 of
+## the License, or (at your option) any later version.
+##
+## This software is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public
+## License along with this software; if not, write to the Free
+## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+## ---------------------------------------------------------------------------
+#template('locationPicker_macros.vm')
+#set ($parameters = {})
+#set ($discard = $parameters.putAll($displayer.parameters))
+#set ($parameters.value = $displayer.value)
+#multiLocationPicker($parameters)

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
@@ -84,6 +84,67 @@
   </dl>
 #end
 
+#**
+ * Picker for a list of locations (i.e. spaces). The locations are selected as you type, in a suggestion input, and can
+ * also be browsed for in a document tree, displayed in a drop down next to the input. The value of the picker is the
+ * list of serialized space references, separated by a comma.
+ *
+ * @param $options the picker options:
+ *          'name' the name of the form field holding the value;
+ *          'value' the initially selected locations, either a serialized list or a collection of references;
+ *          plus the options accepted by #documentTree for the tree used to browse the locations.
+ *#
+#macro (multiLocationPicker $options)
+  #set ($discard = $xwiki.get('jsfx').use('uicomponents/widgets/multiLocationPicker.js', true))
+  #set ($discard = $xwiki.get('ssfx').use('uicomponents/widgets/multiLocationPicker.css', true))
+  #set ($macro.parameters = {})
+  #set ($discard = $macro.parameters.putAll($options))
+  #set ($discard = $macro.parameters.put('multiple', 'multiple'))
+  ## The tree is only an alternative way of feeding the suggestion input: the input remains the single source of truth
+  ## for the value, which is why it doesn't need to know anything about the tree.
+  #if ($isDocumentTreeAvailable)
+    <div class="location-picker-multi">
+      #spacePicker($macro.parameters)
+      #multiLocationPickerBrowser($options)
+    </div>
+  #else
+    #spacePicker($macro.parameters)
+  #end
+#end
+
+#macro (multiLocationPickerBrowser $options)
+  #set ($macro.browseLabel = $escapetool.xml($services.localization.render(
+    'core.widgets.multiLocationPicker.browse')))
+  <div class="location-picker-browse dropdown">
+    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true"
+        aria-expanded="false" title="$macro.browseLabel" aria-label="$macro.browseLabel">
+      $services.icon.renderHTML('chart-organisation')
+    </button>
+    <div class="dropdown-menu dropdown-menu-right">
+      #set ($macro.showWikis = $displayWikiFields)
+      #set ($macro.filterHiddenDocuments = $options.filterHiddenDocuments != false)
+      ## Only the pages backing a space can be picked as a location, hence showTerminalDocuments is false. Checking a
+      ## location must not check the ones nested inside it, hence three_state and cascade. And the checkbox state must
+      ## be independent of the node selection, so that clicking a node label doesn't pick it, hence tie_selection.
+      #documentTree({
+        'class': 'location-tree',
+        'checkboxes': true,
+        'finder': true,
+        'showAttachments': false,
+        'showRoot': false,
+        'showTerminalDocuments': false,
+        'showTranslations': false,
+        'showWikis': $macro.showWikis,
+        'exclusions': "$!options.exclusions",
+        'root': "$!options.root",
+        'filterHiddenDocuments': $macro.filterHiddenDocuments,
+        'sortDocumentsBy': "$!options.sortDocumentsBy",
+        'config': {'checkbox': {'tie_selection': false, 'three_state': false, 'cascade': ''}}
+      })
+    </div>
+  </div>
+#end
+
 #macro (locationPickerActions $options)
   #set ($isTreePickerAvailable = $isDocumentTreeAvailable && $options.parent.label && !$options.parent.readOnly)
   <div class="location-actions btn-group">

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
@@ -90,9 +90,9 @@
  * list of serialized space references, separated by a comma.
  *
  * @param $options the picker options:
- *          'name' the name of the form field holding the value;
- *          'value' the initially selected locations, either a serialized list or a collection of references;
- *          plus the options accepted by #documentTree for the tree used to browse the locations.
+ *   'name' the name of the form field holding the value;
+ *   'value' the initially selected locations, either a serialized list or a collection of references;
+ *   + the options accepted by #documentTree for the tree used to browse the locations.
  *#
 #macro (multiLocationPicker $options)
   #set ($discard = $xwiki.get('jsfx').use('uicomponents/widgets/multiLocationPicker.js', true))
@@ -105,14 +105,14 @@
   #if ($isDocumentTreeAvailable)
     <div class="location-picker-multi">
       #spacePicker($macro.parameters)
-      #multiLocationPickerBrowser($options)
+      #_multiLocationPickerBrowser($options)
     </div>
   #else
     #spacePicker($macro.parameters)
   #end
 #end
 
-#macro (multiLocationPickerBrowser $options)
+#macro (_multiLocationPickerBrowser $options)
   #set ($macro.browseLabel = $escapetool.xml($services.localization.render(
     'core.widgets.multiLocationPicker.browse')))
   <div class="location-picker-browse dropdown">
@@ -123,9 +123,6 @@
     <div class="dropdown-menu dropdown-menu-right">
       #set ($macro.showWikis = $displayWikiFields)
       #set ($macro.filterHiddenDocuments = $options.filterHiddenDocuments != false)
-      ## Only the pages backing a space can be picked as a location, hence showTerminalDocuments is false. Checking a
-      ## location must not check the ones nested inside it, hence three_state and cascade. And the checkbox state must
-      ## be independent of the node selection, so that clicking a node label doesn't pick it, hence tie_selection.
       #documentTree({
         'class': 'location-tree',
         'checkboxes': true,

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -2715,6 +2715,31 @@ $string##
 #end
 
 #**
+* Pulls all the JavaScript and CSS resources needed by the space picker.
+*#
+#macro (spacePicker_import)
+  #picker_import
+  #set ($discard = $xwiki.jsfx.use('uicomponents/suggest/suggestSpaces.js',
+    {'forceSkinAction': true, 'language': $xcontext.locale}))
+#end
+
+#macro (spacePicker $parameters)
+  #spacePicker_import
+  #if ("$!parameters" == "")
+    #set ($parameters = {})
+  #end
+  #set ($discard = $parameters.put('class', "$!parameters.get('class') suggest-spaces"))
+  #if ($parameters.get('multiple') == 'multiple')
+    #set ($discard = $parameters.putIfAbsent('title',
+      $services.localization.render('core.widgets.suggest.spacePicker.multi.title')))
+  #else
+    #set ($discard = $parameters.putIfAbsent('title',
+      $services.localization.render('core.widgets.suggest.spacePicker.single.title')))
+  #end
+  #suggestInput($parameters)
+#end
+
+#**
 * Pulls all the JavaScript and CSS resources needed by the attachment picker.
 *#
 #macro (attachmentPicker_import)

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -2717,14 +2717,14 @@ $string##
 #**
 * Pulls all the JavaScript and CSS resources needed by the space picker.
 *#
-#macro (spacePicker_import)
+#macro (_spacePicker_import)
   #picker_import
   #set ($discard = $xwiki.jsfx.use('uicomponents/suggest/suggestSpaces.js',
     {'forceSkinAction': true, 'language': $xcontext.locale}))
 #end
 
 #macro (spacePicker $parameters)
-  #spacePicker_import
+  #_spacePicker_import
   #if ("$!parameters" == "")
     #set ($parameters = {})
   #end

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -2717,14 +2717,14 @@ $string##
 #**
 * Pulls all the JavaScript and CSS resources needed by the space picker.
 *#
-#macro (_spacePicker_import)
+#macro (spacePicker_import)
   #picker_import
   #set ($discard = $xwiki.jsfx.use('uicomponents/suggest/suggestSpaces.js',
     {'forceSkinAction': true, 'language': $xcontext.locale}))
 #end
 
 #macro (spacePicker $parameters)
-  #_spacePicker_import
+  #spacePicker_import
   #if ("$!parameters" == "")
     #set ($parameters = {})
   #end

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggestSpaces.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggestSpaces.js
@@ -81,13 +81,7 @@ define('xwiki-suggestSpaces', ['jquery', 'xwiki-selectize'], function($) {
 
   /**
    * Looks for spaces matching the given text using two complementary search sources, because neither of them is enough
-   * on its own:
-   * <ul>
-   *   <li>searching for pages matches the title of the space home page (i.e. the name the space is displayed with) but
-   *     not the technical space name, because the name of the page backing a space is always "WebHome";</li>
-   *   <li>searching for spaces matches the technical space name but returns neither the pretty names nor the
-   *     hierarchy.</li>
-   * </ul>
+   * on its own.
    */
   var loadSpaces = function(text, options) {
     return $.when(loadSpacesFromPages(text, options), loadSpacesFromSpaces(text, options))

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggestSpaces.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggestSpaces.js
@@ -1,0 +1,244 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+/*!
+#set ($spaceIcon = $services.icon.getMetaData('folder'))
+#set ($webHome = $services.model.getEntityReference('DOCUMENT', 'default').name)
+#[[*/
+// Start JavaScript-only code.
+(function(spaceIcon, webHome) {
+  "use strict";
+
+define('xwiki-suggestSpaces', ['jquery', 'xwiki-selectize'], function($) {
+  webHome = webHome || 'WebHome';
+
+  // How many suggestions we show at most.
+  var limit = 10;
+
+  var getSelectizeOptions = function(select) {
+    return {
+      create: true,
+      // The document where the selected values are saved. Stored space references will be relative to the wiki of this
+      // document.
+      documentReference: select.data('documentReference'),
+      // Where to look for spaces. The following is supported:
+      // * "wiki:wikiName" look for spaces in the specified wiki
+      // * "space:spaceReference" look for nested spaces of the specified space
+      searchScope: select.data('searchScope'),
+      // The value is a space reference so, unlike for pages, there's no technical "WebHome" name to hide from the
+      // matching. We can match on the value directly.
+      searchField: ['value', 'label', 'hint'],
+      load: function(text, callback) {
+        loadSpaces(text, this.settings).then(callback, callback);
+      },
+      loadSelected: function(value, callback) {
+        loadSpace(value, this.settings).then(callback, callback);
+      }
+    };
+  };
+
+  var processOptions = function(options) {
+    // Resolve the document reference relative to the current document reference.
+    if (!options.documentReference || typeof options.documentReference === 'string') {
+      options.documentReference = XWiki.Model.resolve(options.documentReference, XWiki.EntityType.DOCUMENT,
+        XWiki.currentDocument.documentReference);
+    }
+    // Resolve the search scope. Fall back to the current wiki if the given scope can't be resolved.
+    options.searchScope = resolveEntityReference(options.searchScope || 'wiki:' + XWiki.currentWiki) ||
+      resolveEntityReference('wiki:' + XWiki.currentWiki);
+    return options;
+  };
+
+  /**
+   * Resolves an entity reference from a string representation of the form "entityType:entityReference".
+   */
+  var resolveEntityReference = function(typeAndReference) {
+    if (typeof typeAndReference === 'string') {
+      try {
+        return XWiki.Model.resolve(typeAndReference, null, XWiki.currentDocument.documentReference);
+      } catch (e) {
+        return null;
+      }
+    }
+    return typeAndReference;
+  };
+
+  /**
+   * Looks for spaces matching the given text using two complementary search sources, because neither of them is enough
+   * on its own:
+   * <ul>
+   *   <li>searching for pages matches the title of the space home page (i.e. the name the space is displayed with) but
+   *     not the technical space name, because the name of the page backing a space is always "WebHome";</li>
+   *   <li>searching for spaces matches the technical space name but returns neither the pretty names nor the
+   *     hierarchy.</li>
+   * </ul>
+   */
+  var loadSpaces = function(text, options) {
+    return $.when(loadSpacesFromPages(text, options), loadSpacesFromSpaces(text, options))
+      .then(function(spacesFromPages, spacesFromSpaces) {
+        return removeDuplicates(spacesFromPages.concat(spacesFromSpaces)).slice(0, limit);
+      });
+  };
+
+  var loadSpacesFromPages = function(text, options) {
+    return $.getJSON(getRestSearchURL(options.searchScope), $.param({
+      q: text,
+      scope: ['name', 'title'],
+      // The search doesn't know about spaces so we have to filter out the terminal pages ourselves, which means we need
+      // to ask for more results than we display.
+      number: limit * 4,
+      localeAware: true,
+      prettyNames: true
+    }, true)).then(function(response) {
+      var pages = Array.isArray(response.searchResults) ? response.searchResults : [];
+      // Only the non-terminal pages, i.e. the pages backing a space, are of interest here.
+      return pages.filter(function(page) {
+        return page.pageName === webHome;
+      }).map(processPage.bind(null, options));
+    }, function() {
+      return [];
+    });
+  };
+
+  var loadSpacesFromSpaces = function(text, options) {
+    return $.getJSON(getRestSearchURL(options.searchScope), $.param({
+      q: text,
+      scope: 'spaces',
+      number: limit * 2
+    })).then(function(response) {
+      var spaces = Array.isArray(response.searchResults) ? response.searchResults : [];
+      return spaces.map(function(space) {
+        return createSuggestion(options, resolveSpaceReference(space.space, space.wiki));
+      });
+    }, function() {
+      return [];
+    });
+  };
+
+  /**
+   * Loads a space that is already selected, in order to display it with its pretty name and hierarchy.
+   */
+  var loadSpace = function(value, options) {
+    var spaceReference = XWiki.Model.resolve(value, XWiki.EntityType.SPACE, options.documentReference);
+    var homeReference = new XWiki.EntityReference(webHome, XWiki.EntityType.DOCUMENT, spaceReference);
+    return $.getJSON(new XWiki.Document(homeReference).getRestURL(), $.param({
+      prettyNames: true
+    })).then(function(page) {
+      // An array is expected in xwiki.selectize.js
+      return [processPage(options, page)];
+    }, function() {
+      // The home page of the space may not exist, or may not be viewable. Fall back on the reference itself.
+      return [createSuggestion(options, spaceReference)];
+    });
+  };
+
+  var getRestSearchURL = function(searchScope) {
+    var spaces = searchScope.getReversedReferenceChain().filter(function(component) {
+      return component.type === XWiki.EntityType.SPACE;
+    }).map(function(component) {
+      return component.name;
+    });
+    var wiki = searchScope.extractReferenceValue(XWiki.EntityType.WIKI);
+    return XWiki.Document.getRestSearchURL('', spaces, wiki);
+  };
+
+  var resolveSpaceReference = function(localSpaceReference, wiki) {
+    return XWiki.Model.resolve(localSpaceReference, XWiki.EntityType.SPACE, [wiki]);
+  };
+
+  /**
+   * Adapts a page returned by the REST search or by the page resource to the format expected by the Selectize widget.
+   * The page is expected to be the home page of a space.
+   */
+  var processPage = function(options, page) {
+    var spaceReference = resolveSpaceReference(page.space, page.wiki);
+    var hierarchy = (page.hierarchy && page.hierarchy.items) || [];
+    var labels = hierarchy.filter(function(item) {
+      return item.type === 'space';
+    }).map(function(item) {
+      return item.label;
+    });
+    return createSuggestion(options, spaceReference, labels);
+  };
+
+  /**
+   * Adapts a space reference to the format expected by the Selectize widget. Exposed by this module so that the other
+   * ways of picking a space (e.g. browsing a document tree) can produce suggestions that look exactly like the ones
+   * suggested here.
+   *
+   * @param options the Selectize settings, used to know the document the value is saved in
+   * @param spaceReference the reference of the space to suggest
+   * @param labels the labels of the spaces in the hierarchy, the last one being the label of the given space; when not
+   *   specified the names from the space reference are used instead
+   */
+  var createSuggestion = function(options, spaceReference, labels) {
+    if (!labels || !labels.length) {
+      labels = spaceReference.getReversedReferenceChain().filter(function(component) {
+        return component.type === XWiki.EntityType.SPACE;
+      }).map(function(component) {
+        return component.name;
+      });
+    }
+    var relativeReference = spaceReference.relativeTo(options.documentReference.getRoot());
+    var homeReference = new XWiki.EntityReference(webHome, XWiki.EntityType.DOCUMENT, spaceReference);
+    return {
+      value: XWiki.Model.serialize(relativeReference),
+      label: labels[labels.length - 1],
+      // The hierarchy of the space, without the space itself.
+      hint: labels.slice(0, -1).join(' / '),
+      icon: spaceIcon,
+      url: new XWiki.Document(homeReference).getURL()
+    };
+  };
+
+  var removeDuplicates = function(suggestions) {
+    var seen = {};
+    return suggestions.filter(function(suggestion) {
+      if (Object.hasOwn(seen, suggestion.value)) {
+        return false;
+      }
+      seen[suggestion.value] = true;
+      return true;
+    });
+  };
+
+  $.fn.suggestSpaces = function(options) {
+    return this.each(function() {
+      var actualOptions = $.extend(getSelectizeOptions($(this)), options);
+      $(this).xwikiSelectize(processOptions(actualOptions));
+    });
+  };
+
+  return {
+    createSuggestion: createSuggestion
+  };
+});
+
+require(['jquery', 'xwiki-suggestSpaces', 'xwiki-events-bridge'], function($) {
+  var init = function(event, data) {
+    var container = $((data && data.elements) || document);
+    container.find('.suggest-spaces').suggestSpaces();
+  };
+
+  $(document).on('xwiki:dom:loaded xwiki:dom:updated', init);
+  $(init);
+});
+
+// End JavaScript-only code.
+}).apply(']]#', $jsontool.serialize([$spaceIcon, $webHome]));

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/multiLocationPicker.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/multiLocationPicker.css
@@ -1,0 +1,51 @@
+/**
+ * CSS for the multiple location picker: a space suggestion input plus a document tree to browse for locations.
+ */
+#template('colorThemeInit.vm')
+
+.location-picker-multi {
+  /* Lay the suggestion input and the browse button out in a row, like an input group. */
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+}
+
+.location-picker-multi > .ts-wrapper,
+.location-picker-multi > select.suggest-spaces {
+  /* The suggestion input takes all the space the browse button doesn't need. Note that the widget replaces the SELECT
+     with a wrapper of its own, so both have to grow. */
+  flex-grow: 1;
+}
+
+.location-picker-multi > .ts-wrapper > .ts-control,
+.location-picker-multi > select.suggest-spaces {
+  /* Combine with the browse button. The rounded border actually lives on the SELECT itself before it is enhanced, and
+     on its Tom Select generated .ts-control child afterwards, not on the wrapping .ts-wrapper. */
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.location-picker-multi > .location-picker-browse > .dropdown-toggle {
+  /* Combine with the suggestion input. Match its border color too: .btn-default's own border color doesn't line up
+     with the suggestion input's, which would otherwise show as a color seam where the two meet. */
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-left: none;
+  border-color: var(--input-border);
+}
+
+.location-picker-multi > .location-picker-browse > .dropdown-menu {
+  /* Leave enough room for a deep hierarchy, but keep the drop down short enough to fit below the button in most cases:
+     a deeper tree scrolls inside the drop down rather than making it taller. Bootstrap positions the drop down relative
+     to the button; the only thing we do from JavaScript is flip it above the button when it doesn't fit below. */
+  min-width: 20em;
+  max-width: calc(100vw - 2em);
+  max-height: 20em;
+  overflow: auto;
+  padding: .5em;
+}
+
+.location-picker-multi > .location-picker-browse > .dropdown-menu > .location-tree {
+  /* The tree scrolls with the drop down, it doesn't need a scroll bar of its own. */
+  margin: 0;
+}

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/multiLocationPicker.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/multiLocationPicker.css
@@ -12,22 +12,16 @@
 
 .location-picker-multi > .ts-wrapper,
 .location-picker-multi > select.suggest-spaces {
-  /* The suggestion input takes all the space the browse button doesn't need. Note that the widget replaces the SELECT
-     with a wrapper of its own, so both have to grow. */
   flex-grow: 1;
 }
 
 .location-picker-multi > .ts-wrapper > .ts-control,
 .location-picker-multi > select.suggest-spaces {
-  /* Combine with the browse button. The rounded border actually lives on the SELECT itself before it is enhanced, and
-     on its Tom Select generated .ts-control child afterwards, not on the wrapping .ts-wrapper. */
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
 }
 
 .location-picker-multi > .location-picker-browse > .dropdown-toggle {
-  /* Combine with the suggestion input. Match its border color too: .btn-default's own border color doesn't line up
-     with the suggestion input's, which would otherwise show as a color seam where the two meet. */
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
   border-left: none;
@@ -35,9 +29,7 @@
 }
 
 .location-picker-multi > .location-picker-browse > .dropdown-menu {
-  /* Leave enough room for a deep hierarchy, but keep the drop down short enough to fit below the button in most cases:
-     a deeper tree scrolls inside the drop down rather than making it taller. Bootstrap positions the drop down relative
-     to the button; the only thing we do from JavaScript is flip it above the button when it doesn't fit below. */
+  /* Leave enough room for a deep hierarchy, but keep the drop down short enough to fit below the button in most cases. */
   min-width: 20em;
   max-width: calc(100vw - 2em);
   max-height: 20em;
@@ -46,6 +38,5 @@
 }
 
 .location-picker-multi > .location-picker-browse > .dropdown-menu > .location-tree {
-  /* The tree scrolls with the drop down, it doesn't need a scroll bar of its own. */
   margin: 0;
 }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/multiLocationPicker.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/multiLocationPicker.js
@@ -25,9 +25,8 @@
   "use strict";
 
 /**
- * Lets the user browse a document tree in order to feed the space suggestion input it is attached to. The suggestion
- * input remains the single source of truth for the value: the tree only adds and removes items, it doesn't hold any
- * value of its own.
+ * Lets the user browse a document tree in order to feed the space suggestion input it is attached to. 
+ * The tree only adds and removes items, it does not hold a state itself.
  */
 define('xwiki-multiLocationPicker', ['jquery', 'xwiki-suggestSpaces', 'xwiki-tree'], function($, suggestSpaces) {
   webHome = webHome || 'WebHome';
@@ -50,11 +49,7 @@ define('xwiki-multiLocationPicker', ['jquery', 'xwiki-suggestSpaces', 'xwiki-tre
     var treeElement = menu.find('.location-tree');
     // Set while we update the tree to match the input, so that we don't then update the input back.
     var updatingTree = false;
-
-    /**
-     * The suggestion input is enhanced asynchronously, so we can only look for the widget when the user actually
-     * interacts with the tree.
-     */
+    
     var getSuggestInput = function() {
       return select[0] && select[0].selectize;
     };
@@ -89,8 +84,8 @@ define('xwiki-multiLocationPicker', ['jquery', 'xwiki-suggestSpaces', 'xwiki-tre
     };
 
     /**
-     * @return the suggestion matching the given tree node, in the exact format the suggestion input uses for the
-     *   locations it suggests itself, or null if the node is not a location
+     * @return the suggestion matching the given tree node, in the format of the suggestion input, 
+     *   or null if the node is not a location
      */
     var toSuggestion = function(suggestInput, tree, node) {
       var location = toLocation(tree, node);
@@ -150,7 +145,7 @@ define('xwiki-multiLocationPicker', ['jquery', 'xwiki-suggestSpaces', 'xwiki-tre
     };
 
     /**
-     * Hides the check box of the nodes that are not locations (e.g. the wiki nodes), so that it's clear what can be
+     * Hides the checkbox of the nodes that are not locations (e.g. the wiki nodes), so that it's clear what can be
      * picked.
      */
     var hideCheckboxOfNonLocations = function(tree) {
@@ -163,14 +158,9 @@ define('xwiki-multiLocationPicker', ['jquery', 'xwiki-suggestSpaces', 'xwiki-tre
     };
 
     /**
-     * The drop down is placed right below the button by the style sheet, which is always correct because it is
+     * The dropdown is placed right below the button by the style sheet, which is always correct because it is
      * positioned relative to the button. We only flip it above the button when there isn't enough room below, which
      * easily happens when the picker is displayed near the bottom of a dialog.
-     *
-     * Note that we deliberately toggle a class instead of computing the position of the drop down ourselves: any
-     * ancestor can establish a containing block (the dialog of the macro editor, for instance, is translated, which
-     * makes both absolute and fixed positioning resolve against it rather than against the viewport) and no amount of
-     * coordinate arithmetic is reliable in the face of that.
      */
     var flipIfNeeded = function() {
       browser.removeClass('dropup');

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/multiLocationPicker.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/multiLocationPicker.js
@@ -1,0 +1,238 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+/*!
+#set ($webHome = $services.model.getEntityReference('DOCUMENT', 'default').name)
+#[[*/
+// Start JavaScript-only code.
+(function(webHome) {
+  "use strict";
+
+/**
+ * Lets the user browse a document tree in order to feed the space suggestion input it is attached to. The suggestion
+ * input remains the single source of truth for the value: the tree only adds and removes items, it doesn't hold any
+ * value of its own.
+ */
+define('xwiki-multiLocationPicker', ['jquery', 'xwiki-suggestSpaces', 'xwiki-tree'], function($, suggestSpaces) {
+  webHome = webHome || 'WebHome';
+
+  // The prefix used by the document tree for the id of the nodes backing a page.
+  var documentNodePrefix = 'document:';
+
+  var enhance = function(element) {
+    var picker = $(element);
+    if (picker.data('locationPickerMulti')) {
+      // Already enhanced.
+      return;
+    }
+    picker.data('locationPickerMulti', true);
+
+    var select = picker.find('select.suggest-spaces');
+    var browser = picker.children('.location-picker-browse');
+    var toggle = browser.children('.dropdown-toggle');
+    var menu = browser.children('.dropdown-menu');
+    var treeElement = menu.find('.location-tree');
+    // Set while we update the tree to match the input, so that we don't then update the input back.
+    var updatingTree = false;
+
+    /**
+     * The suggestion input is enhanced asynchronously, so we can only look for the widget when the user actually
+     * interacts with the tree.
+     */
+    var getSuggestInput = function() {
+      return select[0] && select[0].selectize;
+    };
+
+    var toLocation = function(tree, node) {
+      if (node.id.indexOf(documentNodePrefix) !== 0) {
+        return null;
+      }
+      var documentReference = XWiki.Model.resolve(node.id.substring(documentNodePrefix.length),
+        XWiki.EntityType.DOCUMENT);
+      if (documentReference.name !== webHome) {
+        // Only the pages backing a space can be picked as a location. The tree is configured to hide the terminal pages
+        // but let's not rely on it.
+        return null;
+      }
+      return {
+        reference: documentReference.parent,
+        // The tree already knows the pretty name of each ancestor, so we get a proper hierarchy hint for free.
+        labels: getLabels(tree, node)
+      };
+    };
+
+    var getLabels = function(tree, node) {
+      var labels = [node.text];
+      // The parents are listed from the closest one to the root of the tree.
+      node.parents.forEach(function(parentId) {
+        if (parentId.indexOf(documentNodePrefix) === 0) {
+          labels.unshift(tree.get_node(parentId).text);
+        }
+      });
+      return labels;
+    };
+
+    /**
+     * @return the suggestion matching the given tree node, in the exact format the suggestion input uses for the
+     *   locations it suggests itself, or null if the node is not a location
+     */
+    var toSuggestion = function(suggestInput, tree, node) {
+      var location = toLocation(tree, node);
+      return location && suggestSpaces.createSuggestion(suggestInput.settings, location.reference, location.labels);
+    };
+
+    var addLocation = function(tree, node) {
+      var suggestInput = getSuggestInput();
+      if (updatingTree || !suggestInput) {
+        return;
+      }
+      var suggestion = toSuggestion(suggestInput, tree, node);
+      if (suggestion) {
+        suggestInput.addOption(suggestion);
+        suggestInput.addItem(suggestion.value);
+      }
+    };
+
+    var removeLocation = function(tree, node) {
+      var suggestInput = getSuggestInput();
+      if (updatingTree || !suggestInput) {
+        return;
+      }
+      var suggestion = toSuggestion(suggestInput, tree, node);
+      if (suggestion) {
+        suggestInput.removeItem(suggestion.value);
+      }
+    };
+
+    /**
+     * Checks the nodes matching the selected locations and unchecks the others, so that the tree reflects the value of
+     * the suggestion input, which can also be changed without the tree.
+     */
+    var updateTree = function(tree) {
+      var suggestInput = getSuggestInput();
+      if (!suggestInput) {
+        return;
+      }
+      updatingTree = true;
+      try {
+        // Only the nodes that have been loaded so far can be updated, which is enough: the others get their state from
+        // the value of the suggestion input when they are loaded.
+        tree.get_json('#', {'flat': true}).forEach(function(flatNode) {
+          var node = tree.get_node(flatNode.id);
+          var suggestion = toSuggestion(suggestInput, tree, node);
+          if (suggestion) {
+            if (suggestInput.items.indexOf(suggestion.value) < 0) {
+              tree.uncheck_node(node);
+            } else {
+              tree.check_node(node);
+            }
+          }
+        });
+      } finally {
+        updatingTree = false;
+      }
+    };
+
+    /**
+     * Hides the check box of the nodes that are not locations (e.g. the wiki nodes), so that it's clear what can be
+     * picked.
+     */
+    var hideCheckboxOfNonLocations = function(tree) {
+      tree.get_json('#', {'flat': true}).forEach(function(flatNode) {
+        var node = tree.get_node(flatNode.id);
+        if (!toLocation(tree, node)) {
+          tree.hide_checkbox(node);
+        }
+      });
+    };
+
+    /**
+     * The drop down is placed right below the button by the style sheet, which is always correct because it is
+     * positioned relative to the button. We only flip it above the button when there isn't enough room below, which
+     * easily happens when the picker is displayed near the bottom of a dialog.
+     *
+     * Note that we deliberately toggle a class instead of computing the position of the drop down ourselves: any
+     * ancestor can establish a containing block (the dialog of the macro editor, for instance, is translated, which
+     * makes both absolute and fixed positioning resolve against it rather than against the viewport) and no amount of
+     * coordinate arithmetic is reliable in the face of that.
+     */
+    var flipIfNeeded = function() {
+      browser.removeClass('dropup');
+      var button = toggle[0].getBoundingClientRect();
+      var roomBelow = document.documentElement.clientHeight - button.bottom;
+      var roomAbove = button.top;
+      if (roomBelow < menu[0].offsetHeight && roomAbove > roomBelow) {
+        browser.addClass('dropup');
+      }
+    };
+
+    browser.on('shown.bs.dropdown', function() {
+      var tree = $.jstree.reference(treeElement);
+      if (tree) {
+        updateTree(tree);
+      } else {
+        // The tree can only be initialized once its element is visible, otherwise it can't measure itself.
+        treeElement.xtree().on('ready.jstree refresh.jstree load_node.jstree', function(event, data) {
+          hideCheckboxOfNonLocations(data.instance);
+          updateTree(data.instance);
+          // Loading nodes changes the height of the drop down, so it may not fit below the button any more.
+          flipIfNeeded();
+        }).on('check_node.jstree', function(event, data) {
+          addLocation(data.instance, data.node);
+        }).on('uncheck_node.jstree', function(event, data) {
+          removeLocation(data.instance, data.node);
+        });
+      }
+      flipIfNeeded();
+    });
+
+    menu.on('click', function(event) {
+      // Browsing the tree must not close the drop down.
+      event.stopPropagation();
+    });
+
+    menu.on('keydown', function(event) {
+      // Same for typing in the tree finder, but let the Escape key through so that the drop down can still be closed
+      // from the keyboard.
+      if (event.which !== 27) {
+        event.stopPropagation();
+      }
+    });
+  };
+
+  $.fn.multiLocationPicker = function() {
+    return this.each(function() {
+      enhance(this);
+    });
+  };
+});
+
+require(['jquery', 'xwiki-multiLocationPicker', 'xwiki-events-bridge'], function($) {
+  var init = function(event, data) {
+    var elements = $((data && data.elements) || document);
+    elements.filter('.location-picker-multi').multiLocationPicker();
+    elements.find('.location-picker-multi').multiLocationPicker();
+  };
+
+  $(document).on('xwiki:dom:loaded xwiki:dom:updated', init);
+  $(init);
+});
+
+// End JavaScript-only code.
+}).apply(']]#', $jsontool.serialize([$webHome]));

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/multiLocationPicker.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/multiLocationPicker.js
@@ -192,6 +192,12 @@ define('xwiki-multiLocationPicker', ['jquery', 'xwiki-suggestSpaces', 'xwiki-tre
       flipIfNeeded();
     });
 
+    browser.on('hide.bs.dropdown', function() {
+      // The drop down can be closed without the toggle button getting focus back which would otherwise drop 
+      // the focus to the body.
+      toggle.trigger('focus');
+    });
+
     menu.on('click', function(event) {
       // Browsing the tree must not close the drop down.
       event.stopPropagation();

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/multiLocationPicker.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/multiLocationPicker.js
@@ -25,7 +25,7 @@
   "use strict";
 
 /**
- * Lets the user browse a document tree in order to feed the space suggestion input it is attached to. 
+ * Lets the user browse a document tree in order to feed the space suggestion input it is attached to.
  * The tree only adds and removes items, it does not hold a state itself.
  */
 define('xwiki-multiLocationPicker', ['jquery', 'xwiki-suggestSpaces', 'xwiki-tree'], function($, suggestSpaces) {
@@ -49,7 +49,7 @@ define('xwiki-multiLocationPicker', ['jquery', 'xwiki-suggestSpaces', 'xwiki-tre
     var treeElement = menu.find('.location-tree');
     // Set while we update the tree to match the input, so that we don't then update the input back.
     var updatingTree = false;
-    
+
     var getSuggestInput = function() {
       return select[0] && select[0].selectize;
     };
@@ -84,7 +84,7 @@ define('xwiki-multiLocationPicker', ['jquery', 'xwiki-suggestSpaces', 'xwiki-tre
     };
 
     /**
-     * @return the suggestion matching the given tree node, in the format of the suggestion input, 
+     * @return the suggestion matching the given tree node, in the format of the suggestion input,
      *   or null if the node is not a location
      */
     var toSuggestion = function(suggestInput, tree, node) {
@@ -193,7 +193,7 @@ define('xwiki-multiLocationPicker', ['jquery', 'xwiki-suggestSpaces', 'xwiki-tre
     });
 
     browser.on('hide.bs.dropdown', function() {
-      // The drop down can be closed without the toggle button getting focus back which would otherwise drop 
+      // The drop down can be closed without the toggle button getting focus back which would otherwise drop
       // the focus to the body.
       toggle.trigger('focus');
     });
@@ -206,7 +206,7 @@ define('xwiki-multiLocationPicker', ['jquery', 'xwiki-suggestSpaces', 'xwiki-tre
     menu.on('keydown', function(event) {
       // Same for typing in the tree finder, but let the Escape key through so that the drop down can still be closed
       // from the keyboard.
-      if (event.which !== 27) {
+      if (event.key !== 'Escape') {
         event.stopPropagation();
       }
     });
@@ -222,8 +222,7 @@ define('xwiki-multiLocationPicker', ['jquery', 'xwiki-suggestSpaces', 'xwiki-tre
 require(['jquery', 'xwiki-multiLocationPicker', 'xwiki-events-bridge'], function($) {
   var init = function(event, data) {
     var elements = $((data && data.elements) || document);
-    elements.filter('.location-picker-multi').multiLocationPicker();
-    elements.find('.location-picker-multi').multiLocationPicker();
+    elements.filter('.location-picker-multi').add(elements.find('.location-picker-multi')).multiLocationPicker();
   };
 
   $(document).on('xwiki:dom:loaded xwiki:dom:updated', init);


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-24636

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Added a space picker widget (single or multiple selection, suggestion-based).
* Added tests to cover this new picker.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Note that this is not used yet, but https://github.com/xwiki/xwiki-platform/pull/5999/changes depends on these changes for its "spaces" field.

This table is not completely up to date but gives an idea of the diff repartition:

| Bucket | Lines | Files |
|---|---:|---|
| **Space suggest-field widget** (JS autocomplete source) | 244 | `suggestSpaces.js` (244, new) |
| **multiLocationPicker widget** (new multi-value page+wiki picker) | 289 | `multiLocationPicker.js` (238), `multiLocationPicker.css` (51) |
| **Velocity glue wiring the space picker into the type-based displayer** | 110 | `macros.vm` (+25, `spacePicker`/`spacePicker_import` macros only), `locationPicker_macros.vm` (+61), `html_displayer/list(spacereference)/edit.vm` (24, new) |
| **Test coverage (IT)** | 202 | `SpacePickerIT.java` (202, new) |
| **Config / i18n** | 5 | `ApplicationResources.properties` (+5, `spacePicker.single`/`multi.title` keys only) |


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

<img width="2120" height="783" alt="XWIKI-24636-before-after" src="https://github.com/user-attachments/assets/1e50aa8a-2664-4962-997d-883d78c4bfe2" />

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Built the changes with `mvn clean install -Plegacy,snapshot  -pl xwiki-platform-core/xwiki-platform-oldcore,xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates,xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war  -Dxwiki.checkstyle.skip=true -Dxwiki.surefire.captureconsole.skip=true -Dxwiki.revapi.skip=true -DskipTests`

Ran the SpacePickerIT tests with `mvn clean verify -Plegacy,snapshot,integration-tests,docker -Dxwiki.checkstyle.skip=true -Dxwiki.surefire.captureconsole.skip=true -Dxwiki.revapi.skip=true -Dit.test=SpacePickerIT`
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None