### PR TITLE
[Misc] Revert the java:S5785 changes on the equals()/hashCode() contract tests

### DIFF
--- a/xwiki-platform-core/xwiki-platform-bridge/src/test/java/org/xwiki/bridge/ActionExecutingEventTest.java
+++ b/xwiki-platform-core/xwiki-platform-bridge/src/test/java/org/xwiki/bridge/ActionExecutingEventTest.java
@@ -25,7 +25,6 @@ import org.xwiki.bridge.event.ActionExecutingEvent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -34,6 +33,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * 
  * @version $Id$
  */
+// The equals() and hashCode() tests below verify those contracts themselves, so their assertions
+// deliberately call equals() (or compare hashCode() values) explicitly: the boolean form is what makes
+// visible which object is the receiver and which argument it gets, including null and an instance of a
+// foreign class. Using assertEquals()/assertNotEquals() would move that into JUnit's internals and would
+// invite a later SonarQube S3415 "swap these arguments" change that silently stops testing the contract.
+// That is why those methods, and only those, carry @SuppressWarnings("java:S5785").
 class ActionExecutingEventTest
 {
     // Tests for constructors
@@ -151,102 +156,116 @@ class ActionExecutingEventTest
     // Tests for equals(Object)
 
     @Test
+    @SuppressWarnings("java:S5785")
     void equalsSameObject()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("something");
-        assertEquals(event, event, "Same object wasn't equal!");
+        assertTrue(event.equals(event), "Same object wasn't equal!");
     }
 
     @Test
+    @SuppressWarnings("java:S5785")
     void equalsSameAction()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("something");
-        assertEquals(event, new ActionExecutingEvent("something"), "Same action wasn't equal!");
+        assertTrue(event.equals(new ActionExecutingEvent("something")), "Same action wasn't equal!");
     }
 
     @Test
+    @SuppressWarnings("java:S5785")
     void equalsWithNull()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("something");
-        assertNotEquals(event, null, "null was equal!");
+        assertFalse(event.equals(null), "null was equal!");
     }
 
     @Test
+    @SuppressWarnings("java:S5785")
     void doesntEqualWildcardAction()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("something");
-        assertNotEquals(event, new ActionExecutingEvent(), "Wildcard action was equal!");
+        assertFalse(event.equals(new ActionExecutingEvent()), "Wildcard action was equal!");
     }
 
     @Test
+    @SuppressWarnings("java:S5785")
     void doesntEqualDifferentAction()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("something");
-        assertNotEquals(event, new ActionExecutingEvent("else"), "A different action was equal!");
+        assertFalse(event.equals(new ActionExecutingEvent("else")), "A different action was equal!");
     }
 
     @Test
+    @SuppressWarnings("java:S5785")
     void doesntEqualDifferentCaseAction()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("something");
-        assertNotEquals(event, new ActionExecutingEvent("SomeThing"),
+        assertFalse(event.equals(new ActionExecutingEvent("SomeThing")),
             "Action equals comparison was case insensitive!");
     }
 
     @Test
+    @SuppressWarnings("java:S5785")
     void doesntEqualDifferentTypeOfAction()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("something");
-        assertNotEquals(event, new ActionExecutedEvent("something"), "Same object isn't matched!");
+        assertFalse(event.equals(new ActionExecutedEvent("something")), "Same object isn't matched!");
     }
 
     @Test
+    @SuppressWarnings("java:S5785")
     void wildcardActionDoesntEqualOtherActions()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("something");
-        assertNotEquals(new ActionExecutingEvent(), event, "Wildcard action equals another action!");
+        assertFalse(new ActionExecutingEvent().equals(event), "Wildcard action equals another action!");
     }
 
     @Test
+    @SuppressWarnings("java:S5785")
     void wildcardActionDoesntEqualEmptyAction()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("");
-        assertNotEquals(new ActionExecutingEvent(), event, "Wildcard action equals another action!");
+        assertFalse(new ActionExecutingEvent().equals(event), "Wildcard action equals another action!");
     }
 
     @Test
+    @SuppressWarnings("java:S5785")
     void wildcardActionEqualsWildcardAction()
     {
-        assertEquals(new ActionExecutingEvent(), new ActionExecutingEvent(),
+        assertTrue(new ActionExecutingEvent().equals(new ActionExecutingEvent()),
             "Wildcard action isn't equal to another wildcard action");
     }
 
     @Test
+    @SuppressWarnings("java:S5785")
     void wildcardActionDoesntEqualNull()
     {
-        assertNotEquals(new ActionExecutingEvent(), null, "Wildcard action equals null!");
+        assertFalse(new ActionExecutingEvent().equals(null), "Wildcard action equals null!");
     }
 
     // Tests for hashCode()
 
     @Test
+    @SuppressWarnings("java:S5785")
     void verifyHashCode()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("something");
-        assertNotEquals(0, event.hashCode(), "Hashcode was zero!");
+        assertTrue(event.hashCode() != 0, "Hashcode was zero!");
     }
 
     @Test
+    @SuppressWarnings("java:S5785")
     void hashCodeWithEmptyAction()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("");
-        assertEquals(0, event.hashCode(), "Hashcode for empty string action wasn't zero!");
+        assertTrue(event.hashCode() == 0, "Hashcode for empty string action wasn't zero!");
     }
 
     @Test
+    @SuppressWarnings("java:S5785")
     void hashCodeForWildcardAction()
     {
         ActionExecutingEvent event = new ActionExecutingEvent();
-        assertEquals(0, event.hashCode(), "Hashcode for wildcard action wasn't zero!");
+        assertTrue(event.hashCode() == 0, "Hashcode for wildcard action wasn't zero!");
     }
 }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/AbstractRecordableEventDescriptorTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/AbstractRecordableEventDescriptorTest.java
@@ -36,7 +36,9 @@ import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -183,6 +185,12 @@ class AbstractRecordableEventDescriptorTest
     }
 
     @Test
+    // This method verifies the equals() contract itself, so the assertions deliberately call equals()
+    // explicitly: the boolean form is what makes visible which object is the receiver and which argument
+    // it gets, including an instance of a foreign class. Using assertEquals()/assertNotEquals() would move
+    // that into JUnit's internals and would invite a later SonarQube S3415 "swap these arguments" change
+    // that silently stops testing the contract.
+    @SuppressWarnings("java:S5785")
     void equalsAndHashCodeTest()
     {
         OtherFakeRecordableEventDescriptor descriptor1 = new OtherFakeRecordableEventDescriptor(
@@ -195,11 +203,11 @@ class AbstractRecordableEventDescriptorTest
                 "app1", "type2");
 
 
-        assertEquals(descriptor1, descriptor1);
-        assertEquals(descriptor1, descriptor2);
-        assertNotEquals(descriptor1, descriptor3);
-        assertNotEquals(descriptor1, descriptor4);
-        assertNotEquals(descriptor1, new Object());
+        assertTrue(descriptor1.equals(descriptor1));
+        assertTrue(descriptor1.equals(descriptor2));
+        assertFalse(descriptor1.equals(descriptor3));
+        assertFalse(descriptor1.equals(descriptor4));
+        assertFalse(descriptor1.equals(new Object()));
 
         assertEquals(descriptor1.hashCode(), descriptor1.hashCode());
         assertEquals(descriptor1.hashCode(), descriptor2.hashCode());

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/SimpleEventQueryTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/SimpleEventQueryTest.java
@@ -486,6 +486,12 @@ class SimpleEventQueryTest
     }
 
     @Test
+    // This method verifies the equals() contract itself, so the assertions deliberately call equals()
+    // explicitly: the boolean form is what makes visible which object is the receiver and which argument
+    // it gets, including null. Using assertEquals()/assertNotEquals() would move that into JUnit's
+    // internals and would invite a later SonarQube S3415 "swap these arguments" change that silently stops
+    // testing the contract.
+    @SuppressWarnings("java:S5785")
     void equalsandhascode()
     {
         SimpleEventQuery query1 = new SimpleEventQuery();
@@ -506,22 +512,22 @@ class SimpleEventQueryTest
         SimpleEventQuery query4bis = new SimpleEventQuery();
         query4bis.eq("prop", "value");
 
-        assertEquals(query1, query1);
-        assertEquals(query1bis, query1bis);
+        assertTrue(query1.equals(query1));
+        assertTrue(query1bis.equals(query1bis));
 
-        assertEquals(query2, query2);
-        assertEquals(query2bis, query2bis);
+        assertTrue(query2.equals(query2));
+        assertTrue(query2bis.equals(query2bis));
 
-        assertEquals(query3, query3);
-        assertEquals(query3bis, query3bis);
+        assertTrue(query3.equals(query3));
+        assertTrue(query3bis.equals(query3bis));
 
-        assertEquals(query4, query4);
-        assertEquals(query4bis, query4bis);
+        assertTrue(query4.equals(query4));
+        assertTrue(query4bis.equals(query4bis));
 
-        assertNotEquals(query1, query2);
-        assertNotEquals(query1, query3);
-        assertNotEquals(query1, query4);
-        assertNotEquals(query1, null);
+        assertFalse(query1.equals(query2));
+        assertFalse(query1.equals(query3));
+        assertFalse(query1.equals(query4));
+        assertFalse(query1.equals(null));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-observation/src/test/java/org/xwiki/observation/ActionExecutionEventTest.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-observation/src/test/java/org/xwiki/observation/ActionExecutionEventTest.java
@@ -23,20 +23,26 @@ import org.junit.jupiter.api.Test;
 import org.xwiki.observation.event.ActionExecutionEvent;
 import org.xwiki.observation.event.Event;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Deprecated
 class ActionExecutionEventTest
 {
     @Test
+    // This method verifies the equals() contract itself, so the assertions deliberately call equals()
+    // explicitly: the boolean form is what makes visible which object is the receiver and which argument
+    // it gets. Using assertEquals()/assertNotEquals() would move that into JUnit's internals and would
+    // invite a later SonarQube S3415 "swap these arguments" change that silently stops testing the
+    // contract.
+    @SuppressWarnings("java:S5785")
     void actionExecutionEventEquals()
     {
         Event e1 = new ActionExecutionEvent("test");
         Event e2 = new ActionExecutionEvent("test");
         Event e3 = new ActionExecutionEvent("different");
-        assertEquals(e1, e1);
-        assertEquals(e1, e2);
-        assertNotEquals(e1, e3);
+        assertTrue(e1.equals(e1));
+        assertTrue(e1.equals(e2));
+        assertFalse(e1.equals(e3));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/EntityReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/EntityReferenceTest.java
@@ -36,7 +36,6 @@ import org.xwiki.model.EntityType;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -148,6 +147,12 @@ class EntityReferenceTest
     }
 
     @Test
+    // This method verifies the equals() contract itself, so the assertions deliberately call equals()
+    // explicitly: the boolean form is what makes visible which object is the receiver and which argument
+    // it gets. Using assertEquals()/assertNotEquals() would move that into JUnit's internals and would
+    // invite a later SonarQube S3415 "swap these arguments" change that silently stops testing the
+    // contract.
+    @SuppressWarnings("java:S5785")
     void validateEquals()
     {
         EntityReference reference1 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
@@ -180,19 +185,19 @@ class EntityReferenceTest
         EntityReference reference10 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
             new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI, null, map)));
 
-        assertEquals(reference1, reference1);
-        assertEquals(reference2, reference1);
-        assertNotEquals(reference3, reference1);
-        assertNotEquals(reference4, reference1);
-        assertNotEquals(reference5, reference1);
-        assertNotEquals(reference6, reference1);
+        assertTrue(reference1.equals(reference1));
+        assertTrue(reference1.equals(reference2));
+        assertFalse(reference1.equals(reference3));
+        assertFalse(reference1.equals(reference4));
+        assertFalse(reference1.equals(reference5));
+        assertFalse(reference1.equals(reference6));
         assertEquals(reference6, new EntityReference(PAGE_NAME, EntityType.DOCUMENT));
-        assertNotEquals(reference7, reference1);
-        assertEquals(reference8, reference7);
-        assertNotEquals(reference9, reference1);
-        assertNotEquals(reference9, reference7);
-        assertNotEquals(reference10, reference1);
-        assertNotEquals(reference10, reference7);
+        assertFalse(reference1.equals(reference7));
+        assertTrue(reference7.equals(reference8));
+        assertFalse(reference1.equals(reference9));
+        assertFalse(reference7.equals(reference9));
+        assertFalse(reference1.equals(reference10));
+        assertFalse(reference7.equals(reference10));
     }
 
     @Test
@@ -243,6 +248,10 @@ class EntityReferenceTest
     }
 
     @Test
+    // This method verifies the hashCode() contract itself, so the assertions deliberately compare the two
+    // hashCode() values explicitly rather than through assertEquals()/assertNotEquals(), which would move
+    // the comparison into JUnit's internals and hide which value comes from which reference.
+    @SuppressWarnings("java:S5785")
     void validateHashCode()
     {
         EntityReference reference1 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
@@ -277,17 +286,17 @@ class EntityReferenceTest
 
         assertEquals(reference1.hashCode(), reference1.hashCode());
         assertEquals(reference1.hashCode(), reference2.hashCode());
-        assertNotEquals(reference1.hashCode(), reference3.hashCode());
-        assertNotEquals(reference1.hashCode(), reference4.hashCode());
-        assertNotEquals(reference1.hashCode(), reference5.hashCode());
-        assertNotEquals(reference1.hashCode(), reference6.hashCode());
+        assertFalse(reference1.hashCode() == reference3.hashCode());
+        assertFalse(reference1.hashCode() == reference4.hashCode());
+        assertFalse(reference1.hashCode() == reference5.hashCode());
+        assertFalse(reference1.hashCode() == reference6.hashCode());
         assertEquals(reference6.hashCode(), new EntityReference(PAGE_NAME, EntityType.DOCUMENT).hashCode());
-        assertNotEquals(reference1.hashCode(), reference7.hashCode());
+        assertFalse(reference1.hashCode() == reference7.hashCode());
         assertEquals(reference7.hashCode(), reference8.hashCode());
-        assertNotEquals(reference1.hashCode(), reference9.hashCode());
-        assertNotEquals(reference7.hashCode(), reference9.hashCode());
-        assertNotEquals(reference1.hashCode(), reference10.hashCode());
-        assertNotEquals(reference7.hashCode(), reference10.hashCode());
+        assertFalse(reference1.hashCode() == reference9.hashCode());
+        assertFalse(reference7.hashCode() == reference9.hashCode());
+        assertFalse(reference1.hashCode() == reference10.hashCode());
+        assertFalse(reference7.hashCode() == reference10.hashCode());
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/RegexEntityReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/RegexEntityReferenceTest.java
@@ -24,8 +24,8 @@ import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import org.xwiki.model.EntityType;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Validate {@link RegexEntityReference} class.
@@ -33,16 +33,17 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
  * @version $Id$
  */
 // RegexEntityReference.equals() is an asymmetric matcher: it runs the regex only when the regex
-// reference is the receiver. JUnit evaluates assertEquals(expected, actual) as
-// expected.equals(actual), so the regex reference must stay the first argument. Swapping to
-// expected-first order (as SonarQube's S3415 suggests) would call the concrete reference's
-// equals() and skip regex matching, breaking the tests.
-@SuppressWarnings("java:S3415")
+// reference is the receiver. The assertions below therefore call equals() explicitly, so that the
+// receiver is visible at the call site. Using assertEquals()/assertNotEquals() would move the call into
+// JUnit's internals and would invite a later SonarQube S3415 "swap these arguments" change, which would
+// call the concrete reference's equals() instead and skip regex matching altogether. That is why those
+// methods carry @SuppressWarnings("java:S5785").
 class RegexEntityReferenceTest
 {
     private static final DocumentReference REFERENCETOMATCH = new DocumentReference("wiki", "space", "page");
 
     @Test
+    @SuppressWarnings("java:S5785")
     void equalsWhenExact()
     {
         EntityReference wikiReference =
@@ -55,51 +56,56 @@ class RegexEntityReferenceTest
             new RegexEntityReference(Pattern.compile(REFERENCETOMATCH.getName(), Pattern.LITERAL), EntityType.DOCUMENT,
                 spaceReference);
 
-        assertEquals(reference, REFERENCETOMATCH);
+        assertTrue(reference.equals(REFERENCETOMATCH));
     }
 
     @Test
+    @SuppressWarnings("java:S5785")
     void equalsWithOnlyPage()
     {
         EntityReference reference =
             new RegexEntityReference(Pattern.compile(REFERENCETOMATCH.getName(), Pattern.LITERAL), EntityType.DOCUMENT);
 
-        assertEquals(reference, REFERENCETOMATCH);
+        assertTrue(reference.equals(REFERENCETOMATCH));
     }
 
     @Test
+    @SuppressWarnings("java:S5785")
     void equalsWithOnlyWiki()
     {
         EntityReference reference =
             new RegexEntityReference(Pattern.compile(REFERENCETOMATCH.getWikiReference().getName(), Pattern.LITERAL),
                 EntityType.WIKI);
 
-        assertEquals(reference, REFERENCETOMATCH);
+        assertTrue(reference.equals(REFERENCETOMATCH));
     }
 
     @Test
+    @SuppressWarnings("java:S5785")
     void equalsWithPattern()
     {
         EntityReference reference = new RegexEntityReference(Pattern.compile("p.*"), EntityType.DOCUMENT);
 
-        assertEquals(reference, REFERENCETOMATCH);
+        assertTrue(reference.equals(REFERENCETOMATCH));
     }
 
     @Test
+    @SuppressWarnings("java:S5785")
     void equalsWhenPatternNotMatching()
     {
         EntityReference reference = new RegexEntityReference(Pattern.compile("space"), EntityType.DOCUMENT);
 
-        assertNotEquals(reference, REFERENCETOMATCH);
+        assertFalse(reference.equals(REFERENCETOMATCH));
     }
 
     @Test
+    @SuppressWarnings("java:S5785")
     void equalsWhenNonRegexParent()
     {
         EntityReference reference =
             new RegexEntityReference(Pattern.compile("space"), EntityType.SPACE, new EntityReference("wiki",
                 EntityType.WIKI));
 
-        assertEquals(reference, REFERENCETOMATCH);
+        assertTrue(reference.equals(REFERENCETOMATCH));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
@@ -1122,12 +1122,18 @@ class XWikiDocumentMockitoTest
     }
 
     @Test
+    // This method verifies the equals() contract itself, so the assertions deliberately call equals()
+    // explicitly: the boolean form is what makes visible which object is the receiver and which argument
+    // it gets. Using assertEquals()/assertNotEquals() would move that into JUnit's internals and would
+    // invite a later SonarQube S3415 "swap these arguments" change that silently stops testing the
+    // contract.
+    @SuppressWarnings("java:S5785")
     void testEqualsDatas()
     {
         XWikiDocument document = new XWikiDocument(new DocumentReference("wiki", "space", "page"));
         XWikiDocument otherDocument = document.clone();
 
-        assertEquals(document, otherDocument);
+        assertTrue(document.equals(otherDocument));
         assertTrue(document.equalsData(otherDocument));
 
         otherDocument.setAuthorReference(new DocumentReference("wiki", "space", "otherauthor"));
@@ -1139,11 +1145,17 @@ class XWikiDocumentMockitoTest
 
         document.setMinorEdit(false);
 
-        assertNotEquals(document, otherDocument);
+        assertFalse(document.equals(otherDocument));
         assertTrue(document.equalsData(otherDocument));
     }
 
     @Test
+    // This method verifies the equals() contract itself, so the assertions deliberately call equals()
+    // explicitly: the boolean form is what makes visible which object is the receiver and which argument
+    // it gets. Using assertEquals()/assertNotEquals() would move that into JUnit's internals and would
+    // invite a later SonarQube S3415 "swap these arguments" change that silently stops testing the
+    // contract.
+    @SuppressWarnings("java:S5785")
     void testEqualsAttachments() throws XWikiException
     {
         XWikiDocument document = new XWikiDocument(new DocumentReference("wiki", "space", "page"));
@@ -1153,12 +1165,12 @@ class XWikiDocumentMockitoTest
         XWikiAttachment otherAttachment =
             otherDocument.addAttachment("file", new byte[] {1, 2}, this.oldcore.getXWikiContext());
 
-        assertEquals(document, otherDocument);
+        assertTrue(document.equals(otherDocument));
         assertTrue(document.equalsData(otherDocument));
 
         otherAttachment.setContent(new byte[] {1, 2, 3});
 
-        assertNotEquals(document, otherDocument);
+        assertFalse(document.equals(otherDocument));
         assertFalse(document.equalsData(otherDocument));
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiLinkTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiLinkTest.java
@@ -22,7 +22,7 @@ package com.xpn.xwiki.doc;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Unit tests for the {@link XWikiLink} class.
@@ -32,6 +32,12 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 class XWikiLinkTest
 {
     @Test
+    // This method verifies the equals() contract itself, so the assertions deliberately call equals()
+    // explicitly: the boolean form is what makes visible which object is the receiver and which argument
+    // it gets, including null. Using assertEquals()/assertNotEquals() would move that into JUnit's
+    // internals and would invite a later SonarQube S3415 "swap these arguments" change that silently stops
+    // testing the contract.
+    @SuppressWarnings("java:S5785")
     void testXWikiLinkEquals()
     {
         final long docId = 101;
@@ -55,7 +61,7 @@ class XWikiLinkTest
         assertEquals(l1, l3);
 
         // equals null == false
-        assertNotEquals(l1, null);
+        assertFalse(l1.equals(null));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/NumberPropertyTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/NumberPropertyTest.java
@@ -22,16 +22,23 @@ package com.xpn.xwiki.objects;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link NumberProperty}.
  *
  * @version $Id$
  */
+// The equals() tests below verify that contract itself, so their assertions deliberately call equals()
+// explicitly: the boolean form is what makes visible which object is the receiver and which argument it
+// gets, which matters here because the null-valued and non-null-valued sides are not interchangeable.
+// Using assertEquals()/assertNotEquals() would move that into JUnit's internals and would invite a later
+// SonarQube S3415 "swap these arguments" change that silently stops testing the contract. That is why
+// those methods, and only those, carry @SuppressWarnings("java:S5785").
 class NumberPropertyTest
 {
     /**
@@ -39,6 +46,7 @@ class NumberPropertyTest
      * NPE (<a href="https://jira.xwiki.org/browse/XWIKI-9326">XWIKI-9326</a>).
      */
     @Test
+    @SuppressWarnings("java:S5785")
     void nullValueEqualsWithOtherNumberProperty()
     {
         IntegerProperty nullValueProperty = new IntegerProperty();
@@ -50,7 +58,7 @@ class NumberPropertyTest
         assertNotNull(notNullValueProperty.getValue());
 
         // Should not throw a NPE.
-        assertNotEquals(nullValueProperty, notNullValueProperty);
+        assertFalse(nullValueProperty.equals(notNullValueProperty));
     }
 
     /**
@@ -58,6 +66,7 @@ class NumberPropertyTest
      * NPE (<a href="https://jira.xwiki.org/browse/XWIKI-9326">XWIKI-9326</a>).
      */
     @Test
+    @SuppressWarnings("java:S5785")
     void notNullValueEqualsWithOtherNullNumberProperty()
     {
         IntegerProperty nullValueProperty = new IntegerProperty();
@@ -69,7 +78,7 @@ class NumberPropertyTest
         assertNull(notNullValueProperty.getValue());
 
         // Should not throw a NPE.
-        assertNotEquals(nullValueProperty, notNullValueProperty);
+        assertFalse(nullValueProperty.equals(notNullValueProperty));
     }
 
     /**
@@ -77,6 +86,7 @@ class NumberPropertyTest
      * (<a href="https://jira.xwiki.org/browse/XWIKI-9326">XWIKI-9326</a>).
      */
     @Test
+    @SuppressWarnings("java:S5785")
     void equalNullValueEquals()
     {
         IntegerProperty nullValueProperty1 = new IntegerProperty();
@@ -88,13 +98,14 @@ class NumberPropertyTest
         assertNull(nullValueProperty2.getValue());
 
         // Should not throw a NPE.
-        assertEquals(nullValueProperty1, nullValueProperty2);
+        assertTrue(nullValueProperty1.equals(nullValueProperty2));
     }
 
     /**
      * Two equal non-null values.
      */
     @Test
+    @SuppressWarnings("java:S5785")
     void equalNotNullValues()
     {
         IntegerProperty nullValueProperty = new IntegerProperty();
@@ -103,13 +114,14 @@ class NumberPropertyTest
         IntegerProperty notNullValueProperty = new IntegerProperty();
         notNullValueProperty.setValue(1);
 
-        assertEquals(nullValueProperty, notNullValueProperty);
+        assertTrue(nullValueProperty.equals(notNullValueProperty));
     }
 
     /**
      * Two not equal non-null values.
      */
     @Test
+    @SuppressWarnings("java:S5785")
     void notEqualNonNullValues()
     {
         IntegerProperty nullValueProperty = new IntegerProperty();
@@ -118,7 +130,7 @@ class NumberPropertyTest
         IntegerProperty notNullValueProperty = new IntegerProperty();
         notNullValueProperty.setValue(1);
 
-        assertNotEquals(nullValueProperty, notNullValueProperty);
+        assertFalse(nullValueProperty.equals(notNullValueProperty));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/job/question/EntitySelectionTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/job/question/EntitySelectionTest.java
@@ -24,8 +24,9 @@ import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.EntityReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link EntitySelection}.
@@ -35,6 +36,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class EntitySelectionTest
 {
     @Test
+    // This method verifies the equals() contract itself, so the assertions deliberately call equals()
+    // explicitly: the boolean form is what makes visible which object is the receiver and which argument
+    // it gets, including null and an instance of a foreign class. Using assertEquals()/assertNotEquals()
+    // would move that into JUnit's internals and would invite a later SonarQube S3415 "swap these
+    // arguments" change that silently stops testing the contract.
+    @SuppressWarnings("java:S5785")
     void equals()
     {
         EntityReference entityReference = new EntityReference("test", EntityType.PAGE);
@@ -43,11 +50,11 @@ class EntitySelectionTest
         EntitySelection unselected = new EntitySelection(entityReference);
         unselected.setSelected(false);
 
-        assertNotEquals(selected, null);
-        assertEquals(selected, selected);
-        assertNotEquals(selected, entityReference);
-        assertNotEquals(selected, unselected);
-        assertEquals(selected, new EntitySelection(entityReference));
+        assertFalse(selected.equals(null));
+        assertTrue(selected.equals(selected));
+        assertFalse(selected.equals(entityReference));
+        assertFalse(selected.equals(unselected));
+        assertTrue(selected.equals(new EntitySelection(entityReference)));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/RightMapTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/RightMapTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -311,16 +310,26 @@ class RightMapTest
     }
 
     @Test
+    // This method verifies the equals() contract itself, so the assertion deliberately calls equals()
+    // explicitly: the boolean form is what makes visible which map is the receiver and which argument it
+    // gets. Using assertNotEquals() would move that into JUnit's internals and would invite a later
+    // SonarQube S3415 "swap these arguments" change that silently stops testing the contract.
+    @SuppressWarnings("java:S5785")
     void equalsWhenDifferent()
     {
         RightMap<Object> other = new RightMap<>();
         for (Right key : POPULATED_KEYS) {
             other.put(key, newValue());
         }
-        assertNotEquals(populatedMap, other);
+        assertFalse(populatedMap.equals(other));
     }
 
     @Test
+    // This method verifies the equals() contract itself, so the assertion deliberately calls equals()
+    // explicitly: the boolean form is what makes visible which map is the receiver and which argument it
+    // gets. Using assertNotEquals() would move that into JUnit's internals and would invite a later
+    // SonarQube S3415 "swap these arguments" change that silently stops testing the contract.
+    @SuppressWarnings("java:S5785")
     void equalsForLargerMap()
     {
         RightMap<Object> largerMap = new RightMap<>();
@@ -328,17 +337,22 @@ class RightMapTest
             largerMap.put(key, populatedMap.get(key));
         }
         largerMap.put(Right.PROGRAM, newValue());
-        assertNotEquals(populatedMap, largerMap);
+        assertFalse(populatedMap.equals(largerMap));
     }
 
     @Test
+    // This method verifies the equals() contract itself, so the assertion deliberately calls equals()
+    // explicitly: the boolean form is what makes visible which map is the receiver and which argument it
+    // gets. Using assertNotEquals() would move that into JUnit's internals and would invite a later
+    // SonarQube S3415 "swap these arguments" change that silently stops testing the contract.
+    @SuppressWarnings("java:S5785")
     void equalsForSmallerMap()
     {
         RightMap<Object> smallerMap = new RightMap<>();
         for (int i = 0; i < POPULATED_KEYS.length - 1; i++) {
             smallerMap.put(POPULATED_KEYS[i], populatedMap.get(POPULATED_KEYS[i]));
         }
-        assertNotEquals(populatedMap, smallerMap);
+        assertFalse(populatedMap.equals(smallerMap));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/RightSetTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/RightSetTest.java
@@ -26,7 +26,7 @@ import org.apache.commons.collections4.set.AbstractSetTest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Test Set interface of RightSet.
@@ -85,6 +85,11 @@ class RightSetTest extends AbstractSetTest<Right>
      */
     @Test
     @Override
+    // This method verifies the equals() contract itself, so the assertions deliberately call equals()
+    // explicitly: the boolean form is what makes visible which set is the receiver and which argument it
+    // gets. Using assertNotEquals() would move that into JUnit's internals and would invite a later
+    // SonarQube S3415 "swap these arguments" change that silently stops testing the contract.
+    @SuppressWarnings("java:S5785")
     public void testSetEquals()
     {
         resetEmpty();
@@ -94,7 +99,7 @@ class RightSetTest extends AbstractSetTest<Right>
         final Set<Right> set2 = makeConfirmedCollection();
         // CUSTOM: the standard #testSetEquals add a String here, which does not make any sense for RightSet
         set2.add(Right.VIEW);
-        assertNotEquals(getCollection(), set2, "Empty set shouldn't equal nonempty set");
+        assertFalse(getCollection().equals(set2), "Empty set shouldn't equal nonempty set");
 
         resetFull();
         assertEquals(getCollection(), getConfirmed(), "Full sets should be equal");
@@ -102,6 +107,6 @@ class RightSetTest extends AbstractSetTest<Right>
 
         set2.clear();
         set2.addAll(Arrays.asList(getOtherElements()));
-        assertNotEquals(getCollection(), set2, "Sets with different contents shouldn't be equal");
+        assertFalse(getCollection().equals(set2), "Sets with different contents shouldn't be equal");
     }
 }

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/test/java/org/xwiki/url/ExtendedURLTest.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/test/java/org/xwiki/url/ExtendedURLTest.java
@@ -36,6 +36,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -119,6 +120,12 @@ class ExtendedURLTest
     }
 
     @Test
+    // This method verifies the equals() contract itself, so the assertions deliberately call equals()
+    // explicitly: the boolean form is what makes visible which object is the receiver and which argument
+    // it gets, including null and an instance of a foreign class. Using assertEquals()/assertNotEquals()
+    // would move that into JUnit's internals and would invite a later SonarQube S3415 "swap these
+    // arguments" change that silently stops testing the contract.
+    @SuppressWarnings("java:S5785")
     void equality() throws Exception
     {
         ExtendedURL extendedURL1 = new ExtendedURL(new URL("http://localhost:8080/some/path"), null);
@@ -132,9 +139,9 @@ class ExtendedURLTest
         assertNotEquals(extendedURL1, extendedURL4);
         assertNotEquals(extendedURL3, extendedURL4);
 
-        assertNotEquals(extendedURL1, null);
-        assertEquals(extendedURL1, extendedURL1);
-        assertNotEquals(extendedURL1, extendedURL1.getWrappedURL());
+        assertFalse(extendedURL1.equals(null));
+        assertTrue(extendedURL1.equals(extendedURL1));
+        assertFalse(extendedURL1.equals(extendedURL1.getWrappedURL()));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-webjars/xwiki-platform-webjars-api/src/test/java/org/xwiki/webjars/WebJarResourceReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-webjars/xwiki-platform-webjars-api/src/test/java/org/xwiki/webjars/WebJarResourceReferenceTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.xwiki.webjars.internal.WebJarsResourceReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Unit tests for {@link org.xwiki.webjars.internal.WebJarsResourceReference}.
@@ -36,6 +36,12 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 class WebJarResourceReferenceTest
 {
     @Test
+    // This method verifies the equals() and hashCode() contracts themselves, so the assertions
+    // deliberately call equals() (or compare hashCode() values) explicitly: the boolean form is what makes
+    // visible which object is the receiver and which argument it gets. Using
+    // assertEquals()/assertNotEquals() would move that into JUnit's internals and would invite a later
+    // SonarQube S3415 "swap these arguments" change that silently stops testing the contract.
+    @SuppressWarnings("java:S5785")
     void equalsAndHashCode()
     {
         WebJarsResourceReference reference1 = new WebJarsResourceReference("namespace", List.of("one", "two"));
@@ -53,10 +59,10 @@ class WebJarResourceReferenceTest
         assertEquals(reference2, reference1);
         assertEquals(reference2.hashCode(), reference1.hashCode());
 
-        assertNotEquals(reference3, reference1);
-        assertNotEquals(reference3.hashCode(), reference1.hashCode());
+        assertFalse(reference3.equals(reference1));
+        assertFalse(reference3.hashCode() == reference1.hashCode());
 
-        assertNotEquals(reference4, reference3);
-        assertNotEquals(reference4.hashCode(), reference3.hashCode());
+        assertFalse(reference4.equals(reference3));
+        assertFalse(reference4.hashCode() == reference3.hashCode());
     }
 }


### PR DESCRIPTION
# Jira URL

N/A — `[Misc]` change (test-only cleanup, no functional impact).

# Changes

## Description

* Restores the boolean form of the 88 assertions that four earlier java:S5785 passes converted inside
  equals()/hashCode() **contract** tests, across 14 test files in 9 modules:
  `ActionExecutingEventTest`, `AbstractRecordableEventDescriptorTest`, `SimpleEventQueryTest`,
  `ActionExecutionEventTest` (legacy-observation), `EntityReferenceTest`, `RegexEntityReferenceTest`,
  `XWikiDocumentMockitoTest`, `XWikiLinkTest`, `NumberPropertyTest`, `EntitySelectionTest`,
  `RightMapTest`, `RightSetTest`, `ExtendedURLTest`, `WebJarResourceReferenceTest`.
* Records the reason in the code instead of accepting the issues in SonarCloud:
  `@SuppressWarnings("java:S5785")` plus a short comment on each contract-test method.
* Drops the now-unnecessary class-level `@SuppressWarnings("java:S3415")` from
  `RegexEntityReferenceTest`, whose assertions call `equals()` explicitly again.

## Clarifications

* Why the conversion is wrong at these sites: JUnit compares through
  `AssertionUtils.objectsAreEqual(a, b)` (`a == null ? b == null : a.equals(b)`). The transformation is
  mechanically safe, but the call site stops showing which object is the receiver, and it invites a
  later java:S3415 "swap these arguments" change that *would* break the test — which is exactly what
  already happened to `RegexEntityReferenceTest`, whose `equals()` is an asymmetric matcher that only
  runs the regex when the regex reference is the receiver.
* The suppression is placed **per method**, not per class, so that java:S5785 keeps being enforced on
  the non-equals test methods of the same classes.
* Scope: only assertions inside equals()/hashCode() contract tests are reverted. Conversions in
  ordinary tests that merely happen to compare two values with `equals()` are kept — for instance the
  11 `size()`/`==`/GUID-string sites in `XWikiDocumentMockitoTest` and all 50 sites of the chart-macro
  pass (9aac8edf6b1).
* Reverts the contract-test parts of 1eafd658a13, a94435cb30c, ce509be1144 and d5ac2bd37e0. The
  equivalent revert was already done in xwiki-commons (855f7bec62) and the rule is now documented in
  the `sonarqube` dev-LLM skill, so this class of change should not recur.
* Those four commits are also on `stable-18.6.x` (branch cut after them), so the same 88 sites exist
  there. 

# Screenshots & Video

N/A — no UI change.

# Executed Tests

```
mvn -B -ntp test -Plegacy -DfailIfNoTests=false \
  -pl xwiki-platform-core/xwiki-platform-bridge,\
xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api,\
xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api,\
xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api,\
xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api,\
xwiki-platform-core/xwiki-platform-webjars/xwiki-platform-webjars-api \
  -Dtest='ActionExecutingEventTest,AbstractRecordableEventDescriptorTest,SimpleEventQueryTest,\
EntityReferenceTest,RegexEntityReferenceTest,EntitySelectionTest,ExtendedURLTest,\
WebJarResourceReferenceTest'

mvn -B -ntp test -Plegacy -DfailIfNoTests=false \
  -pl xwiki-platform-core/xwiki-platform-oldcore,\
xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api,\
xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-observation \
  -Dtest='XWikiDocumentMockitoTest,XWikiLinkTest,NumberPropertyTest,RightMapTest,RightSetTest,\
ActionExecutionEventTest'
```

Both green — 9 modules, `BUILD SUCCESS`, 0 failures / 0 errors.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
