### PR TITLE
XWIKI-24595: DefaultSolrIndexer sends an empty add request to a remote Solr, causing a "missing content stream" error

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <!-- Name to display by the Extension Manager -->
     <xwiki.extension.name>Solr Search API</xwiki.extension.name>
-    <xwiki.jacoco.instructionRatio>0.44</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.45</xwiki.jacoco.instructionRatio>
     <!-- TODO: Remove once the tests have been fixed to not output anything to the console! -->
     <xwiki.surefire.captureconsole.skip>true</xwiki.surefire.captureconsole.skip>
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/AbstractSolrInstance.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/AbstractSolrInstance.java
@@ -66,6 +66,12 @@ public abstract class AbstractSolrInstance implements SolrInstance
     @Override
     public void add(List<SolrInputDocument> solrDocuments) throws SolrServerException, IOException
     {
+        // An update request without any document has no body, which a remote Solr rejects with a
+        // "missing content stream" error. There is also nothing to send, so skip the request entirely.
+        if (solrDocuments.isEmpty()) {
+            return;
+        }
+
         this.logger.debug("Add Solr documents [{}] to index", solrDocuments);
 
         this.server.getClient().add(solrDocuments);

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrIndexer.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrIndexer.java
@@ -631,6 +631,12 @@ public class DefaultSolrIndexer implements SolrIndexer, Initializable, Disposabl
 
     private void flushDocuments(List<SolrInputDocument> documents)
     {
+        // An update request without any document has no body, which a remote Solr rejects with a
+        // "missing content stream" error. There is also nothing to send, so skip the request entirely.
+        if (documents.isEmpty()) {
+            return;
+        }
+
         try {
             // Copy the documents to flush to a new list so that we can clear the original list without affecting the
             // documents that are being added to the Solr server.

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/SolrClientInstanceTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/SolrClientInstanceTest.java
@@ -1,0 +1,81 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.search.solr.internal;
+
+import java.util.List;
+
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.common.SolrInputDocument;
+import org.junit.jupiter.api.Test;
+import org.xwiki.search.solr.Solr;
+import org.xwiki.search.solr.XWikiSolrCore;
+import org.xwiki.search.solr.internal.search.SearchCoreInitializer;
+import org.xwiki.test.annotation.BeforeComponent;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link SolrClientInstance} and the behaviour it inherits from {@link AbstractSolrInstance}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+class SolrClientInstanceTest
+{
+    @MockComponent
+    private Solr solr;
+
+    private final SolrClient client = mock();
+
+    @InjectMockComponents
+    private SolrClientInstance instance;
+
+    @BeforeComponent
+    void beforeComponent() throws Exception
+    {
+        XWikiSolrCore core = mock();
+        when(core.getClient()).thenReturn(this.client);
+        when(this.solr.getCore(SearchCoreInitializer.CORE_NAME)).thenReturn(core);
+    }
+
+    @Test
+    void addEmptyDocumentListSendsNoRequest() throws Exception
+    {
+        this.instance.add(List.of());
+
+        verifyNoInteractions(this.client);
+    }
+
+    @Test
+    void addDocumentList() throws Exception
+    {
+        List<SolrInputDocument> documents = List.of(new SolrInputDocument());
+
+        this.instance.add(documents);
+
+        verify(this.client).add(documents);
+    }
+}


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24595

# Changes

## Description

* `DefaultSolrIndexer.flushDocuments()` now returns immediately when the batch of documents to flush
  is empty, instead of sending a Solr `add` for an empty collection. SolrJ turns such a request into
  a POST without a body, which the update handler of a remote Solr rejects with `missing content
  stream`, logging an ERROR with a stack trace.
* Added the same guard in `AbstractSolrInstance.add(List)` so that the invariant holds for any
  future caller of the `SolrInstance` API.

## Clarifications

* The empty flush happens on a legitimate code path: `commit()` calls `flushDocuments()`
  unconditionally, and one of its callers in `processBatch()` is `case READY_MARKER`, which fires
  whether or not any document was collected. That is exactly the reported scenario — the startup
  sync job posts its ready marker after reporting 0 documents added, deleted and updated, which
  produces a `commit()` on an empty list.
* This only surfaces with a remote Solr. `EmbeddedSolrServer` accepts an empty `add`, which is why
  the error was never seen with the default embedded configuration.
* The error was benign (indexing proceeded normally); the fix removes the log pollution and spares
  a pointless round trip to the Solr server.
* Guarding in `flushDocuments()` rather than only in the `SolrInstance` API also avoids scheduling a
  no-op task on `solrClientExecutor`. The commit that follows the flush is unaffected — a commit
  request carries parameters and is valid on its own.
* The `xwiki.jacoco.instructionRatio` of the module was raised from `0.44` to `0.45` to lock in the
  coverage brought by the new tests (locally achieved: `0.455`).

# Screenshots & Video

N/A — no UI change.

# Executed Tests

Full module build with the quality profile, from
`xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api`:

```
mvn install -B -ntp -Plegacy,quality
```

`Tests run: 120, Failures: 0, Errors: 0, Skipped: 0`, Checkstyle and the JaCoCo check pass with the
raised ratio.

New `SolrClientInstanceTest` covers both branches of `AbstractSolrInstance.add(List)`:
`addEmptyDocumentListSendsNoRequest` asserts that no interaction at all reaches the `SolrClient`, and
`addDocumentList` asserts that a non-empty list is still forwarded. The first test fails without the
fix.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  *

🤖 Generated with [Claude Code](https://claude.com/claude-code)
