### PR TITLE
XWIKI-24590: Create/check for automated tests for "Buttons Default Background"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker/src/test/it/org/xwiki/flamingo/test/ui/FlamingoThemeIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker/src/test/it/org/xwiki/flamingo/test/ui/FlamingoThemeIT.java
@@ -37,6 +37,7 @@ import org.xwiki.test.docker.junit5.UITest;
 import org.xwiki.test.integration.junit.LogCaptureConfiguration;
 import org.xwiki.test.ui.TestUtils;
 import org.xwiki.test.ui.po.ViewPage;
+import org.xwiki.test.ui.po.editor.WikiEditPage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -101,7 +102,7 @@ class FlamingoThemeIT
         validateViewAndSetThemeFromThemeHomePage(testMethodName);
 
         // Validate setting a color theme from the wiki Admin UI
-        validateSetThemeFromWikiAdminUI(testMethodName);
+        validateSetThemeFromWikiAdminUI(testMethodName, setup);
 
         // Validate setting a color theme from the page Admin UI for the page and its children
         validateSetThemeFromPageAdminUI(testMethodName, setup, info);
@@ -144,7 +145,7 @@ class FlamingoThemeIT
         themeApplicationWebHomePage.useTheme("Charcoal");
     }
 
-    private void validateSetThemeFromWikiAdminUI(String testMethodName)
+    private void validateSetThemeFromWikiAdminUI(String testMethodName, TestUtils setup)
     {
         // Go back to the Theme Admin UI to verify we can set the new theme from there too (using the select control)
         AdministrationPage administrationPage = AdministrationPage.gotoPage();
@@ -163,6 +164,14 @@ class FlamingoThemeIT
         EditThemePage editThemePage = new EditThemePage();
         assertFalse(editThemePage.getPreviewBox().hasError(true));
         editThemePage.clickSaveAndView();
+
+        // Verify that the default button background defined by the theme is applied on a wiki page, the "Cancel"
+        // button of the editor being one of the buttons using that style.
+        // Note: the skin doesn't use the @btn-default-bg value as-is, it lightens it by 5% (see buttons.less), which
+        // turns the #99ccff set on the theme into #b3d9ff.
+        WikiEditPage wikiEditPage = WikiEditPage.gotoPage("Main", "WebHome");
+        assertColor(179, 217, 255, wikiEditPage.getCancelButtonBackgroundColor());
+        wikiEditPage.clickCancel();
 
         // Switch back to Charcoal
         // TODO: Replace this with a setup.updateObject() call since we don't need to test the useTheme() UI as it's
@@ -271,6 +280,10 @@ class FlamingoThemeIT
         // Again...
         editThemePage.selectVariableCategory("Typography");
         editThemePage.setVariableValue("font-family-base", "Monospace");
+        // Change the background of the buttons using the default style. It's light enough to keep a proper contrast
+        // with the button text color.
+        editThemePage.selectVariableCategory("Buttons");
+        editThemePage.setVariableValue("btn-default-bg", "#99ccff");
         // Test that the @lessCode variable is handled too!
         editThemePage.selectVariableCategory("Advanced");
         editThemePage.setTextareaValue("lessCode", ".main{ color: #0000ff; }");

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/editor/EditPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/editor/EditPage.java
@@ -244,6 +244,15 @@ public class EditPage extends BasePage
     }
 
     /**
+     * @return the background color of the "Cancel" button, which uses the default button style
+     * @since 18.7.0RC1
+     */
+    public String getCancelButtonBackgroundColor()
+    {
+        return this.cancel.getCssValue("background-color");
+    }
+
+    /**
      * @return the editor being used on this page
      */
     public Editor getEditor()


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24590

# Changes

## Description

Automates the [Buttons Default Background](https://test.xwiki.org/xwiki/bin/view/Color%20Themes%20Tests/Buttons%20Default%20Background) manual test, which had no automated coverage.

* `FlamingoThemeIT`: select the **Buttons** category in the color theme editor and set `@btn-default-bg`, then verify that a button using the default style gets that background on a wiki page once the theme is applied wiki-wide. The button checked is the editor **Cancel** button, the very example given by the manual test.
* `EditPage`: new `getCancelButtonBackgroundColor()` page-object accessor (`@since 18.7.0RC1`).

## Clarifications

* **Why extend the existing test rather than add a new one.** `FlamingoThemeIT.validateColorThemeFeatures` is the only automated test that edits color theme variables, and it already creates a theme, sets variables and applies the theme wiki-wide — the expensive part. The module also documents that it deliberately holds a single UI test (it asserts that the default color theme is Charcoal, which only holds if no other test has changed it). Adding the two new steps to that flow costs one extra page load instead of a full second theme lifecycle.
* **Prior coverage.** The existing test asserted that the "Buttons" category is *listed* among the variable categories, but never set a button variable nor asserted any button colour. No test anywhere in the repo asserted a `btn-default*` value.
* **Why the expected RGB is not the value that was set.** The skin renders `.btn-default` with `lighten(@btn-default-bg, 5%)` (`flamingo/less/buttons.less`), so the `#99ccff` configured on the theme is rendered as `#b3d9ff` = `rgb(179, 217, 255)`. This is recorded in a comment next to the assertion so the value isn't a magic number.
* **Why the Cancel button and not a content-menu button.** `#contentmenu .btn-default` is deliberately restyled to `@breadcrumb-bg` (`flamingo/less/action-menus.less`) and ignores `@btn-default-bg` entirely, so content-menu buttons are not valid targets for this check. This was confirmed by a first run that returned `rgb(245, 245, 245)`.
* The colour chosen is light enough to keep a proper contrast ratio with the default button text colour, so the WCAG checks stay happy when they are enabled.

# Screenshots & Video

No UI change (test-only).

# Executed Tests

```
mvn -B -ntp verify -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker/pom.xml
```
→ `Tests run: 1, Failures: 0, Errors: 0, Skipped: 0` (146 s), 0 Checkstyle violations.

```
mvn -B -ntp install -f xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/pom.xml -DskipTests
```
→ BUILD SUCCESS, 0 Checkstyle violations.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
