### PR TITLE
[Misc] Retry the LibreOffice download when building the office test image

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/servletengine/ServletContainerExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/servletengine/ServletContainerExecutor.java
@@ -479,10 +479,20 @@ public class ServletContainerExecutor extends AbstractContainerExecutor
                                 + "apt-get --no-install-recommends -y install curl wget unzip procps libxinerama1 "
                                 + "libdbus-glib-1-2 libcairo2 libcups2 libsm6 libx11-xcb1 libnss3 "
                                 + "libxml2-dev libxslt1-dev")
-                            // Download the LibreOffice deb packages
-                            .run("wget --no-verbose -O /tmp/libreoffice.tar.gz $LIBREOFFICE_DOWNLOAD_URL && "
-                                + "mkdir /tmp/libreoffice && "
-                                + "tar -C /tmp/ -xvf /tmp/libreoffice.tar.gz")
+                            // Download and extract the LibreOffice deb packages.
+                            // The download URL points to a mirror redirector: each request is redirected to one of
+                            // the mirrors, and some of them are unreachable or serve a truncated archive. Thus we
+                            // retry the whole download several times, each attempt going back to the redirector and
+                            // thus having a chance to be served by a healthy mirror. The extraction is part of the
+                            // retried command so that a truncated archive leads to a new download too.
+                            .run("for i in 1 2 3 4 5; do "
+                                + "wget --no-verbose --timeout=60 --tries=2 --retry-connrefused "
+                                + "-O /tmp/libreoffice.tar.gz $LIBREOFFICE_DOWNLOAD_URL "
+                                + "&& tar -C /tmp/ -xf /tmp/libreoffice.tar.gz && exit 0; "
+                                + "echo \"Attempt $i to get LibreOffice from $LIBREOFFICE_DOWNLOAD_URL failed\"; "
+                                + "sleep 10; "
+                                + "done; "
+                                + "exit 1")
                             // Install the LibreOffice deb packages and create a symlink to have a consistent path to
                             // the LibreOffice installation directory
                             .run("cd `ls -d /tmp/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_x86-64_deb/DEBS` && "


### PR DESCRIPTION
# Jira URL

N/A — `[Misc]` commit (test framework robustness fix, no functional change).

# Changes

## Description

* Retry the LibreOffice download & extraction when building the dedicated office Docker test image, instead of giving up on the first failure.

Office tests build a Tomcat+LibreOffice image on the fly. The download step was a single unguarded `wget`, so any transient network hiccup killed the image build and thus the whole office test suite:

```
RuntimeException: Error setting up the XWiki testing environment on agent [a15-001lnv0ho0xu3]
└─ ContainerFetchException: Can't get Docker image
   └─ DockerClientException: Could not build image: The command
      '/bin/sh -c wget --no-verbose -O /tmp/libreoffice.tar.gz $LIBREOFFICE_DOWNLOAD_URL && ...'
      returned a non-zero code: 4
```

Seen on [stable-18.4.x #124](https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/stable-18.4.x/124/) (`wget` exit code 4 = network failure).

## Clarifications

* `$LIBREOFFICE_DOWNLOAD_URL` points at `download.documentfoundation.org`, which is a **MirrorBrain redirector**: every request is bounced to some volunteer mirror (a local test run got redirected to `miroir.univ-lorraine.fr`). Mirrors regularly go down, rate-limit, or truncate transfers, which is exactly the shape of this flicker.
* The retry loop re-issues the request to the **redirector**, so each attempt has a chance of landing on a healthy mirror. This is why `wget`'s own `--tries` is not enough on its own: it retries the already-resolved mirror URL and stays pinned to the broken mirror.
* The extraction is inside the retried command, so a truncated archive triggers a fresh download rather than failing in `tar`.
* `--retry-on-http-error` / `--retry-on-host-error` were deliberately *not* used: an unrecognized flag on an older `wget` would turn a flicker into a permanent failure, and the outer loop already covers those cases.
* Two incidental cleanups in the same command: `mkdir /tmp/libreoffice` was dead (the tarball extracts to `/tmp/`) and would have broken retries with "File exists"; `tar -xvf` became `-xf` to avoid repeating the file listing on every attempt.
* Note that agents already holding a working office image will not rebuild it (the image name hashes the *base* image, not the Dockerfile), so this takes effect as images get refreshed.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

* Dumped the generated Dockerfile through the real Testcontainers `DockerfileBuilder` to confirm `run(String)` emits shell form verbatim (no JSON-exec quoting that would break the loop).
* **Failure path**, real `docker build` against a deliberately missing archive: 5 attempts, one clear diagnostic line each, layer exits 1 → the build fails properly instead of silently succeeding.
* **Success path**, real `docker build` with the actual LTS URL (25.8.7): 212 MB downloaded and extracted, and the downstream `ls -d /tmp/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_x86-64_deb/DEBS` glob still resolves (42 debs found), confirming the `mkdir` removal and `-xvf`→`-xf` are safe.
* `mvn -B -ntp verify -DskipTests` in `xwiki-platform-test-docker`: BUILD SUCCESS, 0 Checkstyle violations, license and Revapi clean.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * stable-18.6.x
  * stable-18.4.x
  * stable-17.10.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)
