### PR TITLE
XWIKI-24650: Dashboard content parsing modifies rendering context

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-parser/src/main/java/org/xwiki/rendering/internal/executor/MacroContentExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-parser/src/main/java/org/xwiki/rendering/internal/executor/MacroContentExecutor.java
@@ -28,11 +28,13 @@ import org.xwiki.model.reference.EntityReference;
 import org.xwiki.rendering.block.XDOM;
 import org.xwiki.rendering.executor.ContentExecutor;
 import org.xwiki.rendering.executor.ContentExecutorException;
+import org.xwiki.rendering.internal.transformation.MutableRenderingContext;
 import org.xwiki.rendering.parser.ContentParser;
 import org.xwiki.rendering.parser.MissingParserException;
 import org.xwiki.rendering.parser.ParseException;
 import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.rendering.transformation.MacroTransformationContext;
+import org.xwiki.rendering.transformation.RenderingContext;
 import org.xwiki.rendering.transformation.Transformation;
 import org.xwiki.rendering.transformation.TransformationException;
 
@@ -52,6 +54,12 @@ public class MacroContentExecutor implements ContentExecutor<MacroTransformation
     @Inject
     @Named("macro")
     private Transformation macroTransformation;
+
+    /**
+     * Used to execute the transformation in its own rendering context.
+     */
+    @Inject
+    private RenderingContext renderingContext;
 
     @Override
     public XDOM execute(String content, Syntax syntax, MacroTransformationContext macroContext)
@@ -74,7 +82,10 @@ public class MacroContentExecutor implements ContentExecutor<MacroTransformation
     private void executeContent(XDOM xdom, MacroTransformationContext macroContext) throws ContentExecutorException
     {
         try {
-            this.macroTransformation.transform(xdom, macroContext.getTransformationContext());
+            // Execute the transformation through the rendering context and not directly so that it gets its own
+            // rendering context instead of modifying the context of the transformation that triggered this execution.
+            ((MutableRenderingContext) this.renderingContext).transformInContext(this.macroTransformation,
+                macroContext.getTransformationContext(), xdom);
         } catch (TransformationException e) {
             throw new ContentExecutorException("Failed to execute content", e);
         }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-parser/src/test/java/org/xwiki/rendering/internal/executor/MacroContentExecutorTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-parser/src/test/java/org/xwiki/rendering/internal/executor/MacroContentExecutorTest.java
@@ -27,9 +27,11 @@ import org.junit.jupiter.api.Test;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.rendering.block.XDOM;
 import org.xwiki.rendering.executor.ContentExecutorException;
+import org.xwiki.rendering.internal.transformation.MutableRenderingContext;
 import org.xwiki.rendering.parser.ContentParser;
 import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.rendering.transformation.MacroTransformationContext;
+import org.xwiki.rendering.transformation.RenderingContext;
 import org.xwiki.rendering.transformation.Transformation;
 import org.xwiki.rendering.transformation.TransformationContext;
 import org.xwiki.rendering.transformation.TransformationException;
@@ -64,6 +66,9 @@ class MacroContentExecutorTest
     @Named("macro")
     private Transformation macroTransformation;
 
+    @MockComponent(classToMock = MutableRenderingContext.class)
+    private RenderingContext renderingContext;
+
     @Test
     void executeWithNoSource() throws Exception
     {
@@ -75,8 +80,9 @@ class MacroContentExecutorTest
 
         this.macroContentExecutor.execute("", Syntax.PLAIN_1_0, context);
 
-        // The test is here: Verify that the Macro Transformation has been called
-        verify(this.macroTransformation).transform(parsedBlocks, transformationContext);
+        // The test is here: Verify that the Macro Transformation has been called in its own rendering context.
+        verify((MutableRenderingContext) this.renderingContext).transformInContext(this.macroTransformation,
+            transformationContext, parsedBlocks);
     }
 
     @Test
@@ -90,8 +96,9 @@ class MacroContentExecutorTest
 
         this.macroContentExecutor.execute("", Syntax.PLAIN_1_0, DOCUMENT_REFERENCE, context);
 
-        // The test is here: Verify that the Macro Transformation has been called
-        verify(this.macroTransformation).transform(parsedBlocks, transformationContext);
+        // The test is here: Verify that the Macro Transformation has been called in its own rendering context.
+        verify((MutableRenderingContext) this.renderingContext).transformInContext(this.macroTransformation,
+            transformationContext, parsedBlocks);
     }
 
     @Test
@@ -103,8 +110,8 @@ class MacroContentExecutorTest
         TransformationContext transformationContext = new TransformationContext();
         MacroTransformationContext context = new MacroTransformationContext(transformationContext);
 
-        doThrow(new TransformationException("error"))
-            .when(this.macroTransformation).transform(parsedBlocks, transformationContext);
+        doThrow(new TransformationException("error")).when((MutableRenderingContext) this.renderingContext)
+            .transformInContext(this.macroTransformation, transformationContext, parsedBlocks);
 
         ContentExecutorException exception = assertThrows(ContentExecutorException.class,
             () -> this.macroContentExecutor.execute("", Syntax.PLAIN_1_0, context));


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24650

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

The macro content executor called the macro transformation directly instead of going through MutableRenderingContext#transformInContext(), so the nested transformation it performs ran on the rendering context frame of the transformation that triggered it.

MacroTransformation sets the current block of the rendering context before executing a macro and resets it to null afterward, so once the executed content has been transformed, the enclosing transformation has lost its current block. The current block is what XWiki#getCurrentContentSyntaxId() uses to determine the syntax of the code currently being executed.

Pushing a frame also makes the nested transformation visible to everything that observes transformations through the rendering context.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This is the minimal fix, a proper cleanup would be to deprecate the whole `ContentExecutor` concept and instead rely on either `MacroContentParser` or `BlockAsyncRendererExecutor` to execute the content - they do much more than this simple fix.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes except for the obvious fix.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built the modified module, xwiki-platform-dashboard-macro and xwiki-platform-dashboard-test-docker with the quality profile. Manual test shows that both gadgets now have xwiki/2.0 displayed as title in the scenario of the issue.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * Doesn't feel that important.