### PR TITLE
[Misc] Fix 6 SonarQube java:S7476 issues

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/AbstractSolrCoreInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/AbstractSolrCoreInitializer.java
@@ -273,9 +273,7 @@ public abstract class AbstractSolrCoreInitializer implements SolrCoreInitializer
         // because they are required for things located in solrconfig.xml which is unfortunately impossible to
         // update at runtime
 
-        //////////
         // TYPES
-        //////////
 
         addFieldType(DefaultSolrUtils.SOLR_TYPE_STRINGS, SolrSchemaUtils.SOLR_FIELD_CLASS_STR,
             SOLR_FIELD_SORTMISSINGLAST, true, SOLR_FIELD_MULTIVALUED, true, SOLR_FIELD_DOCVALUES, true);
@@ -325,9 +323,7 @@ public abstract class AbstractSolrCoreInitializer implements SolrCoreInitializer
     private void migrateBaseSchema(long xversion) throws SolrException
     {
         if (xversion < SCHEMA_VERSION_12_10) {
-            //////////
             // TYPES
-            //////////
 
             addTextGeneralFieldType(DefaultSolrUtils.SOLR_TYPE_TEXT_GENERAL, false);
             addTextGeneralFieldType(DefaultSolrUtils.SOLR_TYPE_TEXT_GENERALS, true);

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/metadata/ObjectSolrMetadataExtractorTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/metadata/ObjectSolrMetadataExtractorTest.java
@@ -92,12 +92,10 @@ class ObjectSolrMetadataExtractorTest
         EntityReference objectReference = this.xobject.getReference();
         DocumentReference documentReference = (DocumentReference) objectReference.getParent();
 
-        ///////////////////
         // Call
 
         SolrInputDocument solrDocument = this.metadataExtractor.getSolrDocument(objectReference);
 
-        ///////////////////
         // Assert
 
         assertEquals("wiki:Path.To.Page.WebHome^Path.To.Class[0]", solrDocument.getFieldValue(FieldUtils.ID));


### PR DESCRIPTION
# Changes

## Description

* Remove decorative banner comment lines made of more than two slashes (`//////////`) framing section comments, keeping the comments themselves — reported by SonarCloud rule [java:S7476](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS7476&rule_key=java%3AS7476) ("A single-line comment should start with exactly two slashes, no more")
* 4 occurrences in `AbstractSolrCoreInitializer` (framing `// TYPES` sections) and 2 in `ObjectSolrMetadataExtractorTest` (framing `// Call` / `// Assert`)

Comment-only change, no behaviour impact.

# Executed Tests

* `mvn clean install -Plegacy,quality` on `xwiki-platform-search-solr-api` — BUILD SUCCESS (unit tests, JaCoCo, Revapi, Checkstyle all green)

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None

Generated with Kimi Code