### PR TITLE
XWIKI-24589: Create/check for automated tests for "Base Colors Text Color"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker/src/test/it/org/xwiki/flamingo/test/ui/FlamingoThemeIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker/src/test/it/org/xwiki/flamingo/test/ui/FlamingoThemeIT.java
@@ -218,12 +218,11 @@ class FlamingoThemeIT
 
     private void assertCustomThemeColors(ViewPage page)
     {
-        // FIXME: The following should be put back when https://github.com/SeleniumHQ/selenium/issues/7697 will be fixed
-        // for now we get rgb value with Firefox and rgba value with Chrome
-        //assertEquals("rgb(255, 0, 0)", page.getPageBackgroundColor());
-        // Test 'lessCode' is correctly handled
-        //assertEquals("rgb(0, 0, 255)", page.getTextColor());
         assertColor(255, 218, 218, page.getPageBackgroundColor());
+        // The text color set by the theme is inherited from the "body" element. Note that we cannot assert it on the
+        // page content since the 'lessCode' variable set by this test colors the whole ".main" block in blue.
+        assertColor(102, 51, 0, page.getTextColor());
+        // Test 'lessCode' is correctly handled, the title being inside the ".main" block it colors.
         assertColor(0, 0, 255, page.getTitleColor());
         assertEquals("monospace", page.getTitleFontFamily().toLowerCase());
     }
@@ -277,6 +276,8 @@ class FlamingoThemeIT
         editThemePage.setVariableValue("link-color", "#2c699c");
         // Change another value. We don't deactivate all WCAG checks, so we need to take care about contrast.
         editThemePage.setVariableValue("xwiki-page-content-bg", "#ffdada");
+        // Change the color of the page's text. It's dark enough to keep a proper contrast with the page backgrounds.
+        editThemePage.setVariableValue("text-color", "#663300");
         // Again...
         editThemePage.selectVariableCategory("Typography");
         editThemePage.setVariableValue("font-family-base", "Monospace");

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
@@ -384,6 +384,16 @@ public class ViewPage extends BasePage
         return getElementCSSValue(By.id("document-title"), "font-family");
     }
 
+    /**
+     * @return the color of the page's text, i.e. the color set on the {@code body} element and inherited by all the
+     *     text of the page that doesn't define a color of its own
+     * @since 18.7.0RC1
+     */
+    public String getTextColor()
+    {
+        return getElementCSSValue(By.tagName("body"), "color");
+    }
+
     private String getElementCSSValue(By locator, String attribute)
     {
         return getDriver().findElement(locator).getCssValue(attribute);


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24589

# Changes

## Description

* Automates the [Base Colors Text Color](https://test.xwiki.org/xwiki/bin/view/Color%20Themes%20Tests/Base%20Colors%20Text%20Color) manual test in `FlamingoThemeIT`: the `@text-color` variable of the "Base colors" category of the color theme editor is now set (to `#663300`), and the resulting text color is asserted.
* Adds `ViewPage.getTextColor()`, returning the `color` CSS value of the `body` element (where the skin applies `@text-color`, through Bootstrap's scaffolding).
* Removes two dead commented-out assertions in `assertCustomThemeColors()`: they are superseded by the live `assertColor()` calls right below them (which already handle the `rgb` vs `rgba` discrepancy the FIXME was about), and one of them referenced a `getTextColor()` that had never existed in the code base.

## Clarifications

* I first checked whether the scenario was already covered: `FlamingoThemeIT.validateColorThemeFeatures` is the only automated test touching the color theme editor, and in the "Base colors" category it only set `link-color` and `xwiki-page-content-bg`. `text-color` was never set and the page text color was never asserted, so this manual test was not automated.
* The assertion has been added to `assertCustomThemeColors()`, which is already executed against the theme editor preview iframe, the color theme home page, a page using the theme set from the wiki administration, and a parent/child page pair using the theme set from the page administration. The manual test's "open a wiki page" step is therefore covered on real pages, not only in the preview.
* The text color is asserted on the `body` element rather than on the page content: the test also sets the `lessCode` variable to `.main{ color: #0000ff; }`, and `view.vm` wraps the whole content in a `<div class="main">`, so that blue cascades over `#xwikicontent` and hides `@text-color` there. This is explained in a comment in the test.
* `#663300` was chosen because the Docker test framework runs WCAG contrast checks: it gives roughly 10:1 against the white background and 8:1 against the `#ffdada` content background that the test sets.

# Screenshots & Video

N/A — test-only change, no UI change.

# Executed Tests

```
# The full Docker functional test, which passed:
cd xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker
mvn clean verify -B -ntp -Plegacy,integration-tests,docker
# -> Tests run: 1, Failures: 0, Errors: 0, Skipped: 0 -- in org.xwiki.flamingo.test.ui.FlamingoThemeIT

# The modified page object module (Checkstyle, license check, Spoon, etc.):
cd xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui
mvn clean install -B -ntp -Plegacy
```

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
