### PR TITLE
[Misc] Fix 2 SonarQube simplification-rule issues

### DIFF
--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/EscapeLikeParametersQuery.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/EscapeLikeParametersQuery.java
@@ -100,7 +100,7 @@ public class EscapeLikeParametersQuery extends WrappingQuery
                             buffer.append(part.getValue().replaceAll("([%_!])", ESCAPED_REPLACEMENT));
                         } else if (part instanceof LikeParameterPart) {
                             // Escape the escape character
-                            buffer.append(part.getValue().replaceAll("([!])", ESCAPED_REPLACEMENT));
+                            buffer.append(part.getValue().replaceAll("(!)", ESCAPED_REPLACEMENT));
                         } else {
                             buffer.append(part.getValue());
                         }

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrIndexEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrIndexEventListener.java
@@ -199,7 +199,7 @@ public class SolrIndexEventListener implements EventListener
 
         try {
             // Index the rest of the available translations.
-            document.getTranslationLocales(xcontext).stream()
+            document.getTranslationLocales(xcontext)
                 .forEach(locale -> indexer.index(new DocumentReference(documentReferenceWithoutLocale, locale), false));
         } catch (XWikiException e) {
             this.logger.warn("Failed to index the translations of [{}]. Root cause is [{}].",


### PR DESCRIPTION
# Changes

## Description

* `SolrIndexEventListener`: replace `.stream().forEach()` with `.forEach()` ([java:S3706](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS3706&rule_key=java%3AS3706))
* `EscapeLikeParametersQuery`: replace the redundant single-character regex character class `[!]` with the character itself ([java:S6397](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS6397&rule_key=java%3AS6397))

Both are behaviour-preserving simplifications reported by SonarCloud.

## Clarifications

* The regex group `(!)` is kept because the replacement string (`ESCAPED_REPLACEMENT = "!$1"`) references group 1.

# Executed Tests

* `mvn clean install -Plegacy,quality` on `xwiki-platform-search-solr-api` and `xwiki-platform-query-manager` — both BUILD SUCCESS (unit tests, JaCoCo, Revapi, Checkstyle all green)

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None

Generated with Kimi Code