### PR TITLE
XWIKI-24646: notification cache can be repopulated with an outdated result after its invalidation

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/pom.xml
@@ -34,7 +34,7 @@
     <!-- Skipping revapi since xwiki-platform-legacy-notifications-notifiers-api wraps this module and runs checks on it
      -->
     <xwiki.revapi.skip>true</xwiki.revapi.skip>
-    <xwiki.jacoco.instructionRatio>0.79</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.80</xwiki.jacoco.instructionRatio>
   </properties>
   <dependencies>
     <dependency>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/DefaultAsyncNotificationRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/DefaultAsyncNotificationRenderer.java
@@ -105,11 +105,11 @@ public class DefaultAsyncNotificationRenderer implements AsyncRenderer
     @Override
     public AsyncRendererResult render(boolean async, boolean cached) throws RenderingException
     {
-        // Get the epoch before the events are retrieved below, so that the result is not cached if the events change
-        // in the meantime.
+        // Get the epoch before the events are retrieved below, so that the result is not cached for the current epoch
+        // if the events change in the meantime.
         long epoch = this.notificationCacheManager.getEpoch();
         Object fromCache =
-            this.notificationCacheManager.getFromCache(this.cacheKey, this.configuration.isCount(), true);
+            this.notificationCacheManager.getFromCache(this.cacheKey, this.configuration.isCount(), true, epoch);
 
         NotificationParameters notificationParameters = this.configuration.getNotificationParameters();
         List<CompositeEvent> events = null;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/DefaultAsyncNotificationRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/DefaultAsyncNotificationRenderer.java
@@ -105,6 +105,9 @@ public class DefaultAsyncNotificationRenderer implements AsyncRenderer
     @Override
     public AsyncRendererResult render(boolean async, boolean cached) throws RenderingException
     {
+        // Get the epoch before the events are retrieved below, so that the result is not cached if the events change
+        // in the meantime.
+        long epoch = this.notificationCacheManager.getEpoch();
         Object fromCache =
             this.notificationCacheManager.getFromCache(this.cacheKey, this.configuration.isCount(), true);
 
@@ -117,7 +120,7 @@ public class DefaultAsyncNotificationRenderer implements AsyncRenderer
                 count = events.size();
                 this.notificationCacheManager.setInCache(this.cacheKey, new ArrayList<>(events),
                     this.configuration.isCount(),
-                    true);
+                    true, epoch);
             } catch (NotificationException e) {
                 throw new RenderingException("Error while retrieving the notification", e);
             }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/DefaultNotificationCacheManager.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/DefaultNotificationCacheManager.java
@@ -20,6 +20,7 @@
 package org.xwiki.notifications.notifiers.internal;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -86,6 +87,12 @@ public class DefaultNotificationCacheManager implements Initializable, Disposabl
      * notification is created).
      */
     private Cache<Integer> longCompositeEventCountCache;
+
+    /**
+     * Number of times the caches have been flushed. It allows to detect that the events have changed while a result
+     * was being computed, so that this result is not stored in the caches.
+     */
+    private final AtomicLong epoch = new AtomicLong();
 
     @Override
     public void initialize() throws InitializationException
@@ -176,14 +183,31 @@ public class DefaultNotificationCacheManager implements Initializable, Disposabl
     }
 
     /**
-     * Record in cache the events and their number.
+     * @return the current epoch, to be given back to {@link #setInCache(String, List, boolean, boolean, long)} along
+     *         with a result computed from the events as they are now
+     */
+    public long getEpoch()
+    {
+        return this.epoch.get();
+    }
+
+    /**
+     * Record in cache the events and their number, unless the caches have been flushed since the given epoch was
+     * obtained.
      * @param cacheKey the key to store the given events.
      * @param count if {@code true} only store the number of events; else store the objects.
      * @param events the events to store in cache. Their size will be stored too.
      * @param composite {@code true} if the value to store is about composite events or individual events
+     * @param epoch the epoch obtained from {@link #getEpoch()} before the events were retrieved
      */
-    public void setInCache(String cacheKey, List<Object> events, boolean count, boolean composite)
+    public void setInCache(String cacheKey, List<Object> events, boolean count, boolean composite, long epoch)
     {
+        // The events changed while this result was being computed, so it does not reflect them anymore: storing it
+        // would serve an outdated value until the next flush or the eviction of the entry.
+        if (this.epoch.get() != epoch) {
+            return;
+        }
+
         if (this.configuration.isRestCacheEnabled()) {
             if (count && composite) {
                 this.longCompositeEventCountCache.set(cacheKey, events.size());
@@ -203,6 +227,10 @@ public class DefaultNotificationCacheManager implements Initializable, Disposabl
     public void flushLongCache()
     {
         if (this.configuration.isRestCacheEnabled()) {
+            // Change the epoch before emptying the caches, so that a result computed from the events before this flush
+            // is never stored after it.
+            this.epoch.incrementAndGet();
+
             this.longEventCache.removeAll();
             this.longIndividualEventCountCache.removeAll();
             this.longCompositeEventCache.removeAll();

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/DefaultNotificationCacheManager.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/DefaultNotificationCacheManager.java
@@ -89,8 +89,9 @@ public class DefaultNotificationCacheManager implements Initializable, Disposabl
     private Cache<Integer> longCompositeEventCountCache;
 
     /**
-     * Number of times the caches have been flushed. It allows to detect that the events have changed while a result
-     * was being computed, so that this result is not stored in the caches.
+     * Number of times the caches have been flushed. It is part of the cache keys so that a result computed from
+     * events that have changed in the meantime is stored under a key that is never read again, and thus cannot be
+     * returned instead of an up-to-date result.
      */
     private final AtomicLong epoch = new AtomicLong();
 
@@ -162,20 +163,22 @@ public class DefaultNotificationCacheManager implements Initializable, Disposabl
      * @param cacheKey the key where the event are stored.
      * @param count {@code true} if the value to return is a count instead of a list of events
      * @param composite {@code true} if the value to return is about composite events or individual events
+     * @param epoch the epoch obtained from {@link #getEpoch()} before the events are retrieved
      * @return the value associated with the passed parameters
      */
-    public Object getFromCache(String cacheKey, boolean count, boolean composite)
+    public Object getFromCache(String cacheKey, boolean count, boolean composite, long epoch)
     {
         Object result = null;
         if (this.configuration.isRestCacheEnabled()) {
+            String epochCacheKey = getEpochCacheKey(cacheKey, epoch);
             if (count && composite) {
-                result = this.longCompositeEventCountCache.get(cacheKey);
+                result = this.longCompositeEventCountCache.get(epochCacheKey);
             } else if (count) {
-                result = this.longIndividualEventCountCache.get(cacheKey);
+                result = this.longIndividualEventCountCache.get(epochCacheKey);
             } else if (composite) {
-                result = this.longCompositeEventCache.get(cacheKey);
+                result = this.longCompositeEventCache.get(epochCacheKey);
             } else {
-                result = this.longEventCache.get(cacheKey);
+                result = this.longEventCache.get(epochCacheKey);
             }
         }
 
@@ -183,8 +186,12 @@ public class DefaultNotificationCacheManager implements Initializable, Disposabl
     }
 
     /**
-     * @return the current epoch, to be given back to {@link #setInCache(String, List, boolean, boolean, long)} along
-     *         with a result computed from the events as they are now
+     * The returned value needs to be obtained before the events are retrieved, and given back to
+     * {@link #getFromCache(String, boolean, boolean, long)} and
+     * {@link #setInCache(String, List, boolean, boolean, long)} so that a result is only ever read with the events it
+     * has been computed from.
+     *
+     * @return the current epoch
      */
     public long getEpoch()
     {
@@ -192,8 +199,12 @@ public class DefaultNotificationCacheManager implements Initializable, Disposabl
     }
 
     /**
-     * Record in cache the events and their number, unless the caches have been flushed since the given epoch was
-     * obtained.
+     * Record in cache the events and their number.
+     * <p>
+     * The value is stored under a key that includes the given epoch, so that a result computed from events that have
+     * changed in the meantime is never returned by {@link #getFromCache(String, boolean, boolean, long)}, which only
+     * ever looks up the current epoch.
+     *
      * @param cacheKey the key to store the given events.
      * @param count if {@code true} only store the number of events; else store the objects.
      * @param events the events to store in cache. Their size will be stored too.
@@ -202,23 +213,30 @@ public class DefaultNotificationCacheManager implements Initializable, Disposabl
      */
     public void setInCache(String cacheKey, List<Object> events, boolean count, boolean composite, long epoch)
     {
-        // The events changed while this result was being computed, so it does not reflect them anymore: storing it
-        // would serve an outdated value until the next flush or the eviction of the entry.
+        // The events changed while this result was being computed, so nobody will ever read the entry that would be
+        // stored below: skip it to avoid evicting entries that are still useful. This is only an optimization, the
+        // epoch in the cache key is what guarantees that no outdated result is ever returned.
         if (this.epoch.get() != epoch) {
             return;
         }
 
         if (this.configuration.isRestCacheEnabled()) {
+            String epochCacheKey = getEpochCacheKey(cacheKey, epoch);
             if (count && composite) {
-                this.longCompositeEventCountCache.set(cacheKey, events.size());
+                this.longCompositeEventCountCache.set(epochCacheKey, events.size());
             } else if (count) {
-                this.longIndividualEventCountCache.set(cacheKey, events.size());
+                this.longIndividualEventCountCache.set(epochCacheKey, events.size());
             } else if (composite) {
-                this.longCompositeEventCache.set(cacheKey, events);
+                this.longCompositeEventCache.set(epochCacheKey, events);
             } else {
-                this.longEventCache.set(cacheKey, events);
+                this.longEventCache.set(epochCacheKey, events);
             }
         }
+    }
+
+    private String getEpochCacheKey(String cacheKey, long epoch)
+    {
+        return cacheKey + CACHE_KEY_SEPARATOR + epoch;
     }
 
     /**
@@ -227,10 +245,15 @@ public class DefaultNotificationCacheManager implements Initializable, Disposabl
     public void flushLongCache()
     {
         if (this.configuration.isRestCacheEnabled()) {
-            // Change the epoch before emptying the caches, so that a result computed from the events before this flush
-            // is never stored after it.
+            // Change the epoch before emptying the caches. This is what actually invalidates the caches: the entries
+            // stored under the previous epoch are never read again. Doing it first ensures that a result computed
+            // from the events before this flush cannot be read after it, even if it is stored after the caches have
+            // been emptied.
             this.epoch.incrementAndGet();
 
+            // Empty the caches to free the memory used by the entries of the previous epochs. Entries stored after
+            // this point by computations that are still running are left behind and only removed by the eviction of
+            // the caches.
             this.longEventCache.removeAll();
             this.longIndividualEventCountCache.removeAll();
             this.longCompositeEventCache.removeAll();

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/DefaultAsyncNotificationRendererTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/DefaultAsyncNotificationRendererTest.java
@@ -43,6 +43,8 @@ import org.xwiki.test.junit5.mockito.MockComponent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -57,6 +59,12 @@ class DefaultAsyncNotificationRendererTest
     private static final String CACHE_KEY = "mykey";
     private static final DocumentReference USER_DOC_REFERENCE = new DocumentReference("xwiki", "XWiki", "Foo");
     private static final String USER_SERIALIZED_REFERENCE = "xwiki:XWiki.Foo";
+
+    /**
+     * A non-zero epoch, so that the tests fail if the epoch isn't actually passed from the cache manager to the cache
+     * accesses.
+     */
+    private static final long EPOCH = 42L;
 
     @InjectMockComponents
     private DefaultAsyncNotificationRenderer asyncNotificationRenderer;
@@ -88,6 +96,7 @@ class DefaultAsyncNotificationRendererTest
         this.notificationParameters = new NotificationParameters();
         this.notificationParameters.user = USER_DOC_REFERENCE;
         when(notificationCacheManager.createCacheKey(notificationParameters)).thenReturn(CACHE_KEY);
+        when(this.notificationCacheManager.getEpoch()).thenReturn(EPOCH);
         when(this.documentReferenceSerializer.serialize(USER_DOC_REFERENCE)).thenReturn(USER_SERIALIZED_REFERENCE);
     }
 
@@ -134,9 +143,9 @@ class DefaultAsyncNotificationRendererTest
         this.asyncNotificationRenderer.initialize(
             new NotificationAsyncRendererConfiguration(notificationParameters, false));
         assertEquals(new AsyncRendererResult("Expected result!"), this.asyncNotificationRenderer.render(false, false));
-        verify(this.notificationCacheManager).getFromCache(CACHE_KEY, false, true, 0);
+        verify(this.notificationCacheManager).getFromCache(CACHE_KEY, false, true, EPOCH);
         verify(this.notificationCacheManager).setInCache(CACHE_KEY, new ArrayList<>(compositeEventList), false,
-            true, 0);
+            true, EPOCH);
 
         // Test2: get count of 2 events, without cache
         when(this.htmlNotificationRenderer.render(2)).thenReturn("Expected count result!");
@@ -144,9 +153,9 @@ class DefaultAsyncNotificationRendererTest
             new NotificationAsyncRendererConfiguration(notificationParameters, true));
         assertEquals(new AsyncRendererResult("Expected count result!"),
             this.asyncNotificationRenderer.render(true, true));
-        verify(this.notificationCacheManager).getFromCache(CACHE_KEY, true, true, 0);
+        verify(this.notificationCacheManager).getFromCache(CACHE_KEY, true, true, EPOCH);
         verify(this.notificationCacheManager).setInCache(CACHE_KEY, new ArrayList<>(compositeEventList), true,
-            true, 0);
+            true, EPOCH);
 
         // Test3: get 1 event with cache
         compositeEventList = List.of(
@@ -158,7 +167,7 @@ class DefaultAsyncNotificationRendererTest
         );
         when(this.compositeEventStatusManager.getCompositeEventStatuses(compositeEventList, USER_SERIALIZED_REFERENCE))
             .thenReturn(compositeEventStatusList);
-        when(this.notificationCacheManager.getFromCache(CACHE_KEY, false, true, 0)).thenReturn(compositeEventList);
+        when(this.notificationCacheManager.getFromCache(CACHE_KEY, false, true, EPOCH)).thenReturn(compositeEventList);
 
         when(this.htmlNotificationRenderer.render(compositeEventList, compositeEventStatusList, false))
             .thenReturn("Expected cache result!");
@@ -167,9 +176,9 @@ class DefaultAsyncNotificationRendererTest
         assertEquals(new AsyncRendererResult("Expected cache result!"),
             this.asyncNotificationRenderer.render(true, false));
         verify(this.notificationCacheManager, never()).setInCache(CACHE_KEY,
-            new ArrayList<>(compositeEventList), false, true, 0);
+            new ArrayList<>(compositeEventList), false, true, EPOCH);
 
-        when(this.notificationCacheManager.getFromCache(CACHE_KEY, true, true, 0)).thenReturn(1);
+        when(this.notificationCacheManager.getFromCache(CACHE_KEY, true, true, EPOCH)).thenReturn(1);
         when(this.htmlNotificationRenderer.render(1))
             .thenReturn("Expected count cache result!");
         this.asyncNotificationRenderer.initialize(
@@ -177,7 +186,38 @@ class DefaultAsyncNotificationRendererTest
         assertEquals(new AsyncRendererResult("Expected count cache result!"),
             this.asyncNotificationRenderer.render(false, true));
         verify(this.notificationCacheManager, never()).setInCache(CACHE_KEY,
-            new ArrayList<>(compositeEventList), false, true, 0);
+            new ArrayList<>(compositeEventList), false, true, EPOCH);
+    }
+
+    /**
+     * Ensure that the epoch used to store the result is the one that was current before the events were retrieved, so
+     * that a result computed from events that changed in the meantime isn't stored for the new epoch.
+     */
+    @Test
+    void renderWithEpochChangeWhileRetrievingEvents() throws Exception
+    {
+        List<CompositeEvent> compositeEventList = List.of(
+            mock(CompositeEvent.class),
+            mock(CompositeEvent.class)
+        );
+
+        // Simulate a cache flush that happens while the events are being retrieved.
+        when(this.notificationManager.getEvents(this.notificationParameters)).thenAnswer(invocation -> {
+            when(this.notificationCacheManager.getEpoch()).thenReturn(EPOCH + 1);
+            return compositeEventList;
+        });
+        when(this.htmlNotificationRenderer.render(2)).thenReturn("Expected count result!");
+
+        this.asyncNotificationRenderer.initialize(
+            new NotificationAsyncRendererConfiguration(this.notificationParameters, true));
+        assertEquals(new AsyncRendererResult("Expected count result!"),
+            this.asyncNotificationRenderer.render(false, false));
+
+        verify(this.notificationCacheManager).getFromCache(CACHE_KEY, true, true, EPOCH);
+        verify(this.notificationCacheManager).setInCache(CACHE_KEY, new ArrayList<>(compositeEventList), true, true,
+            EPOCH);
+        verify(this.notificationCacheManager, never()).setInCache(any(), any(), anyBoolean(), anyBoolean(),
+            eq(EPOCH + 1));
     }
 
     @Test
@@ -196,9 +236,9 @@ class DefaultAsyncNotificationRendererTest
         this.asyncNotificationRenderer.initialize(
             new NotificationAsyncRendererConfiguration(notificationParameters, false));
         assertEquals(new AsyncRendererResult("Expected result!"), this.asyncNotificationRenderer.render(false, false));
-        verify(this.notificationCacheManager).getFromCache(CACHE_KEY, false, true, 0);
+        verify(this.notificationCacheManager).getFromCache(CACHE_KEY, false, true, EPOCH);
         verify(this.notificationCacheManager).setInCache(CACHE_KEY, new ArrayList<>(compositeEventList), false,
-            true, 0);
+            true, EPOCH);
         verify(this.compositeEventStatusManager, never()).getCompositeEventStatuses(any(), any());
     }
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/DefaultAsyncNotificationRendererTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/DefaultAsyncNotificationRendererTest.java
@@ -135,7 +135,8 @@ class DefaultAsyncNotificationRendererTest
             new NotificationAsyncRendererConfiguration(notificationParameters, false));
         assertEquals(new AsyncRendererResult("Expected result!"), this.asyncNotificationRenderer.render(false, false));
         verify(this.notificationCacheManager).getFromCache(CACHE_KEY, false, true);
-        verify(this.notificationCacheManager).setInCache(CACHE_KEY, new ArrayList<>(compositeEventList), false, true);
+        verify(this.notificationCacheManager).setInCache(CACHE_KEY, new ArrayList<>(compositeEventList), false,
+            true, 0);
 
         // Test2: get count of 2 events, without cache
         when(this.htmlNotificationRenderer.render(2)).thenReturn("Expected count result!");
@@ -144,7 +145,8 @@ class DefaultAsyncNotificationRendererTest
         assertEquals(new AsyncRendererResult("Expected count result!"),
             this.asyncNotificationRenderer.render(true, true));
         verify(this.notificationCacheManager).getFromCache(CACHE_KEY, true, true);
-        verify(this.notificationCacheManager).setInCache(CACHE_KEY, new ArrayList<>(compositeEventList), true, true);
+        verify(this.notificationCacheManager).setInCache(CACHE_KEY, new ArrayList<>(compositeEventList), true,
+            true, 0);
 
         // Test3: get 1 event with cache
         compositeEventList = List.of(
@@ -165,7 +167,7 @@ class DefaultAsyncNotificationRendererTest
         assertEquals(new AsyncRendererResult("Expected cache result!"),
             this.asyncNotificationRenderer.render(true, false));
         verify(this.notificationCacheManager, never()).setInCache(CACHE_KEY,
-            new ArrayList<>(compositeEventList), false, true);
+            new ArrayList<>(compositeEventList), false, true, 0);
 
         when(this.notificationCacheManager.getFromCache(CACHE_KEY, true, true)).thenReturn(1);
         when(this.htmlNotificationRenderer.render(1))
@@ -175,7 +177,7 @@ class DefaultAsyncNotificationRendererTest
         assertEquals(new AsyncRendererResult("Expected count cache result!"),
             this.asyncNotificationRenderer.render(false, true));
         verify(this.notificationCacheManager, never()).setInCache(CACHE_KEY,
-            new ArrayList<>(compositeEventList), false, true);
+            new ArrayList<>(compositeEventList), false, true, 0);
     }
 
     @Test
@@ -195,7 +197,8 @@ class DefaultAsyncNotificationRendererTest
             new NotificationAsyncRendererConfiguration(notificationParameters, false));
         assertEquals(new AsyncRendererResult("Expected result!"), this.asyncNotificationRenderer.render(false, false));
         verify(this.notificationCacheManager).getFromCache(CACHE_KEY, false, true);
-        verify(this.notificationCacheManager).setInCache(CACHE_KEY, new ArrayList<>(compositeEventList), false, true);
+        verify(this.notificationCacheManager).setInCache(CACHE_KEY, new ArrayList<>(compositeEventList), false,
+            true, 0);
         verify(this.compositeEventStatusManager, never()).getCompositeEventStatuses(any(), any());
     }
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/DefaultAsyncNotificationRendererTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/DefaultAsyncNotificationRendererTest.java
@@ -134,7 +134,7 @@ class DefaultAsyncNotificationRendererTest
         this.asyncNotificationRenderer.initialize(
             new NotificationAsyncRendererConfiguration(notificationParameters, false));
         assertEquals(new AsyncRendererResult("Expected result!"), this.asyncNotificationRenderer.render(false, false));
-        verify(this.notificationCacheManager).getFromCache(CACHE_KEY, false, true);
+        verify(this.notificationCacheManager).getFromCache(CACHE_KEY, false, true, 0);
         verify(this.notificationCacheManager).setInCache(CACHE_KEY, new ArrayList<>(compositeEventList), false,
             true, 0);
 
@@ -144,7 +144,7 @@ class DefaultAsyncNotificationRendererTest
             new NotificationAsyncRendererConfiguration(notificationParameters, true));
         assertEquals(new AsyncRendererResult("Expected count result!"),
             this.asyncNotificationRenderer.render(true, true));
-        verify(this.notificationCacheManager).getFromCache(CACHE_KEY, true, true);
+        verify(this.notificationCacheManager).getFromCache(CACHE_KEY, true, true, 0);
         verify(this.notificationCacheManager).setInCache(CACHE_KEY, new ArrayList<>(compositeEventList), true,
             true, 0);
 
@@ -158,7 +158,7 @@ class DefaultAsyncNotificationRendererTest
         );
         when(this.compositeEventStatusManager.getCompositeEventStatuses(compositeEventList, USER_SERIALIZED_REFERENCE))
             .thenReturn(compositeEventStatusList);
-        when(this.notificationCacheManager.getFromCache(CACHE_KEY, false, true)).thenReturn(compositeEventList);
+        when(this.notificationCacheManager.getFromCache(CACHE_KEY, false, true, 0)).thenReturn(compositeEventList);
 
         when(this.htmlNotificationRenderer.render(compositeEventList, compositeEventStatusList, false))
             .thenReturn("Expected cache result!");
@@ -169,7 +169,7 @@ class DefaultAsyncNotificationRendererTest
         verify(this.notificationCacheManager, never()).setInCache(CACHE_KEY,
             new ArrayList<>(compositeEventList), false, true, 0);
 
-        when(this.notificationCacheManager.getFromCache(CACHE_KEY, true, true)).thenReturn(1);
+        when(this.notificationCacheManager.getFromCache(CACHE_KEY, true, true, 0)).thenReturn(1);
         when(this.htmlNotificationRenderer.render(1))
             .thenReturn("Expected count cache result!");
         this.asyncNotificationRenderer.initialize(
@@ -196,7 +196,7 @@ class DefaultAsyncNotificationRendererTest
         this.asyncNotificationRenderer.initialize(
             new NotificationAsyncRendererConfiguration(notificationParameters, false));
         assertEquals(new AsyncRendererResult("Expected result!"), this.asyncNotificationRenderer.render(false, false));
-        verify(this.notificationCacheManager).getFromCache(CACHE_KEY, false, true);
+        verify(this.notificationCacheManager).getFromCache(CACHE_KEY, false, true, 0);
         verify(this.notificationCacheManager).setInCache(CACHE_KEY, new ArrayList<>(compositeEventList), false,
             true, 0);
         verify(this.compositeEventStatusManager, never()).getCompositeEventStatuses(any(), any());

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/DefaultNotificationCacheManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/DefaultNotificationCacheManagerTest.java
@@ -23,11 +23,17 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 import org.xwiki.cache.Cache;
 import org.xwiki.cache.CacheManager;
 import org.xwiki.cache.config.LRUCacheConfiguration;
+import org.xwiki.cache.internal.MapCache;
 import org.xwiki.eventstream.Event;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
@@ -43,9 +49,13 @@ import org.xwiki.test.mockito.MockitoComponentManager;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -67,18 +77,19 @@ class DefaultNotificationCacheManagerTest
     @MockComponent
     private EntityReferenceSerializer<String> entityReferenceSerializer;
 
-    private Cache longEventCache;
-    private Cache longCountCache;
-    private Cache longCompositeEventCountCache;
-    private Cache longCompositeEventCache;
+    private Cache<Object> longEventCache;
+    private Cache<Object> longCountCache;
+    private Cache<Object> longCompositeEventCountCache;
+    private Cache<Object> longCompositeEventCache;
 
     @BeforeComponent
     public void setupComponents(MockitoComponentManager componentManager) throws Exception
     {
-        this.longEventCache = mock(Cache.class);
-        this.longCountCache = mock(Cache.class);
-        this.longCompositeEventCountCache = mock(Cache.class);
-        this.longCompositeEventCache = mock(Cache.class);
+        // Use actual caches so that the effect of the epoch on the cache keys can be observed.
+        this.longEventCache = spy(new MapCache<>());
+        this.longCountCache = spy(new MapCache<>());
+        this.longCompositeEventCountCache = spy(new MapCache<>());
+        this.longCompositeEventCache = spy(new MapCache<>());
 
         when(this.configuration.isRestCacheEnabled()).thenReturn(true);
         CacheManager cacheManager = componentManager.registerMockComponent(CacheManager.class);
@@ -103,13 +114,15 @@ class DefaultNotificationCacheManagerTest
     @Test
     void getFromCache()
     {
-        this.defaultNotificationCacheManager.getFromCache("anykey", true, false);
-        verify(this.longCountCache).get("anykey");
-        verify(this.longEventCache, never()).get("anykey");
+        long epoch = this.defaultNotificationCacheManager.getEpoch();
 
-        this.defaultNotificationCacheManager.getFromCache("anotherkey", false, false);
-        verify(this.longEventCache).get("anotherkey");
-        verify(this.longCountCache, never()).get("anotherkey");
+        this.defaultNotificationCacheManager.getFromCache("anykey", true, false, epoch);
+        verify(this.longCountCache).get("anykey/0");
+        verify(this.longEventCache, never()).get("anykey/0");
+
+        this.defaultNotificationCacheManager.getFromCache("anotherkey", false, false, epoch);
+        verify(this.longEventCache).get("anotherkey/0");
+        verify(this.longCountCache, never()).get("anotherkey/0");
 
         // 2 for the method getFromCache + 1 for the initialize
         verify(this.configuration, times(3)).isRestCacheEnabled();
@@ -123,15 +136,17 @@ class DefaultNotificationCacheManagerTest
         long epoch = this.defaultNotificationCacheManager.getEpoch();
 
         this.defaultNotificationCacheManager.setInCache("mykey", events, false, false, epoch);
-        verify(this.longEventCache).set("mykey", events);
-        verify(this.longCountCache, never()).set("mykey", events);
+        verify(this.longEventCache).set("mykey/0", events);
+        verify(this.longCountCache, never()).set("mykey/0", events);
+        assertEquals(events, this.defaultNotificationCacheManager.getFromCache("mykey", false, false, epoch));
 
         this.defaultNotificationCacheManager.setInCache("anotherkey", events, true, false, epoch);
-        verify(this.longEventCache, never()).set("anotherkey", 3);
-        verify(this.longCountCache).set("anotherkey", 3);
+        verify(this.longEventCache, never()).set("anotherkey/0", 3);
+        verify(this.longCountCache).set("anotherkey/0", 3);
+        assertEquals(3, this.defaultNotificationCacheManager.getFromCache("anotherkey", true, false, epoch));
 
-        // 2 for the method setInCache + 1 for the initialize
-        verify(this.configuration, times(3)).isRestCacheEnabled();
+        // 2 for the method setInCache + 2 for the method getFromCache + 1 for the initialize
+        verify(this.configuration, times(5)).isRestCacheEnabled();
     }
 
     @Test
@@ -152,10 +167,63 @@ class DefaultNotificationCacheManagerTest
         verify(this.longEventCache, never()).set(any(), any());
         verify(this.longCountCache, never()).set(any(), any());
 
-        // The results computed before the flush are refused, but the ones computed after it are accepted.
-        this.defaultNotificationCacheManager.setInCache("mykey", events, false, true,
-            this.defaultNotificationCacheManager.getEpoch());
-        verify(this.longCompositeEventCache).set("mykey", events);
+        // The results computed before the flush are refused, but the ones computed after it are accepted and stored
+        // under the new epoch.
+        long newEpoch = this.defaultNotificationCacheManager.getEpoch();
+        assertNotEquals(epoch, newEpoch);
+        this.defaultNotificationCacheManager.setInCache("mykey", events, false, true, newEpoch);
+        verify(this.longCompositeEventCache).set("mykey/" + newEpoch, events);
+        assertEquals(events, this.defaultNotificationCacheManager.getFromCache("mykey", false, true, newEpoch));
+    }
+
+    /**
+     * Ensure that a result whose storage in the cache is interleaved with a flush isn't returned anymore, even though
+     * it is stored after the caches have been emptied.
+     */
+    @Test
+    void setInCacheDuringFlush() throws Exception
+    {
+        List<Object> events = Arrays.asList(mock(Event.class), mock(Event.class));
+        long epoch = this.defaultNotificationCacheManager.getEpoch();
+
+        CompletableFuture<Void> storageStarted = new CompletableFuture<>();
+        CompletableFuture<Void> flushFinished = new CompletableFuture<>();
+
+        // Block the storing thread inside the cache, i.e., after the epoch has been checked but before the value has
+        // actually been stored.
+        doAnswer(invocation -> {
+            storageStarted.complete(null);
+            flushFinished.get(10, TimeUnit.SECONDS);
+            return invocation.callRealMethod();
+        }).when(this.longCompositeEventCache).set(any(), any());
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+        try {
+            Future<?> storageFuture = executorService.submit(
+                () -> this.defaultNotificationCacheManager.setInCache("mykey", events, false, true, epoch));
+
+            storageStarted.get(10, TimeUnit.SECONDS);
+
+            // Flush the cache after the set-call arrived in the cache, and thus after it verified the epoch.
+            this.defaultNotificationCacheManager.flushLongCache();
+
+            // Unblock the set call so it can complete normally and wait for it.
+            flushFinished.complete(null);
+            storageFuture.get(10, TimeUnit.SECONDS);
+        } finally {
+            executorService.shutdown();
+        }
+
+        assertTrue(executorService.awaitTermination(10, TimeUnit.SECONDS));
+
+        // The outdated result did land in the cache after it has been emptied, but under the previous epoch.
+        long newEpoch = this.defaultNotificationCacheManager.getEpoch();
+        assertNotEquals(epoch, newEpoch);
+        assertEquals(events, this.longCompositeEventCache.get("mykey/" + epoch));
+
+        // Therefore, it isn't returned anymore.
+        assertNull(this.defaultNotificationCacheManager.getFromCache("mykey", false, true, newEpoch));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/DefaultNotificationCacheManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/DefaultNotificationCacheManagerTest.java
@@ -120,16 +120,42 @@ class DefaultNotificationCacheManagerTest
     {
         List<Object> events = Arrays.asList(mock(Event.class), mock(Event.class),
             mock(Event.class));
-        this.defaultNotificationCacheManager.setInCache("mykey", events, false, false);
+        long epoch = this.defaultNotificationCacheManager.getEpoch();
+
+        this.defaultNotificationCacheManager.setInCache("mykey", events, false, false, epoch);
         verify(this.longEventCache).set("mykey", events);
         verify(this.longCountCache, never()).set("mykey", events);
 
-        this.defaultNotificationCacheManager.setInCache("anotherkey", events, true, false);
+        this.defaultNotificationCacheManager.setInCache("anotherkey", events, true, false, epoch);
         verify(this.longEventCache, never()).set("anotherkey", 3);
         verify(this.longCountCache).set("anotherkey", 3);
 
         // 2 for the method setInCache + 1 for the initialize
         verify(this.configuration, times(3)).isRestCacheEnabled();
+    }
+
+    @Test
+    void setInCacheAfterFlush()
+    {
+        List<Object> events = Arrays.asList(mock(Event.class), mock(Event.class));
+        long epoch = this.defaultNotificationCacheManager.getEpoch();
+
+        this.defaultNotificationCacheManager.flushLongCache();
+
+        this.defaultNotificationCacheManager.setInCache("mykey", events, false, true, epoch);
+        this.defaultNotificationCacheManager.setInCache("mykey", events, true, true, epoch);
+        this.defaultNotificationCacheManager.setInCache("mykey", events, false, false, epoch);
+        this.defaultNotificationCacheManager.setInCache("mykey", events, true, false, epoch);
+
+        verify(this.longCompositeEventCache, never()).set(any(), any());
+        verify(this.longCompositeEventCountCache, never()).set(any(), any());
+        verify(this.longEventCache, never()).set(any(), any());
+        verify(this.longCountCache, never()).set(any(), any());
+
+        // The results computed before the flush are refused, but the ones computed after it are accepted.
+        this.defaultNotificationCacheManager.setInCache("mykey", events, false, true,
+            this.defaultNotificationCacheManager.getEpoch());
+        verify(this.longCompositeEventCache).set("mykey", events);
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/DefaultNotificationCacheManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/DefaultNotificationCacheManagerTest.java
@@ -117,12 +117,12 @@ class DefaultNotificationCacheManagerTest
         long epoch = this.defaultNotificationCacheManager.getEpoch();
 
         this.defaultNotificationCacheManager.getFromCache("anykey", true, false, epoch);
-        verify(this.longCountCache).get("anykey/0");
-        verify(this.longEventCache, never()).get("anykey/0");
+        verify(this.longCountCache).get("anykey/" + epoch);
+        verify(this.longEventCache, never()).get("anykey/" + epoch);
 
         this.defaultNotificationCacheManager.getFromCache("anotherkey", false, false, epoch);
-        verify(this.longEventCache).get("anotherkey/0");
-        verify(this.longCountCache, never()).get("anotherkey/0");
+        verify(this.longEventCache).get("anotherkey/" + epoch);
+        verify(this.longCountCache, never()).get("anotherkey/" + epoch);
 
         // 2 for the method getFromCache + 1 for the initialize
         verify(this.configuration, times(3)).isRestCacheEnabled();
@@ -136,13 +136,13 @@ class DefaultNotificationCacheManagerTest
         long epoch = this.defaultNotificationCacheManager.getEpoch();
 
         this.defaultNotificationCacheManager.setInCache("mykey", events, false, false, epoch);
-        verify(this.longEventCache).set("mykey/0", events);
-        verify(this.longCountCache, never()).set("mykey/0", events);
+        verify(this.longEventCache).set("mykey/" + epoch, events);
+        verify(this.longCountCache, never()).set("mykey/" + epoch, events);
         assertEquals(events, this.defaultNotificationCacheManager.getFromCache("mykey", false, false, epoch));
 
         this.defaultNotificationCacheManager.setInCache("anotherkey", events, true, false, epoch);
-        verify(this.longEventCache, never()).set("anotherkey/0", 3);
-        verify(this.longCountCache).set("anotherkey/0", 3);
+        verify(this.longEventCache, never()).set("anotherkey/" + epoch, 3);
+        verify(this.longCountCache).set("anotherkey/" + epoch, 3);
         assertEquals(3, this.defaultNotificationCacheManager.getFromCache("anotherkey", true, false, epoch));
 
         // 2 for the method setInCache + 2 for the method getFromCache + 1 for the initialize

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/main/java/org/xwiki/notifications/rest/internal/NotificationEventExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/main/java/org/xwiki/notifications/rest/internal/NotificationEventExecutor.java
@@ -178,12 +178,12 @@ public class NotificationEventExecutor implements Initializable, Disposable
 
         private Object execute() throws Exception
         {
-            // Get the epoch before the events are retrieved below, so that the result is not cached if the events
-            // change in the meantime.
+            // Get the epoch before the events are retrieved below, so that the result is not cached for the current
+            // epoch if the events change in the meantime.
             long epoch = notificationCacheManager.getEpoch();
 
             // Check if the result is already in the event cache
-            Object result = notificationCacheManager.getFromCache(this.cacheKey, this.count, this.composite);
+            Object result = notificationCacheManager.getFromCache(this.cacheKey, this.count, this.composite, epoch);
             if (result != null) {
                 return result;
             }
@@ -311,7 +311,8 @@ public class NotificationEventExecutor implements Initializable, Disposable
     public Object submit(String cacheKey, Callable<List> callable, boolean async, boolean count,
         boolean composite) throws Exception
     {
-        Object cached = this.notificationCacheManager.getFromCache(cacheKey, count, composite);
+        Object cached = this.notificationCacheManager.getFromCache(cacheKey, count, composite,
+            this.notificationCacheManager.getEpoch());
 
         if (cached != null) {
             return cached;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/main/java/org/xwiki/notifications/rest/internal/NotificationEventExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/main/java/org/xwiki/notifications/rest/internal/NotificationEventExecutor.java
@@ -178,6 +178,10 @@ public class NotificationEventExecutor implements Initializable, Disposable
 
         private Object execute() throws Exception
         {
+            // Get the epoch before the events are retrieved below, so that the result is not cached if the events
+            // change in the meantime.
+            long epoch = notificationCacheManager.getEpoch();
+
             // Check if the result is already in the event cache
             Object result = notificationCacheManager.getFromCache(this.cacheKey, this.count, this.composite);
             if (result != null) {
@@ -194,7 +198,7 @@ public class NotificationEventExecutor implements Initializable, Disposable
 
                 // Execute the callable
                 List events = this.callable.call();
-                notificationCacheManager.setInCache(this.cacheKey, events, this.count, this.composite);
+                notificationCacheManager.setInCache(this.cacheKey, events, this.count, this.composite, epoch);
 
                 if (this.count) {
                     result = events.size();

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/test/java/org/xwiki/notifications/rest/internal/NotificationEventExecutorTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/test/java/org/xwiki/notifications/rest/internal/NotificationEventExecutorTest.java
@@ -1,0 +1,153 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.notifications.rest.internal;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.inject.Provider;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.cache.Cache;
+import org.xwiki.cache.CacheManager;
+import org.xwiki.cache.internal.MapCache;
+import org.xwiki.context.Execution;
+import org.xwiki.context.ExecutionContextManager;
+import org.xwiki.eventstream.Event;
+import org.xwiki.notifications.NotificationConfiguration;
+import org.xwiki.notifications.notifiers.internal.DefaultNotificationCacheManager;
+import org.xwiki.test.annotation.BeforeComponent;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import com.xpn.xwiki.XWikiContext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link NotificationEventExecutor}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+class NotificationEventExecutorTest
+{
+    private static final String CACHE_KEY = "mykey";
+
+    /**
+     * A non-zero epoch, so that the tests fail if the epoch isn't actually passed from the cache manager to the cache
+     * accesses.
+     */
+    private static final long EPOCH = 42L;
+
+    @InjectMockComponents
+    private NotificationEventExecutor eventExecutor;
+
+    @MockComponent
+    private DefaultNotificationCacheManager notificationCacheManager;
+
+    @MockComponent
+    private NotificationConfiguration notificationConfiguration;
+
+    @MockComponent
+    private ExecutionContextManager contextManager;
+
+    @MockComponent
+    private Execution execution;
+
+    @MockComponent
+    private Provider<XWikiContext> xcontextProvider;
+
+    @MockComponent
+    private CacheManager cacheManager;
+
+    private final AtomicLong epoch = new AtomicLong(EPOCH);
+
+    @BeforeComponent
+    void beforeComponent() throws Exception
+    {
+        // The executor is only used when the pool size is greater than zero.
+        when(this.notificationConfiguration.getRESTPoolSize()).thenReturn(1);
+        Cache<Object> shortCache = new MapCache<>();
+        when(this.cacheManager.<Object>createNewCache(any())).thenReturn(shortCache);
+        when(this.xcontextProvider.get()).thenReturn(mock(XWikiContext.class));
+        when(this.notificationCacheManager.getEpoch()).thenAnswer(invocation -> this.epoch.get());
+    }
+
+    @Test
+    void submitStoresResultWithTheEpoch() throws Exception
+    {
+        List<Object> events = List.of(mock(Event.class), mock(Event.class));
+
+        assertEquals(events, this.eventExecutor.submit(CACHE_KEY, () -> events, false, false, true));
+
+        // Once in submit() to check the cache before queuing anything, once in the callable entry itself.
+        verify(this.notificationCacheManager, times(2)).getFromCache(CACHE_KEY, false, true, EPOCH);
+        verify(this.notificationCacheManager).setInCache(CACHE_KEY, events, false, true, EPOCH);
+    }
+
+    /**
+     * Ensure that the epoch used to store the result is the one that was current before the events were retrieved, so
+     * that a result computed from events that changed in the meantime isn't stored for the new epoch.
+     */
+    @Test
+    void submitWithEpochChangeWhileRetrievingEvents() throws Exception
+    {
+        List<Object> events = List.of(mock(Event.class), mock(Event.class));
+
+        // Simulate a cache flush that happens while the events are being retrieved.
+        Callable<List> callable = () -> {
+            this.epoch.incrementAndGet();
+            return events;
+        };
+
+        assertEquals(events, this.eventExecutor.submit(CACHE_KEY, callable, false, false, true));
+
+        verify(this.notificationCacheManager).setInCache(CACHE_KEY, events, false, true, EPOCH);
+        verify(this.notificationCacheManager, never()).setInCache(any(), any(), anyBoolean(), anyBoolean(),
+            eq(EPOCH + 1));
+    }
+
+    @Test
+    void submitReturnsCachedResultForTheCurrentEpoch() throws Exception
+    {
+        when(this.notificationCacheManager.getFromCache(CACHE_KEY, true, true, EPOCH)).thenReturn(5);
+
+        Callable<List> callable = () -> {
+            throw new AssertionError("The callable must not be executed when the result is cached.");
+        };
+
+        assertEquals(5, this.eventExecutor.submit(CACHE_KEY, callable, false, true, true));
+
+        verify(this.notificationCacheManager, never()).setInCache(any(), any(), anyBoolean(), anyBoolean(),
+            anyLong());
+    }
+}


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24646

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Add a counter to avoid caching outdate notification results

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install javadoc:javadoc -pl :xwiki-platform-notifications-notifiers-api,:xwiki-platform-notifications-rest,:xwiki-platform-notifications-test-docker,:xwiki-platform-mentions-test-docker -Pquality,integration-tests,docker,legacy
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-18.4.x
  * stable-17.10.x