### PR TITLE
[Misc] Fix broken log messages and apply the logging best practices to oldcore

### DIFF
--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/bridge/WikiObjectComponentManagerEventListenerProxy.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/bridge/WikiObjectComponentManagerEventListenerProxy.java
@@ -101,7 +101,8 @@ public class WikiObjectComponentManagerEventListenerProxy
                 wikiObjectsList.add(componentBuilder.getClassReference());
             }
         } catch (ComponentLookupException e) {
-            logger.warn("Unable to collect a list of wiki objects components: %s", e);
+            logger.warn("Unable to collect a list of wiki objects components. Root cause is [{}]",
+                ExceptionUtils.getRootCauseMessage(e));
         }
 
         return wikiObjectsList;

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/AbstractAsynchronousEventStore.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/AbstractAsynchronousEventStore.java
@@ -431,7 +431,7 @@ public abstract class AbstractAsynchronousEventStore implements EventStore, Init
             try {
                 this.contextStore.restore(task.context);
             } catch (ComponentLookupException e) {
-                this.logger.error("Failed to restore context of the event", output, e);
+                this.logger.error("Failed to restore context of the event [{}]", output, e);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/DefaultExtensionIndex.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/DefaultExtensionIndex.java
@@ -148,7 +148,7 @@ public class DefaultExtensionIndex extends AbstractAdvancedSearchableExtensionRe
         try {
             return this.store.exists(extensionId);
         } catch (Exception e) {
-            this.logger.error("Failed to check existance of extension [{}]", extensionId, e);
+            this.logger.error("Failed to check existence of extension [{}]", extensionId, e);
 
             return false;
         }

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-events-hibernate/xwiki-platform-legacy-events-hibernate-api/src/main/java/org/xwiki/eventstream/store/internal/LegacyEventLoader.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-events-hibernate/xwiki-platform-legacy-events-hibernate-api/src/main/java/org/xwiki/eventstream/store/internal/LegacyEventLoader.java
@@ -76,7 +76,7 @@ public class LegacyEventLoader
             List<Event> events = searchEvents(query);
             result.addEvents(events.toArray(new Event[0]));
         } catch (Exception e) {
-            logger.error("Failed to load related events for [%s].", event.getId(), e);
+            logger.error("Failed to load related events for [{}].", event.getId(), e);
         }
 
         return result;

--- a/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSenderPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSenderPlugin.java
@@ -103,7 +103,7 @@ public class MailSenderPlugin extends XWikiDefaultPlugin
     /**
      * Error message logged when a {@link MessagingException} occurs while sending emails.
      */
-    private static final String MESSAGING_EXCEPTION_ERROR = "MessagingException has occured.";
+    private static final String MESSAGING_EXCEPTION_ERROR = "MessagingException has occurred.";
 
     /**
      * Error code signaling that the mail template requested for
@@ -687,8 +687,8 @@ public class MailSenderPlugin extends XWikiDefaultPlugin
                     }
                 } catch (SendFailedException ex) {
                     sendFailedCount++;
-                    LOGGER.error("SendFailedException has occured.", ex);
-                    LOGGER.error("Detailed email information" + mail.toString());
+                    LOGGER.error("SendFailedException has occurred.", ex);
+                    LOGGER.error("Detailed email information: [{}]", mail);
                     if (emailCount == 1) {
                         throw ex;
                     }
@@ -697,14 +697,14 @@ public class MailSenderPlugin extends XWikiDefaultPlugin
                     }
                 } catch (MessagingException mex) {
                     LOGGER.error(MESSAGING_EXCEPTION_ERROR, mex);
-                    LOGGER.error("Detailed email information" + mail.toString());
+                    LOGGER.error("Detailed email information: [{}]", mail);
                     if (emailCount == 1) {
                         throw mex;
                     }
                 } catch (XWikiException e) {
-                    LOGGER.error("XWikiException has occured.", e);
+                    LOGGER.error("XWikiException has occurred.", e);
                 } catch (IOException e) {
-                    LOGGER.error("IOException has occured.", e);
+                    LOGGER.error("IOException has occurred.", e);
                 }
             }
         } finally {

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/main/java/org/xwiki/notifications/preferences/internal/AbstractDocumentNotificationPreferenceProvider.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/main/java/org/xwiki/notifications/preferences/internal/AbstractDocumentNotificationPreferenceProvider.java
@@ -86,7 +86,7 @@ public abstract class AbstractDocumentNotificationPreferenceProvider implements 
                 .saveNotificationsPreferences(documentReference, preferences);
         } else {
             logger.warn("Preference's target [{}] is not a document reference. The corresponding preference will not"
-                    + " be saved.");
+                    + " be saved.", target);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/main/java/org/xwiki/notifications/preferences/internal/WikiNotificationPreferenceProvider.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/main/java/org/xwiki/notifications/preferences/internal/WikiNotificationPreferenceProvider.java
@@ -85,7 +85,7 @@ public class WikiNotificationPreferenceProvider extends AbstractDocumentNotifica
                     preferences);
         } else {
             logger.warn("Preference's target [{}] is not a wiki reference. The corresponding preference will not be"
-                    + " saved.");
+                    + " saved.", target);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -1683,8 +1683,8 @@ public class XWiki implements EventListener
                 }
             } catch (Exception e) {
                 // Failed to retrieve the version, log a warning
-                LOGGER.warn("Failed to retrieve XWiki's version from [{}], using the [{}] property.", VERSION_FILE,
-                    VERSION_FILE_PROPERTY, e);
+                LOGGER.warn("Failed to retrieve XWiki's version from [{}], using the [{}] property. Root cause is "
+                    + "[{}]", VERSION_FILE, VERSION_FILE_PROPERTY, ExceptionUtils.getRootCauseMessage(e));
             }
 
             if (this.version == null) {
@@ -1731,7 +1731,8 @@ public class XWiki implements EventListener
             }
         } catch (Exception ex) {
             // Probably a SecurityException or the file is not accessible (inside a war)
-            LOGGER.info("Failed to get file modification date: {}", ex.getMessage());
+            LOGGER.info("Failed to get the modification date of resource [{}]. Root cause is [{}]", name,
+                ExceptionUtils.getRootCauseMessage(ex));
         }
         return new Date();
     }
@@ -3972,7 +3973,8 @@ public class XWiki implements EventListener
                     return -4;
                 }
             } catch (RuntimeException ex) {
-                LOGGER.warn("Invalid regular expression for xwiki.validusername", ex);
+                LOGGER.warn("Invalid regular expression for the [xwiki.validusername] property. Falling back on the "
+                    + "default one. Root cause is [{}]", ExceptionUtils.getRootCauseMessage(ex));
                 if (!context.getUtil().match(defaultValidationRegex, xwikiname)) {
                     return -4;
                 }
@@ -4012,7 +4014,8 @@ public class XWiki implements EventListener
                 try {
                     sendValidationEmail(xwikiname, password, email, validkey, "validation_email_content", context);
                 } catch (XWikiException e) {
-                    LOGGER.warn("User created. Failed to send the mail to the created user.", e);
+                    LOGGER.warn("User [{}] created but failed to send the validation mail to them. Root cause is "
+                        + "[{}]", xwikiname, ExceptionUtils.getRootCauseMessage(e));
                     return -11;
                 }
 
@@ -4473,7 +4476,7 @@ public class XWiki implements EventListener
 
             XWikiDocument doc = null;
             try {
-                LOGGER.debug("Including Topic {}", topic);
+                LOGGER.debug("Including topic [{}]", topic);
                 try {
                     @SuppressWarnings("unchecked")
                     Set<String> includedDocs = (Set<String>) context.get(INCLUDED_DOCS);
@@ -4483,7 +4486,7 @@ public class XWiki implements EventListener
                     }
 
                     if (includedDocs.contains(prefixedTopic) || currentDocName.equals(prefixedTopic)) {
-                        LOGGER.warn("Error on too many recursive includes for topic {}", topic);
+                        LOGGER.warn("Too many recursive includes for topic [{}]", topic);
                         return "Cannot make recursive include";
                     }
                     includedDocs.add(prefixedTopic);
@@ -4500,7 +4503,8 @@ public class XWiki implements EventListener
                         XWikiException.ERROR_XWIKI_ACCESS_DENIED, "Access to this document is denied: " + doc);
                 }
             } catch (XWikiException e) {
-                LOGGER.warn("Exception Including Topic {}", topic, e);
+                LOGGER.warn("Failed to include topic [{}]. Root cause is [{}]", topic,
+                    ExceptionUtils.getRootCauseMessage(e));
                 return "Topic " + topic + " does not exist";
             }
 
@@ -5316,7 +5320,7 @@ public class XWiki implements EventListener
                 try {
                     return new URL(homepage);
                 } catch (MalformedURLException e) {
-                    LOGGER.warn("Invalid main wiki home page URL [{}] configured: {}", homepage,
+                    LOGGER.warn("Invalid main wiki home page URL [{}] configured. Root cause is [{}]", homepage,
                         ExceptionUtils.getRootCauseMessage(e));
                 }
             }
@@ -6044,9 +6048,7 @@ public class XWiki implements EventListener
 
                     this.authService = new XWikiAuthServiceImpl();
 
-                    if (LOGGER.isDebugEnabled()) {
-                        LOGGER.debug("Initialized AuthService {} using 'new'.", this.authService.getClass().getName());
-                    }
+                    LOGGER.debug("Initialized AuthService [{}] using 'new'.", this.authService.getClass().getName());
                 }
             }
 
@@ -6067,22 +6069,18 @@ public class XWiki implements EventListener
     private void setAuthService(Class<? extends XWikiAuthService> authClass)
     {
         try {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Using AuthClass {}", authClass.getName());
-            }
+            LOGGER.debug("Using AuthClass [{}]", authClass.getName());
 
             this.authService = authClass.newInstance();
 
             LOGGER.debug("Initialized AuthService using Reflection.");
         } catch (Exception e) {
-            LOGGER.warn("Failed to initialize the AuthService from class [{}], fallbacking on standard authenticator",
-                authClass.getName(), e);
+            LOGGER.warn("Failed to initialize the AuthService from class [{}], falling back on the standard "
+                + "authenticator. Root cause is [{}]", authClass.getName(), ExceptionUtils.getRootCauseMessage(e));
 
             this.authService = new XWikiAuthServiceImpl();
 
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Initialized AuthService {} using 'new'.", this.authService.getClass().getName());
-            }
+            LOGGER.debug("Initialized AuthService [{}] using 'new'.", this.authService.getClass().getName());
         }
     }
 
@@ -6114,10 +6112,9 @@ public class XWiki implements EventListener
                     Exception lastException = e;
 
                     if (!DEFAULT_RIGHT_SERVICE_CLASS.equals(rightsClass)) {
-                        LOGGER.warn(String.format(
-                            "Failed to initialize custom RightService [%s]"
-                                + " by Reflection, using default implementation [%s].",
-                            rightsClass, DEFAULT_RIGHT_SERVICE_CLASS), e);
+                        LOGGER.warn("Failed to initialize custom RightService [{}] by Reflection, using default "
+                            + "implementation [{}]. Root cause is [{}]", rightsClass, DEFAULT_RIGHT_SERVICE_CLASS,
+                            ExceptionUtils.getRootCauseMessage(e));
                         rightsClass = DEFAULT_RIGHT_SERVICE_CLASS;
                         try {
                             this.rightService = (XWikiRightService) Class.forName(rightsClass).newInstance();
@@ -6128,16 +6125,15 @@ public class XWiki implements EventListener
                     }
 
                     if (this.rightService == null) {
-                        LOGGER.warn("Failed to initialize RightService [{}] by Reflection, "
-                            + "using OLD implementation [{}] with 'new'.", rightsClass,
-                            XWikiRightServiceImpl.class.getCanonicalName(), lastException);
+                        LOGGER.warn("Failed to initialize RightService [{}] by Reflection, using OLD implementation "
+                            + "[{}] with 'new'. Root cause is [{}]", rightsClass,
+                            XWikiRightServiceImpl.class.getCanonicalName(),
+                            ExceptionUtils.getRootCauseMessage(lastException));
 
                         this.rightService = new XWikiRightServiceImpl();
 
-                        if (LOGGER.isDebugEnabled()) {
-                            LOGGER.debug("Initialized old RightService implementation {} using 'new'.",
-                                this.rightService.getClass().getName());
-                        }
+                        LOGGER.debug("Initialized old RightService implementation [{}] using 'new'.",
+                            this.rightService.getClass().getName());
                     }
                 }
             }
@@ -6154,7 +6150,8 @@ public class XWiki implements EventListener
                 try {
                     this.statsService = (XWikiStatsService) Class.forName(storeClass).newInstance();
                 } catch (Exception e) {
-                    LOGGER.error(e.getMessage(), e);
+                    LOGGER.error("Failed to initialize the statistics service from class [{}], falling back on the "
+                        + "default implementation", storeClass, e);
 
                     this.statsService = new XWikiStatsServiceImpl();
                 }
@@ -6186,7 +6183,8 @@ public class XWiki implements EventListener
                 factoryService = (XWikiURLFactoryService) Class.forName(urlFactoryServiceClass)
                     .getConstructor(XWiki.class).newInstance(this);
             } catch (Exception e) {
-                LOGGER.warn("Failed to initialize URLFactory Service [{}]", urlFactoryServiceClass, e);
+                LOGGER.warn("Failed to initialize URLFactory Service [{}]. Root cause is [{}]", urlFactoryServiceClass,
+                    ExceptionUtils.getRootCauseMessage(e));
             }
         }
         if (factoryService == null) {
@@ -6524,7 +6522,8 @@ public class XWiki implements EventListener
 
             return sdf.format(date);
         } catch (Exception e) {
-            LOGGER.info("Failed to format date [{}] with pattern [{}]: {}", date, xformat, e.getMessage());
+            LOGGER.info("Failed to format date [{}] with pattern [{}]. Root cause is [{}]", date, xformat,
+                ExceptionUtils.getRootCauseMessage(e));
             if (format == null) {
                 if (xformat.equals(defaultFormat)) {
                     return date.toString();
@@ -7854,8 +7853,8 @@ public class XWiki implements EventListener
                 setAuthService(authClass);
             }
         } catch (ClassNotFoundException e) {
-            LOGGER.warn("Failed to get the class of the configured authenticator ({}), keeping current authenticator.",
-                ExceptionUtils.getRootCauseMessage(e));
+            LOGGER.warn("Failed to get the class of the configured authenticator, keeping the current authenticator. "
+                + "Root cause is [{}]", ExceptionUtils.getRootCauseMessage(e));
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
@@ -666,7 +666,7 @@ public class XWiki extends Api
             LOGGER.info("Access denied for loading revision [{}] of document [{}]: [{}]", revision, reference,
                 ExceptionUtils.getRootCauseMessage(e));
         } catch (Exception e) {
-            LOGGER.error("Failed to access revision [{}] of document {}", revision, reference, e);
+            LOGGER.error("Failed to access revision [{}] of document [{}]", revision, reference, e);
         }
 
         return null;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiAttachment.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiAttachment.java
@@ -915,7 +915,7 @@ public class XWikiAttachment implements Cloneable
                 try {
                     inputStream.close();
                 } catch (IOException e) {
-                    LOGGER.warn("Failed to close attachment content input stream: {}",
+                    LOGGER.warn("Failed to close attachment content input stream: [{}]",
                         ExceptionUtils.getRootCauseMessage(e));
                 }
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -4890,7 +4890,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
             try {
                 attachment.loadAttachmentContent(context);
             } catch (XWikiException e) {
-                LOGGER.warn("Failed to load attachment [{}]: {}", attachment.getReference(),
+                LOGGER.warn("Failed to load attachment [{}]: [{}]", attachment.getReference(),
                     ExceptionUtils.getRootCauseMessage(e));
             }
         }
@@ -5931,7 +5931,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
                         XDOM dom = parseContent(getSyntax(), largeField.getValue(), getDocumentReference());
                         getUniqueLinkedEntityReferences(dom, entityTypes, references);
                     } catch (XWikiException e) {
-                        LOGGER.warn("Failed to extract links from xobject property [{}], skipping it. Error: {}",
+                        LOGGER.warn("Failed to extract links from xobject property [{}], skipping it. Error: [{}]",
                             largeField.getReference(), ExceptionUtils.getRootCauseMessage(e));
                     }
                 }
@@ -6953,7 +6953,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
                     return tdoc;
                 }
             } catch (Exception e) {
-                LOGGER.error("Error when loading document {} for locale {}", getDocumentReference(), locale, e);
+                LOGGER.error("Error when loading document [{}] for locale [{}]", getDocumentReference(), locale, e);
             }
 
             tdoc = getTranslatedDocument(LocaleUtils.getParentLocale(locale), context);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/DefaultMandatoryDocumentInitializerManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/DefaultMandatoryDocumentInitializerManager.java
@@ -76,8 +76,8 @@ public class DefaultMandatoryDocumentInitializerManager implements MandatoryDocu
                 }
             }
         } catch (ComponentLookupException e) {
-            this.logger.error("Failed to initialize component [{}] for document", MandatoryDocumentInitializer.class,
-                documentReference, e);
+            this.logger.error("Failed to initialize component [{}] for document [{}]",
+                MandatoryDocumentInitializer.class, documentReference, e);
         }
 
         return null;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/input/XWikiAttachmentEventGenerator.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/input/XWikiAttachmentEventGenerator.java
@@ -276,7 +276,7 @@ public class XWikiAttachmentEventGenerator
                 try {
                     content.close();
                 } catch (IOException e) {
-                    this.logger.warn("Failed to close the content stream of the attachment [{}]: {}",
+                    this.logger.warn("Failed to close the content stream of the attachment [{}]: [{}]",
                         attachment.getReference(), ExceptionUtils.getRootCauseMessage(e));
                 }
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/PropertyClassOutputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/PropertyClassOutputFilterStream.java
@@ -144,7 +144,7 @@ public class PropertyClassOutputFilterStream extends AbstractEntityOutputFilterS
 
             // Make sure the property is known
             if (propertyClass == null) {
-                this.logger.warn("{} - Unknown property meta class field [{}] for property type [{}] in class [{}]",
+                this.logger.warn("[{}] - Unknown property meta class field [{}] for property type [{}] in class [{}]",
                     this.currentEntityReference, name, this.entity.getClassType(), classReference);
 
                 return;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/skin/AbstractResourceSkin.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/skin/AbstractResourceSkin.java
@@ -114,7 +114,7 @@ public abstract class AbstractResourceSkin extends AbstractSkin
                 try {
                     this.properties = new Configurations().properties(url);
                 } catch (ConfigurationException e) {
-                    LOGGER.error("Failed to load skin [{}] properties file ({})", this.id, url, e);
+                    LOGGER.error("Failed to load skin [{}] properties file [{}]", this.id, url, e);
 
                     this.properties = new BaseConfiguration();
                 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/HibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/HibernateStore.java
@@ -725,7 +725,7 @@ public class HibernateStore implements Disposable, Initializable
         // XWiki uses a new Session for a new Transaction so we need to keep both in sync and thus we check if that's
         // the case. If it isn't it means some code is faulty somewhere.
         if (((session == null) && (transaction != null)) || ((transaction == null) && (session != null))) {
-            this.logger.warn("Incompatible session ({}) and transaction ({}) status", session, transaction);
+            this.logger.warn("Incompatible session [{}] and transaction [{}] status", session, transaction);
 
             // TODO: Fix this problem, don't ignore it!
             return false;
@@ -1040,7 +1040,7 @@ public class HibernateStore implements Disposable, Initializable
                 }
             } catch (Exception e) {
                 this.logger.warn(
-                    "Failed to get the sequences of the schema [{}] ({}). Trying to create hibernate_sequence anyway.",
+                    "Failed to get the sequences of the schema [{}]: [{}]. Trying to create hibernate_sequence anyway.",
                     schemaName, ExceptionUtils.getRootCauseMessage(e));
 
                 // Ignore errors in the log during the creation of the sequence since we know it can fail and we

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/template/InternalTemplateManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/template/InternalTemplateManager.java
@@ -1062,7 +1062,7 @@ public class InternalTemplateManager implements Initializable, Disposable
                         template = null;
                     }
                 } catch (Exception e) {
-                    this.logger.warn("Failed to get the instant for resource with idenfier [{}]: {}", id,
+                    this.logger.warn("Failed to get the instant for resource with identifier [{}]: [{}]", id,
                         ExceptionUtils.getRootCauseMessage(e));
                 }
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/monitor/api/MonitorData.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/monitor/api/MonitorData.java
@@ -32,8 +32,6 @@ import org.slf4j.LoggerFactory;
 
 public class MonitorData
 {
-    private static final String MONITOR_PREFIX = "MONITOR ";
-
     private static final Logger LOGGER = LoggerFactory.getLogger(MonitorData.class);
 
     private URL url;
@@ -146,9 +144,7 @@ public class MonitorData
         MonitorTimer timer;
         timer = this.timers.get(timername);
         if (timer != null) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("MONITOR: error recursive timers for " + timername);
-            }
+            LOGGER.debug("MONITOR: error recursive timers for [{}]", timername);
         } else {
             timer = new MonitorTimer(timername, details);
             timer.setStartDate();
@@ -166,9 +162,7 @@ public class MonitorData
         MonitorTimer timer;
         timer = this.timers.get(timername);
         if (timer == null) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("MONITOR: could not find timer for " + timername);
-            }
+            LOGGER.debug("MONITOR: could not find timer for [{}]", timername);
         } else {
             timer.setDetails(details);
         }
@@ -183,9 +177,7 @@ public class MonitorData
         MonitorTimer timer;
         timer = this.timers.get(timername);
         if (timer == null) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("MONITOR: could not find timer for " + timername);
-            }
+            LOGGER.debug("MONITOR: could not find timer for [{}]", timername);
         } else {
             timer.setEndDate();
             if (timer.getDetails() != null) {
@@ -198,10 +190,8 @@ public class MonitorData
                 this.timerSummaries.put(timername, tsummary);
             }
             tsummary.addTimer(timer.getDuration());
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(MONITOR_PREFIX + this.wikiPage + " " + this.action + " " + timer.getName() + ": "
-                    + timer.getDuration() + "ms " + timer.getDetails());
-            }
+            LOGGER.debug("MONITOR page [{}], action [{}], timer [{}]: [{}]ms, details [{}]", this.wikiPage,
+                this.action, timer.getName(), timer.getDuration(), timer.getDetails());
         }
     }
 
@@ -217,14 +207,12 @@ public class MonitorData
 
     public void log()
     {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(MONITOR_PREFIX + this.wikiPage + ": " + getDuration() + "ms");
-            Iterator<MonitorTimerSummary> it = this.timerSummaries.values().iterator();
-            while (it.hasNext()) {
-                MonitorTimerSummary tsummary = it.next();
-                LOGGER.debug(MONITOR_PREFIX + this.wikiPage + " " + this.action + " " + tsummary.getName() + ": "
-                    + tsummary.getDuration() + "ms " + tsummary.getNbCalls());
-            }
+        LOGGER.debug("MONITOR page [{}]: [{}]ms", this.wikiPage, getDuration());
+        Iterator<MonitorTimerSummary> it = this.timerSummaries.values().iterator();
+        while (it.hasNext()) {
+            MonitorTimerSummary tsummary = it.next();
+            LOGGER.debug("MONITOR page [{}], action [{}], timer [{}]: [{}]ms in [{}] calls", this.wikiPage,
+                this.action, tsummary.getName(), tsummary.getDuration(), tsummary.getNbCalls());
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/monitor/api/MonitorPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/monitor/api/MonitorPlugin.java
@@ -32,8 +32,6 @@ import com.xpn.xwiki.plugin.XWikiDefaultPlugin;
 
 public class MonitorPlugin extends XWikiDefaultPlugin
 {
-    private static final String FAILED_WITH_EXCEPTION_MESSAGE = " failed with exception ";
-
     private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(MonitorPlugin.class);
 
     private boolean bActive;
@@ -93,19 +91,14 @@ public class MonitorPlugin extends XWikiDefaultPlugin
             if (mdata != null) {
                 removeFromActiveTimerDataList(cthread);
                 addToLastUnfinishedTimerDataList(mdata);
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("MONITOR: Thread " + cthread.getName() + " for page " + mdata.getWikiPage()
-                        + " did not call endRequest");
-                }
+                LOGGER.debug("MONITOR: Thread [{}] for page [{}] did not call endRequest", cthread.getName(),
+                    mdata.getWikiPage());
                 mdata.endRequest(false);
             }
             mdata = new MonitorData(page, action, url, cthread.getName());
             this.activeTimerDataList.put(cthread, mdata);
         } catch (Throwable e) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("MONITOR: endRequest failed with exception " + e);
-                e.printStackTrace();
-            }
+            LOGGER.debug("MONITOR: startRequest failed", e);
         }
     }
 
@@ -124,9 +117,7 @@ public class MonitorPlugin extends XWikiDefaultPlugin
             Thread cthread = Thread.currentThread();
             MonitorData mdata = this.activeTimerDataList.get(cthread);
             if (mdata == null) {
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("MONITOR: Thread " + cthread.getName() + " did not call startRequest");
-                }
+                LOGGER.debug("MONITOR: Thread [{}] did not call startRequest", cthread.getName());
                 return;
             }
             mdata.endRequest(true);
@@ -135,10 +126,7 @@ public class MonitorPlugin extends XWikiDefaultPlugin
             removeFromActiveTimerDataList(cthread);
             addToTimerDataList(mdata);
         } catch (Throwable e) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("MONITOR: endRequest failed with exception " + e);
-                e.printStackTrace();
-            }
+            LOGGER.debug("MONITOR: endRequest failed", e);
         }
     }
 
@@ -220,10 +208,7 @@ public class MonitorPlugin extends XWikiDefaultPlugin
                 mdata.startTimer(timername, desc);
             }
         } catch (Throwable e) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("MONITOR: startRequest for timer " + timername + FAILED_WITH_EXCEPTION_MESSAGE + e);
-                e.printStackTrace();
-            }
+            LOGGER.debug("MONITOR: startTimer for timer [{}] failed", timername, e);
         }
     }
 
@@ -240,10 +225,7 @@ public class MonitorPlugin extends XWikiDefaultPlugin
                 mdata.setTimerDetails(timername, desc);
             }
         } catch (Throwable e) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("MONITOR: setTimerDesc for timer " + timername + FAILED_WITH_EXCEPTION_MESSAGE + e);
-                e.printStackTrace();
-            }
+            LOGGER.debug("MONITOR: setTimerDesc for timer [{}] failed", timername, e);
         }
     }
 
@@ -260,10 +242,7 @@ public class MonitorPlugin extends XWikiDefaultPlugin
                 mdata.endTimer(timername);
             }
         } catch (Throwable e) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("MONITOR: endRequest for timer " + timername + FAILED_WITH_EXCEPTION_MESSAGE + e);
-                e.printStackTrace();
-            }
+            LOGGER.debug("MONITOR: endTimer for timer [{}] failed", timername, e);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/PdfExportImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/PdfExportImpl.java
@@ -193,7 +193,7 @@ public class PdfExportImpl implements PdfExport
      */
     private String convertToStrictXHtml(String input)
     {
-        LOGGER.debug("Cleaning HTML:\n{}", input);
+        LOGGER.debug("Cleaning HTML:\n[{}]", input);
 
         HTMLCleaner cleaner = Utils.getComponent(HTMLCleaner.class);
         HTMLCleanerConfiguration config = cleaner.getDefaultConfiguration();
@@ -201,7 +201,7 @@ public class PdfExportImpl implements PdfExport
         filters.add(Utils.getComponent(HTMLFilter.class, "uniqueId"));
         config.setFilters(filters);
         String result = HTMLUtils.toString(cleaner.clean(new StringReader(input), config));
-        LOGGER.debug("Cleaned XHTML:\n{}", result);
+        LOGGER.debug("Cleaned XHTML:\n[{}]", result);
         return result;
     }
 
@@ -221,13 +221,13 @@ public class PdfExportImpl implements PdfExport
     protected void exportXHTML(String xhtml, OutputStream out, ExportType type, XWikiContext context)
         throws XWikiException
     {
-        LOGGER.debug("Final XHTML for export:\n{}", xhtml);
+        LOGGER.debug("Final XHTML for export:\n[{}]", xhtml);
 
         // XSL Transformation to XML-FO
         String xmlfo = convertXHtmlToXMLFO(xhtml, context);
 
         // Debug output
-        LOGGER.debug("Final XSL-FO source:\n{}", xmlfo);
+        LOGGER.debug("Final XSL-FO source:\n[{}]", xmlfo);
 
         renderXSLFO(xmlfo, out, type, context);
     }
@@ -256,7 +256,7 @@ public class PdfExportImpl implements PdfExport
             LOGGER.error("Failed to close the XSLT stream", e);
         }
 
-        LOGGER.debug("Intermediary XSL-FO:\n{}", xmlfo);
+        LOGGER.debug("Intermediary XSL-FO:\n[{}]", xmlfo);
 
         return applyXSLT(xmlfo, getFopCleanupXslt(context));
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
@@ -377,7 +377,7 @@ public class Package
             }
             return true;
         } catch (ExcludeDocumentException e) {
-            LOGGER.info("Skip the document " + doc.getDocumentReference());
+            LOGGER.info("Skip the document [{}]", doc.getDocumentReference());
 
             return false;
         }
@@ -536,9 +536,9 @@ public class Package
                     try {
                         doc = readFromXML(new CloseShieldInputStream(zis));
                     } catch (Throwable e) {
-                        LOGGER.warn(
-                            "Failed to parse document [{}] from XML during import, thus it will not be installed. "
-                                + "The error was: " + ExceptionUtils.getRootCauseMessage(e));
+                        LOGGER.warn("Failed to parse document [{}] from XML during import, thus it will not be "
+                            + "installed. Root cause is [{}]", entry.getName(),
+                            ExceptionUtils.getRootCauseMessage(e));
                         // It will be listed in the "failed documents" section after the import.
                         addToErrors(entry.getName().replace("/", "."), context);
 
@@ -551,7 +551,7 @@ public class Package
                         this.filter(doc, context);
                         docsToLoad.add(doc);
                     } catch (ExcludeDocumentException e) {
-                        LOGGER.info("Skip the document '" + doc.getDocumentReference() + "'");
+                        LOGGER.info("Skip the document [{}]", doc.getDocumentReference());
                     }
                 }
             }
@@ -567,8 +567,8 @@ public class Package
                 if (documentExistInPackageFile(doc.getFullName(), doc.getLanguage(), description)) {
                     this.add(doc, context);
                 } else {
-                    LOGGER.warn("document " + doc.getDocumentReference() + " does not exist in package definition."
-                        + " It will not be installed.");
+                    LOGGER.warn("Document [{}] does not exist in the package definition. It will not be installed.",
+                        doc.getDocumentReference());
                     // It will be listed in the "skipped documents" section after the
                     // import.
                     addToSkipped(doc.getFullName(), context);
@@ -662,9 +662,7 @@ public class Package
 
             return result;
         } finally {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Package test install result " + result);
-            }
+            LOGGER.debug("Package test install result [{}]", result);
         }
     }
 
@@ -818,9 +816,7 @@ public class Package
 
         int result = DocumentInfo.INSTALL_OK;
 
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Package installing document " + doc.getFullName() + " " + doc.getLanguage());
-        }
+        LOGGER.debug("Package installing document [{}] for language [{}]", doc.getFullName(), doc.getLanguage());
 
         if (doc.getAction() == DocumentInfo.ACTION_SKIP) {
             addToSkipped(doc.getFullName() + ":" + doc.getLanguage(), context);
@@ -852,12 +848,7 @@ public class Package
                         // let's log the error but not stop
                         result = DocumentInfo.INSTALL_ERROR;
                         addToErrors(doc.getFullName() + ":" + doc.getLanguage(), context);
-                        if (LOGGER.isErrorEnabled()) {
-                            LOGGER.error("Failed to delete document " + previousdoc.getDocumentReference());
-                        }
-                        if (LOGGER.isDebugEnabled()) {
-                            LOGGER.debug("Failed to delete document " + previousdoc.getDocumentReference(), e);
-                        }
+                        LOGGER.error("Failed to delete document [{}]", previousdoc.getDocumentReference(), e);
                     }
                 } else if (previousdoc.hasElement(XWikiDocument.HAS_ATTACHMENTS)) {
                     // We conserve the old attachments in the new documents
@@ -939,9 +930,7 @@ public class Package
 
             } catch (XWikiException e) {
                 addToErrors(doc.getFullName() + ":" + doc.getLanguage(), context);
-                if (LOGGER.isErrorEnabled()) {
-                    LOGGER.error("Failed to save document " + doc.getFullName(), e);
-                }
+                LOGGER.error("Failed to save document [{}]", doc.getFullName(), e);
                 result = DocumentInfo.INSTALL_ERROR;
             }
         }
@@ -1281,7 +1270,7 @@ public class Package
             fos.flush();
             fos.close();
         } catch (ExcludeDocumentException e) {
-            LOGGER.info("Skip the document " + doc.getDocumentReference());
+            LOGGER.info("Skip the document [{}]", doc.getDocumentReference());
         } catch (Exception e) {
             Object[] args = new Object[1];
             args[0] = doc.getDocumentReference();
@@ -1415,10 +1404,10 @@ public class Package
                                 "document " + doc.getDocumentReference() + " does not exist in package definition");
                         }
                     } catch (ExcludeDocumentException e) {
-                        LOGGER.info("Skip the document '" + doc.getDocumentReference() + "'");
+                        LOGGER.info("Skip the document [{}]", doc.getDocumentReference());
                     }
                 } else if (!file.getName().equals(DefaultPackageFileName)) {
-                    LOGGER.info(file.getAbsolutePath() + " is not a valid wiki document");
+                    LOGGER.info("File [{}] is not a valid wiki document", file.getAbsolutePath());
                 }
             }
         }
@@ -1454,7 +1443,7 @@ public class Package
             throw new PackageException(PackageException.ERROR_PACKAGE_UNKNOWN, "Error when reading the XML");
         }
 
-        LOGGER.info("Package read " + count + " documents");
+        LOGGER.info("Package read [{}] documents", count);
 
         return "";
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateBaseStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateBaseStore.java
@@ -638,7 +638,7 @@ public class XWikiHibernateBaseStore extends AbstractXWikiStore
             Session session = this.store.getCurrentSession();
             if (session != null) {
                 if (LOGGER.isWarnEnabled()) {
-                    LOGGER.warn("Cleanup of session was needed: {}", session.toString());
+                    LOGGER.warn("Cleanup of session was needed: [{}]", session);
                 }
 
                 this.store.endTransaction(false);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
@@ -768,10 +768,9 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
                                 if (this.logger.isDebugEnabled()) {
                                     this.logger.debug("saveXWikiDoc:");
                                     this.logger.debug("    - document: [{}]", doc.getDocumentReferenceWithLocale());
-                                    this.logger.debug(
-                                        "    - optimizedObjects: {} (doc.isNew: {} doc.isChangeTracked: {}, isClassOptimized: {})",
-                                        optimizedObjects, doc.isNew(), doc.isChangeTracked(),
-                                        isClassOptimized(entry.getKey()));
+                                    this.logger.debug("    - optimizedObjects: [{}] (doc.isNew: [{}], "
+                                        + "doc.isChangeTracked: [{}], isClassOptimized: [{}])", optimizedObjects,
+                                        doc.isNew(), doc.isChangeTracked(), isClassOptimized(entry.getKey()));
                                     this.logger.debug("    - saved xobjects: [{}]", count);
                                 }
                             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/query/HqlQueryExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/query/HqlQueryExecutor.java
@@ -135,7 +135,7 @@ public class HqlQueryExecutor extends AbstractQueryExecutor implements Initializ
                                 safeQueries.add(definition.getName());
                             }
                         } catch (QueryException e) {
-                            this.logger.warn("Failed to validate named query [{}] with statement [{}]: {}",
+                            this.logger.warn("Failed to validate named query [{}] with statement [{}]: [{}]",
                                 definition.getName(), definition.getQuery(), ExceptionUtils.getRootCauseMessage(e));
                         }
                     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/AbstractDataMigrationManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/AbstractDataMigrationManager.java
@@ -825,7 +825,7 @@ public abstract class AbstractDataMigrationManager implements DataMigrationManag
             this.logger.info("The following data migration(s) will be applied for wiki [{}] currently in version [{}]:",
                 database, curversion);
             for (XWikiMigration migration : neededMigrations) {
-                this.logger.info("  {} - {}{}", migration.dataMigration.getName(),
+                this.logger.info("  [{}] - [{}]{}", migration.dataMigration.getName(),
                     migration.dataMigration.getDescription(), (migration.isForced ? " (forced)" : ""));
             }
         } else {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/AbstractResizeMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/AbstractResizeMigration.java
@@ -108,7 +108,7 @@ public abstract class AbstractResizeMigration extends AbstractHibernateDataMigra
     private void warnDatabaseTooOld(String databaseName, Version databaseVersion)
     {
         this.logger.warn(
-            "The migration cannot run on {} versions lower than {}. The short String limitation will remain 255.",
+            "The migration cannot run on [{}] versions lower than [{}]. The short String limitation will remain 255.",
             databaseName, databaseVersion);
     }
 
@@ -141,7 +141,7 @@ public abstract class AbstractResizeMigration extends AbstractHibernateDataMigra
                     }
                 }
             } catch (SQLException e) {
-                this.logger.warn("Failed to get database information: {}", ExceptionUtils.getRootCauseMessage(e));
+                this.logger.warn("Failed to get database information: [{}]", ExceptionUtils.getRootCauseMessage(e));
             }
         } else if (this.hibernateStore.getDatabaseProductName() == DatabaseProduct.MSSQL) {
             // Impossible to apply this migration on Microsoft SQL Server
@@ -279,7 +279,7 @@ public abstract class AbstractResizeMigration extends AbstractHibernateDataMigra
             String script = String.format("<changeSet author=\"xwiki\" id=\"R%s\">%s</changeSet>",
                 getVersion().getVersion(), builder.toString());
 
-            this.logger.debug("Liquibase script: {}", script);
+            this.logger.debug("Liquibase script: [{}]", script);
 
             return script;
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R140600000XWIKI19869DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R140600000XWIKI19869DataMigration.java
@@ -252,7 +252,7 @@ public class R140600000XWIKI19869DataMigration extends AbstractHibernateDataMigr
                 }
             } catch (Exception e) {
                 this.logger.warn(
-                    "Failed to handler revision [{}] for user page [{}]: {}. It's recommended to delete this version.",
+                    "Failed to handle revision [{}] for user page [{}]: [{}]. It's recommended to delete this version.",
                     node.getVersion().toString(), userDoc.getDocumentReference(),
                     ExceptionUtils.getRootCauseMessage(e));
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R40000XWIKI6990DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R40000XWIKI6990DataMigration.java
@@ -852,11 +852,11 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
                     this.logger.debug(TIME_ELAPSED_COLLECTION_MESSAGE, coll[0], times[timer++] / 1000000);
                 }
                 for (String customMappedClass : customClassToProcess) {
-                    this.logger.debug("Time elapsed for {} custom table: {} ms", customMappedClass,
+                    this.logger.debug("Time elapsed for [{}] custom table: [{}] ms", customMappedClass,
                         times[timer++] / 1000000);
                 }
                 for (String propertyClass : classToProcess) {
-                    this.logger.debug("Time elapsed for {} property table: {} ms", propertyClass,
+                    this.logger.debug("Time elapsed for [{}] property table: [{}] ms", propertyClass,
                         times[timer++] / 1000000);
                 }
                 this.logger.debug(TIME_ELAPSED_CLASS_MESSAGE, BaseObject.class.getName(),
@@ -1386,7 +1386,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
 
         logProgress("%d schema updates required.", this.logCount);
         if (this.logger.isDebugEnabled()) {
-            this.logger.debug("About to execute this Liquibase XML: {}", sb.toString());
+            this.logger.debug("About to execute this Liquibase XML: [{}]", sb);
         }
         return sb.toString();
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyPersistentLoginManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyPersistentLoginManager.java
@@ -186,9 +186,8 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
             protectedUsername = encryptText(protectedUsername);
             protectedPassword = encryptText(protectedPassword);
             if (protectedUsername == null || protectedPassword == null) {
-                LOGGER.error("ERROR!!");
-                LOGGER.error("There was a problem encrypting the username or password!!");
-                LOGGER.error("Remember Me function will be disabled!!");
+                LOGGER.error("Failed to encrypt the username or password for protection [{}]. The Remember Me "
+                    + "function is disabled.", this.protection);
                 return;
             }
         }
@@ -219,12 +218,8 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
                 Cookie validationCookie = new Cookie(getCookiePrefix() + COOKIE_VALIDATION, validationHash);
                 setupCookie(validationCookie, sessionCookie, secureCookie, cookieDomain, response);
             } else {
-                if (LOGGER.isErrorEnabled()) {
-                    LOGGER.error("WARNING!!! WARNING!!!");
-                    LOGGER.error("PROTECTION=ALL or PROTECTION=VALIDATION was specified");
-                    LOGGER.error("but Validation Hash could NOT be generated");
-                    LOGGER.error("Validation has been disabled!!!!");
-                }
+                LOGGER.error("Protection [{}] was specified but the validation hash could not be generated. "
+                    + "Validation is disabled.", this.protection);
             }
         }
     }
@@ -240,9 +235,7 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
         try {
             cookie.setMaxAge(Math.round(60 * 60 * 24 * Float.parseFloat(this.cookieLife)));
         } catch (Exception e) {
-            if (LOGGER.isErrorEnabled()) {
-                LOGGER.error("Failed setting cookie Max age with duration " + this.cookieLife);
-            }
+            LOGGER.error("Failed to set the cookie max age with duration [{}]", this.cookieLife, e);
         }
     }
 
@@ -254,10 +247,8 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
      */
     private void addCookie(HttpServletResponse response, Cookie cookie)
     {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Adding cookie: " + cookie.getDomain() + cookie.getPath() + " " + cookie.getName() + "="
-                + cookie.getValue());
-        }
+        LOGGER.debug("Adding cookie [{}] with value [{}] for domain [{}] and path [{}]", cookie.getName(),
+            cookie.getValue(), cookie.getDomain(), cookie.getPath());
         response.addCookie(cookie);
     }
 
@@ -281,9 +272,7 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
                 }
             }
         }
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Cookie domain is:" + cookieDomain);
-        }
+        LOGGER.debug("Cookie domain is [{}]", cookieDomain);
         return cookieDomain;
     }
 
@@ -300,10 +289,8 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
     private String getValidationHash(String username, String password, String clientIP)
     {
         if (this.validationKey == null) {
-            if (LOGGER.isErrorEnabled()) {
-                LOGGER.error("ERROR! >> validationKey not specified...");
-                LOGGER.error("you are REQUIRED to specify the validatonkey in xwiki.cfg");
-            }
+            LOGGER.error("No validation key specified. The [xwiki.authentication.validationKey] property is "
+                + "required in xwiki.cfg.");
             return null;
         }
         MessageDigest md5 = null;
@@ -336,7 +323,7 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
             }
             this.valueAfterMD5 = sb.toString();
         } catch (Exception e) {
-            LOGGER.error("Failed to get [" + MessageDigest.class.getName() + "] instance", e);
+            LOGGER.error("Failed to get a [{}] instance", MessageDigest.class.getName(), e);
         }
 
         return this.valueAfterMD5;
@@ -366,14 +353,11 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
                 // See XWIKI-2211
                 return encryptedEncodedText.replace("=", "_");
             }
-            if (LOGGER.isErrorEnabled()) {
-                LOGGER.error("ERROR! >> SecretKey not generated...");
-                LOGGER.error("you are REQUIRED to specify the encryptionKey in xwiki.cfg");
-            }
+            LOGGER.error("No secret key generated. The [xwiki.authentication.encryptionKey] property is required "
+                + "in xwiki.cfg.");
         } catch (Exception e) {
-            if (LOGGER.isErrorEnabled()) {
-                LOGGER.error("Failed to encrypt text: " + clearText, e);
-            }
+            // The text being encrypted is a username or a password, so it must never reach the logs.
+            LOGGER.error("Failed to encrypt the authentication cookie value", e);
         }
         return null;
     }
@@ -570,7 +554,8 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
             byte[] decryptedText = c1.doFinal(decodedEncryptedText);
             return new String(decryptedText);
         } catch (Exception e) {
-            LOGGER.error("Error decypting text: " + encryptedText, e);
+            // The decrypted text is a username or a password, so the encrypted form must not reach the logs either.
+            LOGGER.error("Failed to decrypt the authentication cookie value", e);
             return null;
         }
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiAuthServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiAuthServiceImpl.java
@@ -231,8 +231,8 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
 
             return null;
         } finally {
-            LOGGER.debug("XWikiAuthServiceImpl.checkAuth(XWikiContext) took " + (System.currentTimeMillis() - time)
-                + " milliseconds to run.");
+            LOGGER.debug("XWikiAuthServiceImpl.checkAuth(XWikiContext) took [{}] milliseconds to run.",
+                System.currentTimeMillis() - time);
         }
     }
 
@@ -451,14 +451,12 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
                 result = new PasswordClass().getEquivalentPassword(stored, password).equals(stored);
             }
 
-            if (LOGGER.isDebugEnabled()) {
-                if (result) {
-                    LOGGER.debug("Password check for user " + username + " successful");
-                } else {
-                    LOGGER.debug("Password check for user " + username + " failed");
-                }
-                LOGGER.debug((System.currentTimeMillis() - time) + " milliseconds spent validating password.");
+            if (result) {
+                LOGGER.debug("Password check for user [{}] successful", username);
+            } else {
+                LOGGER.debug("Password check for user [{}] failed", username);
             }
+            LOGGER.debug("Spent [{}] milliseconds validating the password.", System.currentTimeMillis() - time);
 
             return result;
         } catch (Throwable e) {
@@ -494,30 +492,22 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
     {
         String createuser = getParam("auth_createuser", context);
 
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Create user param is " + createuser);
-        }
+        LOGGER.debug("Create user param is [{}]", createuser);
 
         if (createuser != null) {
             String wikiname = context.getWiki().clearName(user, true, true, context);
             XWikiDocument userdoc =
                 context.getWiki().getDocument(new DocumentReference(context.getWikiId(), XWiki.SYSTEM_SPACE, wikiname), context);
             if (userdoc.isNew()) {
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("User page does not exist for user " + user);
-                }
+                LOGGER.debug("User page does not exist for user [{}]", user);
 
                 if ("empty".equals(createuser)) {
-                    if (LOGGER.isDebugEnabled()) {
-                        LOGGER.debug("Creating emptry user for user " + user);
-                    }
+                    LOGGER.debug("Creating empty user for user [{}]", user);
 
                     context.getWiki().createEmptyUser(wikiname, "edit", context);
                 }
             } else {
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("User page already exists for user " + user);
-                }
+                LOGGER.debug("User page already exists for user [{}]", user);
             }
 
             return wikiname;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiRightServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiRightServiceImpl.java
@@ -461,7 +461,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
                 }
             } catch (XWikiRightNotFoundException e) {
             } catch (Exception e) {
-                LOGGER.error("Failed to check right [{}] for group [{}] on document [¶}]", accessLevel, group,
+                LOGGER.error("Failed to check right [{}] for group [{}] on document [{}]", accessLevel, group,
                     doc.getPrefixedFullName(), e);
             }
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/RegisterAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/RegisterAction.java
@@ -157,7 +157,7 @@ public class RegisterAction extends XWikiAction
                     return false;
                 }
             } catch (Exception e) {
-                LOGGER.warn("Cannot verify answer for CAPTCHA of type [{}]: {}", defaultCaptchaName,
+                LOGGER.warn("Cannot verify answer for CAPTCHA of type [{}]: [{}]", defaultCaptchaName,
                     ExceptionUtils.getRootCauseMessage(e));
                 return false;
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SkinAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SkinAction.java
@@ -455,7 +455,7 @@ public class SkinAction extends XWikiAction
                 .call(() -> context.getWiki().evaluateVelocity(content, namespace), author, sourceDocument);
         } catch (Exception e) {
             // Should not happen since there is nothing in the call() method throwing an exception.
-            LOGGER.error("Failed to evaluate velocity content for namespace {} with the rights of the user {}",
+            LOGGER.error("Failed to evaluate velocity content for namespace [{}] with the rights of the user [{}]",
                 namespace, author, e);
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
@@ -153,7 +153,7 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
                     defaultWikiURL =
                         new URL(protocolConfiguration, this.originalURL.getHost(), this.originalURL.getPort(), "");
                 } catch (MalformedURLException e) {
-                    LOGGER.warn("The configured protocol [{}] produce an invalid URL: {}", protocolConfiguration,
+                    LOGGER.warn("The configured protocol [{}] produces an invalid URL: [{}]", protocolConfiguration,
                         ExceptionUtils.getRootCauseMessage(e));
                 }
             }
@@ -172,7 +172,7 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
             try {
                 url = xcontext.getWiki().getServerURL(xcontext.getWikiId(), xcontext);
             } catch (MalformedURLException e) {
-                LOGGER.warn("Can't get the standard URL for wiki [{}]: {}", xcontext.getWikiId(),
+                LOGGER.warn("Can't get the standard URL for wiki [{}]: [{}]", xcontext.getWikiId(),
                     ExceptionUtils.getRootCauseMessage(e));
             }
         }
@@ -234,7 +234,7 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
             try {
                 return normalizeURL(surl, context);
             } catch (MalformedURLException e) {
-                LOGGER.warn("Could not create URL from xwiki.cfg xwiki.home parameter: {}. Ignoring parameter.", surl);
+                LOGGER.warn("Could not create URL from xwiki.cfg xwiki.home parameter [{}]. Ignoring parameter.", surl);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/internal/filter/Importer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/internal/filter/Importer.java
@@ -168,7 +168,7 @@ public class Importer
             // Generate import report
             generateReport(importLogger, context);
         } catch (Exception e) {
-            this.logger.warn("Failed to close the log queue: {}", ExceptionUtils.getRootCauseMessage(e));
+            this.logger.warn("Failed to close the log queue: [{}]", ExceptionUtils.getRootCauseMessage(e));
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/internal/velocity/XWikiVelocityManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/internal/velocity/XWikiVelocityManager.java
@@ -229,7 +229,7 @@ public class XWikiVelocityManager extends DefaultVelocityManager implements Init
             try {
                 injectBaseMacros(velocityEngine, skinMacrosTemplate);
             } catch (Exception e) {
-                this.logger.warn("Failed to load global macros for engine with key [{}]: {}", cacheKey,
+                this.logger.warn("Failed to load global macros for engine with key [{}]: [{}]", cacheKey,
                     ExceptionUtils.getRootCauseMessage(e));
             }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/MySQLHibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/MySQLHibernateAdapter.java
@@ -102,7 +102,7 @@ public class MySQLHibernateAdapter extends AbstractHibernateAdapter
     {
         String rowFormat = rowFormats.get(tableName);
 
-        this.logger.debug("Row format for table [{}]: {}", tableName, rowFormat);
+        this.logger.debug("Row format for table [{}]: [{}]", tableName, rowFormat);
 
         String expectedRowFormat = compressed ? getCompressedRowFormat() : getDefaultRowFormat();
 

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/XWikiRepositoryModel.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/XWikiRepositoryModel.java
@@ -542,7 +542,7 @@ public final class XWikiRepositoryModel
             try {
                 reposiories.add(toRepositoryDescriptor(stringRepository, factory));
             } catch (URISyntaxException e) {
-                LOGGER.warn("Failed to parse repository descriptor [{}]", stringRepository,
+                LOGGER.warn("Failed to parse repository descriptor [{}]. Root cause is [{}]", stringRepository,
                     ExceptionUtils.getRootCauseMessage(e));
             }
         }

--- a/xwiki-platform-core/xwiki-platform-sheet/xwiki-platform-sheet-api/src/main/java/org/xwiki/sheet/internal/DefaultSheetManager.java
+++ b/xwiki-platform-core/xwiki-platform-sheet/xwiki-platform-sheet-api/src/main/java/org/xwiki/sheet/internal/DefaultSheetManager.java
@@ -195,7 +195,7 @@ public class DefaultSheetManager implements SheetManager
                 return false;
             }
         } catch (Exception e) {
-            this.logger.error("Failed to check for the existance of the sheet with reference [{}]", sheetReference, e);
+            this.logger.error("Failed to check for the existence of the sheet with reference [{}]", sheetReference, e);
 
             return false;
         }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-rest/src/main/java/org/xwiki/test/extension/RestExtensionInstaller.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-rest/src/main/java/org/xwiki/test/extension/RestExtensionInstaller.java
@@ -165,7 +165,7 @@ public class RestExtensionInstaller
 
         JobExecutor jobExecutor = new JobExecutor();
         JobRequest request = getModelFactory().toRestJobRequest(installRequest);
-        LOGGER.info("Provisioning the extensions...", request);
+        LOGGER.info("Provisioning the extensions...");
         jobExecutor.execute(InstallJob.JOBTYPE, request, xwikiRESTURL, credentials);
     }
 


### PR DESCRIPTION
Applies the [Logging Best Practices](https://dev.xwiki.org/xwiki/bin/view/Community/CodeStyle/JavaCodeStyle/#HLoggingBestPractices) and fixes log statements that were outright broken.

I audited all 2088 SLF4J call sites in the repo with a small parser (placeholder/argument arity, concatenation, `String.format`, `warn()`-with-Throwable, bracketing, spelling). This PR lands **all of the first category (broken messages) repo-wide, plus the largest part of the `xwiki-platform-oldcore` conventions sweep** — 107 of oldcore's 219 sites. The rest is deliberately left for follow-up PRs, one per module.

## Commit 1 — broken log messages (whole repo)

These printed nothing useful at all, so they are worth fixing everywhere at once:

| Problem | Where |
|---|---|
| Corrupted placeholder `[¶}]` instead of `[{}]` | `XWikiRightServiceImpl` |
| `%s` / `{0}` placeholders, which SLF4J never substitutes | `LegacyEventLoader`, `WikiObjectComponentManagerEventListenerProxy` |
| Placeholder with no matching argument (rendered literally as `{}`) | `AbstractDocumentNotificationPreferenceProvider`, `WikiNotificationPreferenceProvider` |
| Argument with no matching placeholder (silently dropped) | `AbstractAsynchronousEventStore`, `DefaultMandatoryDocumentInitializerManager`, `XWikiRepositoryModel`, `RestExtensionInstaller` |
| `existance` → `existence` | `DefaultExtensionIndex`, `DefaultSheetManager` |

## Commit 2 — oldcore conventions sweep

Parameterized signatures instead of concatenation/`String.format` (which also lets the redundant `isDebugEnabled()`/`isErrorEnabled()` guards go), `[]` around placeholder values, `ExceptionUtils.getRootCauseMessage()` instead of a Throwable on `warn()`, and the Throwable actually passed to `error()`.

It also picked up genuine bugs on the way:

- `Package.readFromZip()` promised a `[{}]` document reference but passed no argument, so a failing import entry was never identified.
- `MonitorPlugin` logged `endRequest`/`startRequest` from `startRequest()`, `startTimer()` and `endTimer()` (copy-paste).
- Two `e.printStackTrace()` calls replaced by passing the Throwable to the logger.
- `MyPersistentLoginManager` included the username/password being encrypted or decrypted in its error messages; those values no longer reach the logs.

## Deliberately left alone

- `[{}@{}]` / `[{}.{}]` compound-identifier placeholders (8 uses) — the values are already visually delimited, so splitting them into `[{}]@[{}]` would be pure noise.
- Unbracketed `{}` whose argument is a collection/`Optional`, since `toString()` already adds brackets (the double-bracket note in the rules) — e.g. `XWikiHibernateStore.optimizedObjectClasses`.
- Unbracketed `{}` holding a sentence fragment rather than a value, e.g. `AbstractDataMigrationManager`'s `"without needing{} data migration"`.
- `R40000XWIKI6990DataMigration.logProgress()`, a `String.format`-based helper whose conversion would mean rewriting every caller's format string.
- `error()` without a Throwable where no exception is in scope — not a violation of the rule, which is about not discarding an exception you have. 82 such sites are excluded on purpose.

## Verification

- `xwiki-platform-oldcore`: `mvn test` → **1140 tests, 0 failures**; `checkstyle:check -Plegacy,quality` → **0 violations**.
- All 10 other modules touched by commit 1 compile.

## Remaining work

365 sites remain, for follow-up PRs sliced one per module:

| Category | Remaining |
|---|---:|
| Placeholder not surrounded with `[]` | 113 |
| `warn()` passing a Throwable | 101 |
| String concatenation in the message | 78 |
| Message built with `String.format()` / `.formatted()` | 33 |
| `warn()` using `e.getMessage()` | 20 |
| Trailing whitespace / double period | 20 |

Biggest remaining modules: `xwiki-platform-oldcore` (112), `xwiki-platform-test` (39), `xwiki-platform-search` (18), `xwiki-platform-notifications` (17), `xwiki-platform-legacy` (13), `xwiki-platform-component` (11).
