### PR TITLE
XWIKI-24593: Create/check for automated tests for "Typography Font Family Sans Serif"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker/src/test/it/org/xwiki/flamingo/test/ui/FlamingoThemeIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker/src/test/it/org/xwiki/flamingo/test/ui/FlamingoThemeIT.java
@@ -207,6 +207,37 @@ class FlamingoThemeIT
         assertColor(255, 255, 255, vp.getPageBackgroundColor());
     }
 
+    /**
+     * Verify that setting only the "Font Family Sans Serif" variable (and leaving "Font Family Base" empty) is
+     * enough for the custom font to be applied, since Bootstrap LESS makes {@code @font-family-base} fall back to
+     * {@code @font-family-sans-serif} by default.
+     */
+    @Test
+    void validateFontFamilySansSerifFallback(TestUtils setup, TestInfo info)
+    {
+        setup.loginAsSuperAdmin();
+
+        String testMethodName = info.getTestMethod().get().getName();
+        setup.deletePage("FlamingoThemes", testMethodName);
+
+        AdministrationPage administrationPage = AdministrationPage.gotoPage();
+        ThemesAdministrationSectionPage presentationAdministrationSectionPage =
+            administrationPage.clickThemesSection();
+        presentationAdministrationSectionPage.manageColorThemes();
+        ThemeApplicationWebHomePage themeApplicationWebHomePage = new ThemeApplicationWebHomePage();
+
+        EditThemePage editThemePage = themeApplicationWebHomePage.createNewTheme(testMethodName);
+        editThemePage.setAutoRefresh(false);
+        editThemePage.selectVariableCategory("Typography");
+        editThemePage.setVariableValue("font-family-sans-serif", "math");
+        editThemePage.refreshPreview();
+
+        PreviewBox previewBox = editThemePage.getPreviewBox();
+        assertFalse(previewBox.hasError());
+        assertEquals("math", previewBox.getTitleFontFamily().toLowerCase());
+        previewBox.switchToDefaultContent();
+    }
+
     private void assertCustomThemeColors(ViewPage page)
     {
         // FIXME: The following should be put back when https://github.com/SeleniumHQ/selenium/issues/7697 will be fixed

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker/src/test/it/org/xwiki/flamingo/test/ui/FlamingoThemeIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker/src/test/it/org/xwiki/flamingo/test/ui/FlamingoThemeIT.java
@@ -270,15 +270,13 @@ class FlamingoThemeIT
         editThemePage.setVariableValue("xwiki-page-content-bg", "#ffdada");
         // Again...
         editThemePage.selectVariableCategory("Typography");
-        // Verify that setting only "Font Family Sans Serif" (and leaving "Font Family Base" empty) is enough for
-        // the custom font to be applied, since Bootstrap LESS makes @font-family-base fall back to
-        // @font-family-sans-serif by default (see: https://jira.xwiki.org/browse/XWIKI-24593).
+        // Verify that setting only "Font Family Sans Serif" (and leaving "Font Family Base" empty) is enough for the
+        // custom font to be applied, since Bootstrap's LESS makes @font-family-base fall back to
+        // @font-family-sans-serif. Note that "math" is a CSS generic font family and not a font name: the assertion
+        // below reads the computed CSS value, so no matching font needs to be installed on the OS running the browser.
+        // Avoid the "fantasy" generic family here since Firefox doesn't support it on Linux.
         editThemePage.setVariableValue("font-family-sans-serif", "math");
-        try {
-            editThemePage.refreshPreview();
-        } catch (TimeoutException e) {
-            editThemePage.refreshPreview();
-        }
+        refreshPreviewWithRetry(editThemePage);
         previewBox = editThemePage.getPreviewBox();
         assertFalse(previewBox.hasError());
         assertEquals("math", previewBox.getTitleFontFamily().toLowerCase());
@@ -289,19 +287,24 @@ class FlamingoThemeIT
         editThemePage.selectVariableCategory("Advanced");
         editThemePage.setTextareaValue("lessCode", ".main{ color: #0000ff; }");
         // Refresh
-        // From time-to-time the preview does not load on Firefox certainly because of some JS race condition.
-        // Right now we cannot get the javascript console logs because of a geckodriver limitation, so it's hard to
-        // fix properly. For now, I'm trying to just trigger once again the refresh in case of first timeout.
-        try {
-            editThemePage.refreshPreview();
-        } catch (TimeoutException e) {
-            editThemePage.refreshPreview();
-        }
+        refreshPreviewWithRetry(editThemePage);
         previewBox = editThemePage.getPreviewBox();
         // Verify that there is still no errors
         assertFalse(previewBox.hasError());
         // Verify colors
         assertCustomThemeColors(previewBox);
         previewBox.switchToDefaultContent();
+    }
+
+    // From time-to-time the preview does not load on Firefox certainly because of some JS race condition.
+    // Right now we cannot get the javascript console logs because of a geckodriver limitation, so it's hard to
+    // fix properly. For now, we just trigger once again the refresh in case of first timeout.
+    private void refreshPreviewWithRetry(EditThemePage editThemePage)
+    {
+        try {
+            editThemePage.refreshPreview();
+        } catch (TimeoutException e) {
+            editThemePage.refreshPreview();
+        }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker/src/test/it/org/xwiki/flamingo/test/ui/FlamingoThemeIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker/src/test/it/org/xwiki/flamingo/test/ui/FlamingoThemeIT.java
@@ -107,6 +107,37 @@ class FlamingoThemeIT
         validateSetThemeFromPageAdminUI(testMethodName, setup, info);
     }
 
+    /**
+     * Verify that setting only the "Font Family Sans Serif" variable (and leaving "Font Family Base" empty) is
+     * enough for the custom font to be applied, since Bootstrap LESS makes {@code @font-family-base} fall back to
+     * {@code @font-family-sans-serif} by default (see: https://jira.xwiki.org/browse/XWIKI-24593).
+     */
+    @Test
+    void validateFontFamilySansSerifFallback(TestUtils setup, TestInfo info)
+    {
+        setup.loginAsSuperAdmin();
+
+        String testMethodName = info.getTestMethod().get().getName();
+        setup.deletePage("FlamingoThemes", testMethodName);
+
+        AdministrationPage administrationPage = AdministrationPage.gotoPage();
+        ThemesAdministrationSectionPage presentationAdministrationSectionPage =
+            administrationPage.clickThemesSection();
+        presentationAdministrationSectionPage.manageColorThemes();
+        ThemeApplicationWebHomePage themeApplicationWebHomePage = new ThemeApplicationWebHomePage();
+
+        EditThemePage editThemePage = themeApplicationWebHomePage.createNewTheme(testMethodName);
+        editThemePage.setAutoRefresh(false);
+        editThemePage.selectVariableCategory("Typography");
+        editThemePage.setVariableValue("font-family-sans-serif", "math");
+        editThemePage.refreshPreview();
+
+        PreviewBox previewBox = editThemePage.getPreviewBox();
+        assertFalse(previewBox.hasError());
+        assertEquals("math", previewBox.getTitleFontFamily().toLowerCase());
+        previewBox.switchToDefaultContent();
+    }
+
     private void validateThemeCreation(ThemeApplicationWebHomePage themeApplicationWebHomePage, String testMethodName)
     {
         EditThemePage editThemePage = themeApplicationWebHomePage.createNewTheme(testMethodName);
@@ -205,37 +236,6 @@ class FlamingoThemeIT
         // Charcoal background color set.
         vp = setup.gotoPage("NonExistentSpace", "NonExistentPage");
         assertColor(255, 255, 255, vp.getPageBackgroundColor());
-    }
-
-    /**
-     * Verify that setting only the "Font Family Sans Serif" variable (and leaving "Font Family Base" empty) is
-     * enough for the custom font to be applied, since Bootstrap LESS makes {@code @font-family-base} fall back to
-     * {@code @font-family-sans-serif} by default.
-     */
-    @Test
-    void validateFontFamilySansSerifFallback(TestUtils setup, TestInfo info)
-    {
-        setup.loginAsSuperAdmin();
-
-        String testMethodName = info.getTestMethod().get().getName();
-        setup.deletePage("FlamingoThemes", testMethodName);
-
-        AdministrationPage administrationPage = AdministrationPage.gotoPage();
-        ThemesAdministrationSectionPage presentationAdministrationSectionPage =
-            administrationPage.clickThemesSection();
-        presentationAdministrationSectionPage.manageColorThemes();
-        ThemeApplicationWebHomePage themeApplicationWebHomePage = new ThemeApplicationWebHomePage();
-
-        EditThemePage editThemePage = themeApplicationWebHomePage.createNewTheme(testMethodName);
-        editThemePage.setAutoRefresh(false);
-        editThemePage.selectVariableCategory("Typography");
-        editThemePage.setVariableValue("font-family-sans-serif", "math");
-        editThemePage.refreshPreview();
-
-        PreviewBox previewBox = editThemePage.getPreviewBox();
-        assertFalse(previewBox.hasError());
-        assertEquals("math", previewBox.getTitleFontFamily().toLowerCase());
-        previewBox.switchToDefaultContent();
     }
 
     private void assertCustomThemeColors(ViewPage page)

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker/src/test/it/org/xwiki/flamingo/test/ui/FlamingoThemeIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker/src/test/it/org/xwiki/flamingo/test/ui/FlamingoThemeIT.java
@@ -107,37 +107,6 @@ class FlamingoThemeIT
         validateSetThemeFromPageAdminUI(testMethodName, setup, info);
     }
 
-    /**
-     * Verify that setting only the "Font Family Sans Serif" variable (and leaving "Font Family Base" empty) is
-     * enough for the custom font to be applied, since Bootstrap LESS makes {@code @font-family-base} fall back to
-     * {@code @font-family-sans-serif} by default (see: https://jira.xwiki.org/browse/XWIKI-24593).
-     */
-    @Test
-    void validateFontFamilySansSerifFallback(TestUtils setup, TestInfo info)
-    {
-        setup.loginAsSuperAdmin();
-
-        String testMethodName = info.getTestMethod().get().getName();
-        setup.deletePage("FlamingoThemes", testMethodName);
-
-        AdministrationPage administrationPage = AdministrationPage.gotoPage();
-        ThemesAdministrationSectionPage presentationAdministrationSectionPage =
-            administrationPage.clickThemesSection();
-        presentationAdministrationSectionPage.manageColorThemes();
-        ThemeApplicationWebHomePage themeApplicationWebHomePage = new ThemeApplicationWebHomePage();
-
-        EditThemePage editThemePage = themeApplicationWebHomePage.createNewTheme(testMethodName);
-        editThemePage.setAutoRefresh(false);
-        editThemePage.selectVariableCategory("Typography");
-        editThemePage.setVariableValue("font-family-sans-serif", "math");
-        editThemePage.refreshPreview();
-
-        PreviewBox previewBox = editThemePage.getPreviewBox();
-        assertFalse(previewBox.hasError());
-        assertEquals("math", previewBox.getTitleFontFamily().toLowerCase());
-        previewBox.switchToDefaultContent();
-    }
-
     private void validateThemeCreation(ThemeApplicationWebHomePage themeApplicationWebHomePage, String testMethodName)
     {
         EditThemePage editThemePage = themeApplicationWebHomePage.createNewTheme(testMethodName);
@@ -301,6 +270,20 @@ class FlamingoThemeIT
         editThemePage.setVariableValue("xwiki-page-content-bg", "#ffdada");
         // Again...
         editThemePage.selectVariableCategory("Typography");
+        // Verify that setting only "Font Family Sans Serif" (and leaving "Font Family Base" empty) is enough for
+        // the custom font to be applied, since Bootstrap LESS makes @font-family-base fall back to
+        // @font-family-sans-serif by default (see: https://jira.xwiki.org/browse/XWIKI-24593).
+        editThemePage.setVariableValue("font-family-sans-serif", "math");
+        try {
+            editThemePage.refreshPreview();
+        } catch (TimeoutException e) {
+            editThemePage.refreshPreview();
+        }
+        previewBox = editThemePage.getPreviewBox();
+        assertFalse(previewBox.hasError());
+        assertEquals("math", previewBox.getTitleFontFamily().toLowerCase());
+        previewBox.switchToDefaultContent();
+
         editThemePage.setVariableValue("font-family-base", "Monospace");
         // Test that the @lessCode variable is handled too!
         editThemePage.selectVariableCategory("Advanced");


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-24593

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added a test in the FlamingoThemeIT test suite that checks that the sans serif variable works as expected with a keyword

## Clarification

* I updated slightly the manual test itself and took this updated test as the base for the automatic test, because it used to have inconsistent results (see https://jira.xwiki.org/browse/XWIKI-24593).

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, test change only.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Ran the new test both in firefox and chrome, both passed:
* `mvn -q -pl xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker -Plegacy,snapshot,integration-tests,docker verify -Dit.test=FlamingoThemeIT#validateFontFamilySansSerifFallback -Dxwiki.test.ui.browser=firefox -Dxwiki.revapi.skip=true -Dxwiki.checkstyle.skip=true`
* `mvn -q -pl xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker -Plegacy,snapshot,integration-tests,docker
  verify -Dit.test=FlamingoThemeIT#validateFontFamilySansSerifFallback -Dxwiki.test.ui.browser=chrome -Dxwiki.revapi.skip=true -Dxwiki.checkstyle.skip=true`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None.