### PR TITLE
XWIKI-22198: Bootstrap switches are not keyboard accessible

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
@@ -337,8 +337,10 @@ define('xwiki-bootstrap-switch', ['jquery', 'bootstrap', 'bootstrap-switch'], fu
 }
 
 /* Bootstrap Switch hides the real checkbox/radio input with "visibility: hidden", which also removes it from the
-  tab order and the accessibility tree. Restore its visibility (it stays invisible thanks to the opacity and
-  z-index rules) so that it remains keyboard and screen-reader accessible. */
+  tab order and the accessibility tree. Restore its visibility so that it remains keyboard and screen-reader
+  accessible. This doesn't introduce any visual change because Bootstrap Switch already makes the input fully
+  transparent (opacity: 0) and stacks it behind the switch (z-index: -1, while .bootstrap-switch itself establishes
+  a stacking context with z-index: 0), so it never actually paints. */
 .bootstrap-switch input[type='radio'],
 .bootstrap-switch input[type='checkbox'] {
   visibility: visible;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
@@ -168,7 +168,15 @@ define('xwiki-bootstrap-switch', ['jquery', 'bootstrap', 'bootstrap-switch'], fu
       // The caller wants to set multiple options, including the label.
       option.labelText = fixLabel(option.labelText);
     }
-    return this.bootstrapSwitchOrig.apply(this, arguments);
+    var result = this.bootstrapSwitchOrig.apply(this, arguments);
+    // The handle and label spans only duplicate the state already carried by the underlying (still focusable)
+    // checkbox/radio input, so screen readers shouldn't announce them as separate interactive elements.
+    this.each(function() {
+      $(this).parent().find(
+        '.bootstrap-switch-handle-on, .bootstrap-switch-handle-off, .bootstrap-switch-label'
+      ).attr('aria-hidden', 'true');
+    });
+    return result;
   };
 
   // Copy data (such as default configuration, constructor) from the original Bootstrap Switch function.
@@ -309,6 +317,14 @@ define('xwiki-bootstrap-switch', ['jquery', 'bootstrap', 'bootstrap-switch'], fu
     displays the switch badly when inside a table with .hyphenate style. Moreover, the standard Bootstrap Switch styles
     add a zero-width-space before all descendant SPANs (why?) which increases the height of the switch in Firefox. */
   white-space: nowrap;
+}
+
+/* Bootstrap Switch hides the real checkbox/radio input with "visibility: hidden", which also removes it from the
+  tab order and the accessibility tree. Restore its visibility (it stays invisible thanks to the opacity and
+  z-index rules) so that it remains keyboard and screen-reader accessible. */
+.bootstrap-switch input[type='radio'],
+.bootstrap-switch input[type='checkbox'] {
+  visibility: visible;
 }</code>
     </property>
     <property>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
@@ -172,7 +172,7 @@ define('xwiki-bootstrap-switch', ['jquery', 'bootstrap', 'bootstrap-switch'], fu
     // The handle and label spans only duplicate the state already carried by the underlying (still focusable)
     // checkbox/radio input, so screen readers shouldn't announce them as separate interactive elements.
     this.each(function() {
-      $(this).parent().find(
+      $(this).closest('.bootstrap-switch').find(
         '.bootstrap-switch-handle-on, .bootstrap-switch-handle-off, .bootstrap-switch-label'
       ).attr('aria-hidden', 'true');
     });

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
@@ -190,13 +190,6 @@ define('xwiki-bootstrap-switch', ['jquery', 'bootstrap', 'bootstrap-switch'], fu
         }
       };
       syncIndeterminateAria();
-      // The user directly interacting with the input (click/keyboard) also clears "indeterminate" natively, but
-      // bypasses this wrapper entirely, so keep aria-checked in sync with that path too. Listen for
-      // switchChange.bootstrapSwitch rather than change.bootstrapSwitch: Bootstrap Switch's own internal
-      // change.bootstrapSwitch handler calls stopImmediatePropagation(), which would silently swallow a listener
-      // bound afterwards on that same event; switchChange.bootstrapSwitch is a separate event it re-triggers once
-      // its own handling is done, so it isn't affected. Bound once per input, under the same namespace Bootstrap
-      // Switch itself uses so it's cleaned up together on destroy().
       if (!$input.data('xwikiIndeterminateAriaBound')) {
         $input.data('xwikiIndeterminateAriaBound', true);
         $input.on('switchChange.bootstrapSwitch', syncIndeterminateAria);

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
@@ -327,6 +327,12 @@ define('xwiki-bootstrap-switch', ['jquery', 'bootstrap', 'bootstrap-switch'], fu
 .bootstrap-switch input[type='radio'],
 .bootstrap-switch input[type='checkbox'] {
   visibility: visible;
+}
+
+/* The default focus border color (--input-border-focus) falls under the WCAG 1.4.11 3:1 contrast requirement.
+  Use the theme's info color instead, scoped to the switch only. */
+.bootstrap-switch.bootstrap-switch-focused {
+  border-color: var(--brand-info);
 }</code>
     </property>
     <property>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
@@ -175,23 +175,6 @@ define('xwiki-bootstrap-switch', ['jquery', 'bootstrap', 'bootstrap-switch'], fu
       $(this).parent().find(
         '.bootstrap-switch-handle-on, .bootstrap-switch-handle-off, .bootstrap-switch-label'
       ).attr('aria-hidden', 'true');
-      // Bootstrap Switch supports a third, "indeterminate" state (bootstrapSwitch('indeterminate', true)), backed by
-      // the native input's "indeterminate" DOM property. That property alone isn't exposed to the accessibility tree,
-      // so screen readers never learn about it; expose it explicitly via aria-checked="mixed" instead, which is the
-      // standard way to convey a mixed/tri-state checkbox (native checked/unchecked semantics are used otherwise).
-      var $input = $(this);
-      var syncIndeterminateAria = function() {
-        if ($input.prop('indeterminate')) {
-          $input.attr('aria-checked', 'mixed');
-        } else {
-          $input.removeAttr('aria-checked');
-        }
-      };
-      syncIndeterminateAria();
-      if (!$input.data('xwikiIndeterminateAriaBound')) {
-        $input.data('xwikiIndeterminateAriaBound', true);
-        $input.on('switchChange.bootstrapSwitch', syncIndeterminateAria);
-      }
     });
     return result;
   };

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
@@ -168,7 +168,7 @@ define('xwiki-bootstrap-switch', ['jquery', 'bootstrap', 'bootstrap-switch'], fu
       // The caller wants to set multiple options, including the label.
       option.labelText = fixLabel(option.labelText);
     }
-    var result = this.bootstrapSwitchOrig.apply(this, arguments);
+    const result = this.bootstrapSwitchOrig.apply(this, arguments);
     // The handle and label spans only duplicate the state already carried by the underlying (still focusable)
     // checkbox/radio input, so screen readers shouldn't announce them as separate interactive elements.
     this.each(function() {

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
@@ -176,6 +176,32 @@ define('xwiki-bootstrap-switch', ['jquery', 'bootstrap', 'bootstrap-switch'], fu
         '.bootstrap-switch-handle-on, .bootstrap-switch-handle-off, .bootstrap-switch-label'
       ).attr('aria-hidden', 'true');
     });
+    // Bootstrap Switch supports a third, "indeterminate" state (bootstrapSwitch('indeterminate', true)), backed by
+    // the native input's "indeterminate" DOM property. That property alone isn't exposed to the accessibility tree,
+    // so screen readers never learn about it; expose it explicitly via aria-checked="mixed" instead, which is the
+    // standard way to convey a mixed/tri-state checkbox (native checked/unchecked semantics are used otherwise).
+    this.each(function() {
+      var $input = $(this);
+      var syncIndeterminateAria = function() {
+        if ($input.prop('indeterminate')) {
+          $input.attr('aria-checked', 'mixed');
+        } else {
+          $input.removeAttr('aria-checked');
+        }
+      };
+      syncIndeterminateAria();
+      // The user directly interacting with the input (click/keyboard) also clears "indeterminate" natively, but
+      // bypasses this wrapper entirely, so keep aria-checked in sync with that path too. Listen for
+      // switchChange.bootstrapSwitch rather than change.bootstrapSwitch: Bootstrap Switch's own internal
+      // change.bootstrapSwitch handler calls stopImmediatePropagation(), which would silently swallow a listener
+      // bound afterwards on that same event; switchChange.bootstrapSwitch is a separate event it re-triggers once
+      // its own handling is done, so it isn't affected. Bound once per input, under the same namespace Bootstrap
+      // Switch itself uses so it's cleaned up together on destroy().
+      if (!$input.data('xwikiIndeterminateAriaBound')) {
+        $input.data('xwikiIndeterminateAriaBound', true);
+        $input.on('switchChange.bootstrapSwitch', syncIndeterminateAria);
+      }
+    });
     return result;
   };
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
@@ -175,12 +175,10 @@ define('xwiki-bootstrap-switch', ['jquery', 'bootstrap', 'bootstrap-switch'], fu
       $(this).parent().find(
         '.bootstrap-switch-handle-on, .bootstrap-switch-handle-off, .bootstrap-switch-label'
       ).attr('aria-hidden', 'true');
-    });
-    // Bootstrap Switch supports a third, "indeterminate" state (bootstrapSwitch('indeterminate', true)), backed by
-    // the native input's "indeterminate" DOM property. That property alone isn't exposed to the accessibility tree,
-    // so screen readers never learn about it; expose it explicitly via aria-checked="mixed" instead, which is the
-    // standard way to convey a mixed/tri-state checkbox (native checked/unchecked semantics are used otherwise).
-    this.each(function() {
+      // Bootstrap Switch supports a third, "indeterminate" state (bootstrapSwitch('indeterminate', true)), backed by
+      // the native input's "indeterminate" DOM property. That property alone isn't exposed to the accessibility tree,
+      // so screen readers never learn about it; expose it explicitly via aria-checked="mixed" instead, which is the
+      // standard way to convey a mixed/tri-state checkbox (native checked/unchecked semantics are used otherwise).
       var $input = $(this);
       var syncIndeterminateAria = function() {
         if ($input.prop('indeterminate')) {

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
@@ -169,13 +169,16 @@ define('xwiki-bootstrap-switch', ['jquery', 'bootstrap', 'bootstrap-switch'], fu
       option.labelText = fixLabel(option.labelText);
     }
     const result = this.bootstrapSwitchOrig.apply(this, arguments);
-    // The handle and label spans only duplicate the state already carried by the underlying (still focusable)
-    // checkbox/radio input, so screen readers shouldn't announce them as separate interactive elements.
-    this.each(function() {
-      $(this).closest('.bootstrap-switch').find(
-        '.bootstrap-switch-handle-on, .bootstrap-switch-handle-off, .bootstrap-switch-label'
-      ).attr('aria-hidden', 'true');
-    });
+    // The "destroy" command removes the decorative spans and unwraps the input, so there is nothing left to mark.
+    if (option !== 'destroy') {
+      // The handle and label spans only duplicate the state already carried by the underlying (still focusable)
+      // checkbox/radio input, so screen readers shouldn't announce them as separate interactive elements.
+      this.each(function() {
+        $(this).closest('.bootstrap-switch').find(
+          '.bootstrap-switch-handle-on, .bootstrap-switch-handle-off, .bootstrap-switch-label'
+        ).attr('aria-hidden', 'true');
+      });
+    }
     return result;
   };
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
@@ -330,9 +330,9 @@ define('xwiki-bootstrap-switch', ['jquery', 'bootstrap', 'bootstrap-switch'], fu
 }
 
 /* The default focus border color (--input-border-focus) falls under the WCAG 1.4.11 3:1 contrast requirement.
-  Use the theme's info color instead, scoped to the switch only. */
+  Use the theme's primary color instead, scoped to the switch only. */
 .bootstrap-switch.bootstrap-switch-focused {
-  border-color: var(--brand-info);
+  border-color: var(--brand-primary);
 }</code>
     </property>
     <property>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
@@ -336,6 +336,9 @@ define('xwiki-bootstrap-switch', ['jquery', 'bootstrap', 'bootstrap-switch'], fu
   Use the theme's primary color instead, scoped to the switch only. */
 .bootstrap-switch.bootstrap-switch-focused {
   border-color: var(--brand-primary);
+  /* Bootstrap Switch draws the focus glow with a hardcoded light blue that doesn't follow the color theme and no
+    longer matches the border color set above. */
+  box-shadow: 0 0 8px var(--brand-primary);
 }</code>
     </property>
     <property>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/BootstrapSwitch.xml
@@ -168,7 +168,15 @@ define('xwiki-bootstrap-switch', ['jquery', 'bootstrap', 'bootstrap-switch'], fu
       // The caller wants to set multiple options, including the label.
       option.labelText = fixLabel(option.labelText);
     }
-    return this.bootstrapSwitchOrig.apply(this, arguments);
+    var result = this.bootstrapSwitchOrig.apply(this, arguments);
+    // The handle and label spans only duplicate the state already carried by the underlying (still focusable)
+    // checkbox/radio input, so screen readers shouldn't announce them as separate interactive elements.
+    this.each(function() {
+      $(this).parent().find(
+        '.bootstrap-switch-handle-on, .bootstrap-switch-handle-off, .bootstrap-switch-label'
+      ).attr('aria-hidden', 'true');
+    });
+    return result;
   };
 
   // Copy data (such as default configuration, costructor) from the original Bootstrap Switch function.
@@ -309,6 +317,14 @@ define('xwiki-bootstrap-switch', ['jquery', 'bootstrap', 'bootstrap-switch'], fu
     displays the switch badly when inside a table with .hyphenate style. Moreover, the standard Bootstrap Switch styles
     add a zero-width-space before all descendant SPANs (why?) which increases the height of the switch in Firefox. */
   white-space: nowrap;
+}
+
+/* Bootstrap Switch hides the real checkbox/radio input with "visibility: hidden", which also removes it from the
+  tab order and the accessibility tree. Restore its visibility (it stays invisible thanks to the opacity and
+  z-index rules) so that it remains keyboard and screen-reader accessible. */
+.bootstrap-switch input[type='radio'],
+.bootstrap-switch input[type='checkbox'] {
+  visibility: visible;
 }</code>
     </property>
     <property>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22198
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Hide the decorative handle/label spans from AT.
* Restore visibility of the real checkbox/radio input so it stays in the tab order and accessibility tree.
* Make the "indeterminate" third state of boostrap switches AT compatible with `aria-checked="mixed"`

<!-- * Add a contextual aria-label to event-type switches and to the generic livedata toggle displayer.
* Restore focus to the notification application event-type switch the user just toggled after the save request completes. -->

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, the changes have no impact on the visual user interface but only on its accessibility.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Ran a test suite that involves bootstrap toggles successfully with:
`mvn clean verify -B -ntp -Plegacy,integration-tests,docker -pl xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker -Dtest=NotificationsSettingsIT`

Passed the notification webjar tests with `npx vitest run` on `DisplayerToggle.test.ts`.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None.