### PR TITLE
[Misc] Fix 11 SonarQube constant-and-resource-rule issues

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -7231,10 +7231,10 @@ public class XWiki implements EventListener
         temp = temp.replaceAll("[\u0125\u0127\u021f]", "h");
         temp = temp.replaceAll("[\u00cc\u00cd\u00ce\u00cf\u0128\u012a\u012c\u012e\u0130\u01cf\u0208\u020a]", "I");
         temp = temp.replaceAll("[\u00ec\u00ed\u00ee\u00ef\u0129\u012b\u012d\u012f\u0131\u01d0\u0209\u020b]", "i");
-        temp = temp.replaceAll("\u0132", "IJ");
-        temp = temp.replaceAll("\u0133", "ij");
-        temp = temp.replaceAll("\u0134", "J");
-        temp = temp.replaceAll("\u0135", "j");
+        temp = temp.replace("\u0132", "IJ");
+        temp = temp.replace("\u0133", "ij");
+        temp = temp.replace("\u0134", "J");
+        temp = temp.replace("\u0135", "j");
         temp = temp.replaceAll("[\u0136\u01e8]", "K");
         temp = temp.replaceAll("[\u0137\u0138\u01e9]", "k");
         temp = temp.replaceAll("[\u0139\u013b\u013d\u013f\u0141]", "L");
@@ -7261,20 +7261,20 @@ public class XWiki implements EventListener
         temp = temp.replaceAll(
             "[\u00f9\u00fa\u00fb\u00fc\u0169\u016b\u016d\u016f\u0171\u0173\u01d4\u01d6\u01d8\u01da\u01dc\u0215\u0217]",
             "u");
-        temp = temp.replaceAll("\u0174", "W");
-        temp = temp.replaceAll("\u0175", "w");
+        temp = temp.replace("\u0174", "W");
+        temp = temp.replace("\u0175", "w");
         temp = temp.replaceAll("[\u00dd\u0176\u0178\u0232]", "Y");
         temp = temp.replaceAll("[\u00fd\u00ff\u0177\u0233]", "y");
         temp = temp.replaceAll("[\u0179\u017b\u017d]", "Z");
         temp = temp.replaceAll("[\u017a\u017c\u017e]", "z");
-        temp = temp.replaceAll("\u00df", "SS");
+        temp = temp.replace("\u00df", "SS");
         temp = temp.replaceAll("[_':,;\\\\/]", " ");
         name = temp;
         name = name.replaceAll("\\s+", "");
         name = name.replaceAll("[\\(\\)]", " ");
 
         if (stripDots) {
-            name = name.replaceAll("\\.", "");
+            name = name.replace(".", "");
         }
 
         if (ascii) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiGroupServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiGroupServiceImpl.java
@@ -62,15 +62,15 @@ import com.xpn.xwiki.web.Utils;
  */
 public class XWikiGroupServiceImpl implements XWikiGroupService, EventListener
 {
-    public static final EntityReference GROUPCLASS_REFERENCE =
-        new EntityReference("XWikiGroups", EntityType.DOCUMENT, new EntityReference("XWiki", EntityType.SPACE));
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(XWikiDocument.class);
-
     /**
      * Name of the "XWiki.XWikiGroups" class without the space name.
      */
     private static final String CLASS_SUFFIX_XWIKIGROUPS = "XWikiGroups";
+
+    public static final EntityReference GROUPCLASS_REFERENCE = new EntityReference(CLASS_SUFFIX_XWIKIGROUPS,
+        EntityType.DOCUMENT, new EntityReference(XWiki.SYSTEM_SPACE, EntityType.SPACE));
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(XWikiDocument.class);
 
     /**
      * Name of the "XWiki.XWikiUsers" class without the space name.
@@ -96,11 +96,6 @@ public class XWikiGroupServiceImpl implements XWikiGroupService, EventListener
      * Name of the field of class XWiki.XWikiGroups where group's members names are inserted.
      */
     private static final String FIELD_XWIKIGROUPS_MEMBER = "member";
-
-    /**
-     * Default space name for a group or a user.
-     */
-    private static final String DEFAULT_MEMBER_SPACE = "XWiki";
 
     /**
      * String between wiki name and full name in document path.
@@ -221,7 +216,7 @@ public class XWikiGroupServiceImpl implements XWikiGroupService, EventListener
         if (memberWiki != null) {
             equals |= currentMember.equals(memberWiki + WIKI_FULLNAME_SEP + memberSpace + SPACE_NAME_SEP + memberName);
 
-            if (memberSpace == null || DEFAULT_MEMBER_SPACE.equals(memberSpace)) {
+            if (memberSpace == null || XWiki.SYSTEM_SPACE.equals(memberSpace)) {
                 equals |= currentMember.equals(memberSpace + SPACE_NAME_SEP + memberName);
             }
         }
@@ -229,7 +224,7 @@ public class XWikiGroupServiceImpl implements XWikiGroupService, EventListener
         if (context.getWikiId() == null || context.getWikiId().equalsIgnoreCase(memberWiki)) {
             equals |= currentMember.equals(memberName);
 
-            if (memberSpace == null || DEFAULT_MEMBER_SPACE.equals(memberSpace)) {
+            if (memberSpace == null || XWiki.SYSTEM_SPACE.equals(memberSpace)) {
                 equals |= currentMember.equals(memberSpace + SPACE_NAME_SEP + memberName);
             }
         }
@@ -328,7 +323,7 @@ public class XWikiGroupServiceImpl implements XWikiGroupService, EventListener
         parameterValues.add(FIELD_XWIKIGROUPS_MEMBER);
 
         if (context.getWikiId() == null || context.getWikiId().equalsIgnoreCase(memberWiki)) {
-            if (memberSpace == null || DEFAULT_MEMBER_SPACE.equals(memberSpace)) {
+            if (memberSpace == null || XWiki.SYSTEM_SPACE.equals(memberSpace)) {
                 parameterValues.add(HQLLIKE_ALL_SYMBOL + memberName + HQLLIKE_ALL_SYMBOL);
             } else {
                 parameterValues
@@ -783,7 +778,7 @@ public class XWikiGroupServiceImpl implements XWikiGroupService, EventListener
                     .bindValue("shortname", XWikiRightService.GUEST_USER_FULLNAME)
                     .bindValue("veryshortname", XWikiRightService.GUEST_USER);
             } else if (memberReference.getWikiReference().getName().equals(context.getWikiId())
-                || ("XWiki".equals(memberReference.getLastSpaceReference().getName())
+                || (XWiki.SYSTEM_SPACE.equals(memberReference.getLastSpaceReference().getName())
                     && memberReference.getName().equals(XWikiRightService.GUEST_USER))) {
                 query = context.getWiki().getStore().getQueryManager().getNamedQuery("listGroupsForUser")
                     .bindValue("username", this.entityReferenceSerializer.serialize(memberReference))
@@ -812,7 +807,7 @@ public class XWikiGroupServiceImpl implements XWikiGroupService, EventListener
         if (isAllGroupImplicit(context) && !XWikiRightService.isGuest(memberReference)
             && memberReference.getWikiReference().getName().equals(context.getWikiId())) {
             DocumentReference currentXWikiAllGroup =
-                new DocumentReference(context.getWikiId(), "XWiki", XWikiRightService.ALLGROUP_GROUP);
+                new DocumentReference(context.getWikiId(), XWiki.SYSTEM_SPACE, XWikiRightService.ALLGROUP_GROUP);
 
             if (!currentXWikiAllGroup.equals(memberReference)) {
                 groupReferences.add(currentXWikiAllGroup);

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/XWikiRepositoryModel.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/XWikiRepositoryModel.java
@@ -355,14 +355,14 @@ public final class XWikiRepositoryModel
 
     // Solr
 
-    public static final String SOLRPROP_EXTENSION_VALIDEXTENSION =
-        toExtensionClassSolrPropertyName(PROP_EXTENSION_VALIDEXTENSION, "boolean");
-
     public static final String SOLR_STRING = "string";
 
     public static final String SOLR_INTEGER = "int";
 
     public static final String SOLR_BOOLEAN = "boolean";
+
+    public static final String SOLRPROP_EXTENSION_VALIDEXTENSION =
+        toExtensionClassSolrPropertyName(PROP_EXTENSION_VALIDEXTENSION, SOLR_BOOLEAN);
 
     public static final Map<String, SolrField> SOLR_FIELDS = new HashMap<>();
 


### PR DESCRIPTION
# Changes

## Description

Fixes 11 SonarCloud issues in the constant-and-resource rule family:

* `XWiki`: use `replace()` instead of `replaceAll()` where the pattern reduces to a single literal
  character (a Unicode escape such as `Ĳ`) or a single escaped literal (`"\\."`), and the replacement
  contains no `$` or `\`
  ([java:S5361](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS5361&rule_key=java%3AS5361),
  8 issues)
* `XWikiGroupServiceImpl`: replace the duplicated `"XWikiGroups"` and `"XWiki"` literals with the
  already-defined `CLASS_SUFFIX_XWIKIGROUPS` constant and with `com.xpn.xwiki.XWiki.SYSTEM_SPACE`, the
  canonical constant for the `XWiki` system space
  ([java:S1192](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS1192&rule_key=java%3AS1192),
  2 issues)
* `XWikiRepositoryModel`: use the already-defined `SOLR_BOOLEAN` constant (java:S1192, 1 issue)

All changes are behaviour-preserving.

## Clarifications

* In `XWikiGroupServiceImpl` and `XWikiRepositoryModel`, the reused constants were declared textually
  *after* their new use site, which Java forbids for static initializers, so the constant declarations
  were moved above the fields that reference them (no API change: same fields, same visibility, same
  values).
* Using `XWiki.SYSTEM_SPACE` makes the local private `DEFAULT_MEMBER_SPACE` constant a redundant alias
  of it — the default space of a user or group document is the system space, not a value that merely
  happens to match it — so that constant is removed and its three uses now reference
  `XWiki.SYSTEM_SPACE` directly. No `"XWiki"` literal remains in the class.
* The three `java:S3626` "redundant jump" issues in `XWikiAction#execute` (lines 653, 716, 726) are
  deliberately **not** fixed and remain open in SonarCloud. All three sit inside a deeply nested
  `try/catch/finally`, where the explicit `return` statements keep the control flow readable and
  consistent with the surrounding branches; this code shape is an explicit drop condition for the rule.

# Executed Tests

* `mvn clean install -Plegacy,quality` on `xwiki-platform-oldcore` (1140 tests, 0 failures) and on
  `xwiki-platform-repository-server-api` — both BUILD SUCCESS (unit tests, JaCoCo, Revapi and
  Checkstyle all green)

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None

Generated with Kimi Code, then reviewed and revised with Claude Code.
