### PR TITLE
XWIKI-23126: NavigationPanelAdministrationIT#navigationPanelAdministration is flickering

### DIFF
--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-pageobjects/src/main/java/org/xwiki/panels/test/po/NavigationPanelAdministrationPage.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-pageobjects/src/main/java/org/xwiki/panels/test/po/NavigationPanelAdministrationPage.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.panels.test.po;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -109,6 +110,11 @@ public class NavigationPanelAdministrationPage extends ViewPage
         }
         if (source != null) {
             getDriver().dragAndDrop(source, this.excludedPagesPane);
+            // The drop is handled by synchronous client-side JavaScript (no server round-trip), but the resulting DOM
+            // mutation (hiding the tree nodes, toggling the "No pages found" placeholder) may not be reflected yet by
+            // the time the drag-and-drop Selenium command returns. Wait for it explicitly so callers don't read the
+            // tree state mid-mutation.
+            waitUntilTopLevelPagesState(Arrays.asList(pages), false);
         }
     }
 
@@ -133,7 +139,24 @@ public class NavigationPanelAdministrationPage extends ViewPage
         }
         if (source != null) {
             getDriver().dragAndDrop(source, this.treeElement);
+            // See the comment in #exclude(String...) about why we need to wait for the drop to be fully processed.
+            waitUntilTopLevelPagesState(Arrays.asList(pages), true);
         }
+    }
+
+    /**
+     * Wait until the given pages are (or aren't) part of the visible top level pages of the navigation tree.
+     *
+     * @param pages the pages to check
+     * @param visible {@code true} to wait until the pages are visible top level pages, {@code false} to wait until
+     *     they aren't anymore
+     */
+    private void waitUntilTopLevelPagesState(List<String> pages, boolean visible)
+    {
+        getDriver().waitUntilCondition(driver -> {
+            List<String> topLevelPages = getNavigationTree().getTopLevelPages();
+            return pages.stream().allMatch(page -> topLevelPages.contains(page) == visible);
+        });
     }
 
     public boolean isExcludingTopLevelExtensionPages()
@@ -169,6 +192,9 @@ public class NavigationPanelAdministrationPage extends ViewPage
 
     private WebElement getPageByTitle(String pageTitle)
     {
+        // Make sure the tree has finished (re)loading before looking up a node in it, otherwise we might race with
+        // its initial AJAX load, e.g. right after the page was reloaded.
+        getNavigationTree();
         return getDriver().findElementWithoutWaiting(this.treeElement,
             By.xpath("(.//li[contains(@class, 'jstree-node')]/a[. = '" + pageTitle + "'])"));
     }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-23126

# Changes

## Description

* Fix a DOM-read race in `NavigationPanelAdministrationPage` (page object used by `NavigationPanelAdministrationIT`) that caused the test to intermittently read the navigation tree mid-mutation or before it had finished (re)loading.

## Clarifications

Investigated via Develocity (`community.develocity.cloud`): over the last 30 days the test failed in ~4.2% of its 718 runs (30 failures + 1 flaky), spread across `master` and `stable-16.10.x`, multiple browsers/DBs/CI agents — ruling out CI infra as the cause. The failures fell into a few related assertion-mismatch signatures around `getNavigationTree().getTopLevelPages()` flip-flopping between the real page list, `[]`, and the `"No pages found"` placeholder, plus one `NoSuchElementException` in `isPinned()`.

Root cause, confirmed by reading the client-side JS (`PanelsCode/NavigationConfigurationSheet.xml`) and the page objects:
* `exclude()`/`include()` perform a Selenium drag-and-drop that triggers purely client-side, synchronous jQuery/jsTree DOM mutations (`show_node`/`hide_node`/`create_node` + the `"No pages found"` placeholder toggle) — there's no server round-trip. But `NavigationPanelAdministrationPage` returned immediately after the drag-and-drop call, before that mutation was necessarily reflected in the DOM, so a caller reading the tree right after could observe a mix of pre- and post-mutation state.
* `getPageByTitle()` (used by `isPinned`/`pinPage`/`unpinPage`/`dragBefore`) searched the tree without first waiting for it to be ready, which raced with the tree's initial AJAX load right after a page reload (`saveAndReload()`), producing the observed `NoSuchElementException`.
* `getNavigationTree()`'s existing `waitForIt()` doesn't help here: it only waits for `.jstree-container-ul` to exist and `aria-busy != "true"`, and `aria-busy` is only toggled during the tree's *initial* load — it becomes a permanent no-op for every later mutation.

This is a reopened manifestation of the previously "fixed" XWIKI-21606 — that earlier fix (March 2025) was incomplete, since it didn't add real synchronization after `exclude`/`include`/`pin`/`dragBefore`.

Fix: `exclude()`/`include()` now wait (`waitUntilTopLevelPagesState`) until the dragged pages have actually become hidden/visible in the tree before returning, and `getPageByTitle()` now waits for the tree to finish (re)loading (`getNavigationTree()`) before searching it.

Out of scope: a separate, distinct test-isolation issue was also observed in the Develocity data (extra top-level pages leaking in from sibling nested tests in the same `AllIT` suite) — unrelated to this DOM-timing race, not fixed here.

# Screenshots & Video

N/A (test-only change, no product UI change).

# Executed Tests

* `mvn clean verify -pl .../xwiki-platform-panels-test-pageobjects -Plegacy` — compiles cleanly, 0 Checkstyle violations.
* Validated the fix by temporarily replacing `@Test` with `@RepeatedTest(value = N, failureThreshold = 1)` on `navigationPanelAdministration` and running it against a real Docker/Firefox instance:
  * `mvn clean install -pl .../xwiki-platform-panels-test-docker -Plegacy,integration-tests,docker -Dit.test=AllIT$NestedNavigationPanelAdministrationIT#navigationPanelAdministration -Dxwiki.test.ui.browser=firefox`
  * 10/10 passed, then 50/50 passed — 60 consecutive runs, 0 failures — versus the ~4% failure rate observed in CI over the last month.
  * The temporary `@RepeatedTest` change was reverted before this PR; only the actual page-object fix is included.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)