### PR TITLE
XWIKI-24648: Realtime user list in CKEditor and wiki editor flickers when other users move the caret

### DIFF
--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-webjar/src/main/webjar/toolbar.js
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-webjar/src/main/webjar/toolbar.js
@@ -363,19 +363,60 @@ define('xwiki-realtime-toolbar', [
     }
 
     onUserListChange(users) {
+      // The user data we receive also holds information that is not displayed on the toolbar, most notably the caret
+      // position of each user, which changes very often. Skip the update when nothing we display has changed, in order
+      // to avoid needless DOM churn. Recreating the coeditor elements every few seconds makes them visibly flicker
+      // (they briefly disappear and re-appear, both on the toolbar and in an open users dropdown), dismisses the
+      // avatar tooltip while it is being hovered, and invalidates any reference held on them (e.g. by the functional
+      // tests).
+      const signature = JSON.stringify(users.map(user => [user.id, user.reference, user.name, user.avatar]));
+      if (signature === this._userListSignature) {
+        return;
+      }
+      this._userListSignature = signature;
+
       const usersWrapper = this._toolbar.querySelector('.realtime-users');
-      usersWrapper.innerHTML = '';
       const limit = Number.parseInt(usersWrapper.dataset.limit) || 4;
-      users.slice(0, limit).forEach(user => {
-        usersWrapper.appendChild(this._displayUser(user, true));
-      });
+      this._updateUserList(usersWrapper, users.slice(0, limit), true);
+
       const usersDropdown = this._toolbar.querySelector('.realtime-users-dropdown');
       usersDropdown.hidden = users.length <= limit;
       if (!usersDropdown.hidden) {
         usersDropdown.querySelector('.dropdown-toggle').dataset.more = users.length - limit;
-        const menu = usersDropdown.querySelector('.dropdown-menu');
-        menu.innerHTML = '';
-        users.forEach(user => menu.appendChild(this._displayUser(user)));
+        this._updateUserList(usersDropdown.querySelector('.dropdown-menu'), users);
+      }
+    }
+
+    _updateUserList(listElement, users, compact = false) {
+      const existingWrappers = new Map();
+      listElement.querySelectorAll(':scope > li > .realtime-user').forEach(userElement => {
+        existingWrappers.set(userElement.dataset.id, userElement.parentElement);
+      });
+
+      // Reuse the element of a user that is already listed, rather than recreating it, so that its avatar is not
+      // reloaded and so that the references others may hold on it (e.g. the functional tests) remain valid.
+      let nextNode = listElement.firstChild;
+      users.forEach(user => {
+        let wrapper = existingWrappers.get(user.id);
+        if (wrapper) {
+          existingWrappers.delete(user.id);
+          this._updateUser(wrapper.firstElementChild, user);
+        } else {
+          wrapper = this._displayUser(user, compact);
+        }
+        if (wrapper === nextNode) {
+          nextNode = nextNode.nextSibling;
+        } else {
+          listElement.insertBefore(wrapper, nextNode);
+        }
+      });
+
+      // Whatever is left after the last user we placed is either a user that left the editing session or some leftover
+      // from the template (e.g. the placeholder list item).
+      while (nextNode) {
+        const nodeToRemove = nextNode;
+        nextNode = nextNode.nextSibling;
+        nodeToRemove.remove();
       }
     }
 
@@ -385,28 +426,38 @@ define('xwiki-realtime-toolbar', [
       if (compact) {
         userElement.classList.add('realtime-user-compact');
       }
+      this._updateUser(userElement, user);
+
+      const wrapper = document.createElement('li');
+      wrapper.appendChild(userElement);
+      return wrapper;
+    }
+
+    _updateUser(userElement, user) {
       userElement.href = new XWiki.Document(XWiki.Model.resolve(user.reference, XWiki.EntityType.DOCUMENT)).getURL();
       userElement.dataset.id = user.id;
       userElement.dataset.reference = user.reference;
-      $(userElement).on('click.realtime', event => {
+      $(userElement).off('click.realtime').on('click.realtime', event => {
         event.preventDefault();
         this._config.selectUser(user.id);
       });
 
       const avatar = userElement.querySelector('.realtime-user-avatar');
-      // Leave the default avatar if there's no avatar specified.
-      if (user.avatar) {
-        avatar.src = user.avatar;
-      }
+      // Fall back on the default avatar if there's no avatar specified.
+      avatar.setAttribute('src', user.avatar || this._getDefaultAvatarURL());
       avatar.alt = user.name;
       avatar.title = user.name;
       avatar.parentElement.dataset.abbr = this._getUserNameAbbreviation(user.name);
 
       userElement.querySelector('.realtime-user-name').textContent = user.name;
+    }
 
-      const wrapper = document.createElement('li');
-      wrapper.appendChild(userElement);
-      return wrapper;
+    _getDefaultAvatarURL() {
+      if (this._defaultAvatarURL === undefined) {
+        const template = document.querySelector('template#realtime-user');
+        this._defaultAvatarURL = template.content.querySelector('.realtime-user-avatar').getAttribute('src');
+      }
+      return this._defaultAvatarURL;
     }
 
     _getUserNameAbbreviation(name) {


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24648

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Skip the coeditor list update when none of the displayed information changed. The user data published by each coeditor also holds their caret position, which is polled every 3 seconds, so the whole list was emptied and rebuilt every few seconds while somebody else was moving the caret across block elements, making the coeditors visibly disappear and re-appear, both on the toolbar and in an open coeditors dropdown.
* Reconcile the coeditor list in place instead of emptying it and re-creating every entry, so that a genuine join or leave doesn't recreate the elements of the coeditors that didn't change. The avatar source is now always set, falling back on the default avatar from the template, since a reused element may hold the avatar of a coeditor that had one.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This is part of what was suggested for fixing https://jira.xwiki.org/browse/XWIKI-22178. While I have tried fixing the stale elements in an [independent change](https://github.com/xwiki/xwiki-platform/commit/0828edd19e2863e7011ce05b1dd2256f2c275a0f), this should further help fixing the flickering and fixes a real UI issue.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes except that it removes the flickering.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Ran the WYSIWYG and wiki editor realtime tests. Claude Code also ran the isolated JavaScript code with some tests against jsdom but I haven't checked how extensive that was. Further, Claude Code verified in the WYSIWYG realtime integration test setup that the element is really not becoming stale anymore.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-18.4.x
  * stable-17.10.x