### PR TITLE
[Misc] Apply the logging best practices to xwiki-platform-test

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/DockerTestUtils.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/DockerTestUtils.java
@@ -30,7 +30,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.FileUtils;
-import org.codehaus.plexus.util.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
@@ -339,7 +339,7 @@ public final class DockerTestUtils
             InetAddress ip = InetAddress.getLocalHost();
             hostname = ip.getHostName();
         } catch (Exception e) {
-            LOGGER.warn("Failed to get hostname", e);
+            LOGGER.warn("Failed to get hostname. Root cause is [{}]", ExceptionUtils.getRootCauseMessage(e));
             hostname = "Unknown";
         }
         return hostname;

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/StopFileWatcher.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/StopFileWatcher.java
@@ -28,6 +28,7 @@ import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,7 +79,8 @@ final class StopFileWatcher
                     LOGGER.warn("Not deleting non-empty file [{}], please delete it manually.", target);
                 }
             } catch (IOException e) {
-                LOGGER.warn("Could not delete existing file [{}]", target, e);
+                LOGGER.warn("Could not delete existing file [{}]. Root cause is [{}]", target,
+                    ExceptionUtils.getRootCauseMessage(e));
             }
         }
 
@@ -109,7 +111,8 @@ final class StopFileWatcher
                 }
             }
         } catch (IOException e) {
-            LOGGER.warn("WatchService failed, falling back to blocking wait for [{}]", target.getFileName(), e);
+            LOGGER.warn("WatchService failed, falling back to blocking wait for [{}]. Root cause is [{}]",
+                target.getFileName(), ExceptionUtils.getRootCauseMessage(e));
             return false;
         } catch (InterruptedException e) {
             LOGGER.error(WAIT_FAILED_MESSAGE, target.getFileName(), e);

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/WARBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/WARBuilder.java
@@ -212,7 +212,7 @@ public class WARBuilder
         LOGGER.info("Copying JDBC driver for database [{}]...", this.testConfiguration.getDatabase());
         File jdbcDriverFile = getJDBCDriver(this.testConfiguration.getDatabase(), this.artifactResolver);
         if (this.testConfiguration.isVerbose()) {
-            LOGGER.info("... JDBC driver file: {}", jdbcDriverFile);
+            LOGGER.info("... JDBC driver file: [{}]", jdbcDriverFile);
         }
         copyFile(jdbcDriverFile, libDirectory);
     }
@@ -224,7 +224,7 @@ public class WARBuilder
         for (File file : warDependencies) {
             // Unzip the WARs in the target directory
             if (testConfiguration.isVerbose()) {
-                LOGGER.info("... Unzipping WAR: {}", file);
+                LOGGER.info("... Unzipping WAR: [{}]", file);
             }
             unzip(file, targetWARDirectory);
         }
@@ -243,11 +243,11 @@ public class WARBuilder
         createDirectory(libDirectory);
         for (Artifact artifact : jarDependencies) {
             if (testConfiguration.isVerbose()) {
-                LOGGER.info("... Copying JAR: {}", artifact.getFile());
+                LOGGER.info("... Copying JAR: [{}]", artifact.getFile());
             }
             copyFile(artifact.getFile(), libDirectory);
             if (testConfiguration.isVerbose()) {
-                LOGGER.info("... Generating XED file for: {}", artifact.getFile());
+                LOGGER.info("... Generating XED file for: [{}]", artifact.getFile());
             }
             generateXEDForJAR(artifact, libDirectory, this.mavenResolver);
         }
@@ -260,7 +260,7 @@ public class WARBuilder
         File skinsDirectory = new File(targetWARDirectory, "skins");
         for (File file : skinDependencies) {
             if (testConfiguration.isVerbose()) {
-                LOGGER.info("... Unzipping skin: {}", file);
+                LOGGER.info("... Unzipping skin: [{}]", file);
             }
             unzip(file, skinsDirectory);
         }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/XWikiDockerExtension.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/XWikiDockerExtension.java
@@ -395,8 +395,8 @@ public class XWikiDockerExtension extends AbstractExecutionConditionExtension
             XWikiExecutor executor = DockerTestUtils.getCurrentXWikiExecutor(extensionContext);
             String url = executor.getHttpClientBaseURL();
 
-            LOGGER.info("XWiki is kept running for manual inspection ({}={}).", KEEP_RUNNING_PROPERTY, true);
-            LOGGER.info("Access XWiki at: {}", url);
+            LOGGER.info("XWiki is kept running for manual inspection ([{}]=[{}]).", KEEP_RUNNING_PROPERTY, true);
+            LOGGER.info("Access XWiki at: [{}]", url);
             LOGGER.info("You can log in as [{}] with password [{}]", SUPERADMIN, SUPERADMIN_PASSWORD);
 
             // Wait for the user to create the file "stop.txt" in the current directory.

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/configuration/ConfigurationFilesGenerator.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/configuration/ConfigurationFilesGenerator.java
@@ -114,7 +114,7 @@ public class ConfigurationFilesGenerator
                     String fileName = entry.getName().replace(VM_EXTENSION, "");
                     File outputFile = new File(configurationFileTargetDirectory, fileName);
                     if (this.testConfiguration.isVerbose()) {
-                        LOGGER.info("... Generating: {}", outputFile);
+                        LOGGER.info("... Generating: [{}]", outputFile);
                     }
                     // Note: Init is done once even if this method is called several times...
                     Velocity.init();
@@ -142,7 +142,7 @@ public class ConfigurationFilesGenerator
         File outputDirectory = new File(configurationFileTargetDirectory, "classes");
         File outputFile = new File(outputDirectory, LOGBACK_FILE);
         if (this.testConfiguration.isVerbose()) {
-            LOGGER.info("... Generating logging configuration: {}", outputFile);
+            LOGGER.info("... Generating logging configuration: [{}]", outputFile);
         }
         try (FileOutputStream fos = new FileOutputStream(outputFile)) {
             // Allows modules to override the default logback config by providing a LOGBACK_OVERRIDE_FILE file in

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/database/DatabaseContainerExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/database/DatabaseContainerExecutor.java
@@ -169,8 +169,8 @@ public class DatabaseContainerExecutor extends AbstractContainerExecutor
                         + "with return code [%d] and console logs [%s]", DBUSERNAME, result.getExitCode(),
                         errorMessage));
                 } else {
-                    LOGGER.info("Failed to set MySQL permissions, retrying ({}/{})... Error: [{}]", i + 1, maxRetries,
-                        errorMessage);
+                    LOGGER.info("Failed to set MySQL permissions, retrying ([{}]/[{}])... Error: [{}]", i + 1,
+                        maxRetries, errorMessage);
                     // Wait longer at each retry to slightly increase the chance that the retry will work.
                     Thread.sleep(5000L * (i + 1));
                 }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/servletengine/ServletContainerExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/servletengine/ServletContainerExecutor.java
@@ -432,7 +432,7 @@ public class ServletContainerExecutor extends AbstractContainerExecutor
     private GenericContainer<?> createServletContainer() throws Exception
     {
         String baseImageName = getBaseImageName();
-        LOGGER.info("Get base image name: {}", baseImageName);
+        LOGGER.info("Get base image name: [{}]", baseImageName);
         GenericContainer<?> container;
 
         if (this.testConfiguration.isOffice()) {

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/main/java/org/xwiki/test/integration/XWikiExecutorSuite.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/main/java/org/xwiki/test/integration/XWikiExecutorSuite.java
@@ -111,7 +111,7 @@ public class XWikiExecutorSuite extends ClasspathSuite
                     // If the runner still has tests remaining after the filtering, add it.
                     runners.add(runner);
                 } catch (NoTestsRemainException e) {
-                    LOGGER.info("Skipping test class: {}", description.getClassName());
+                    LOGGER.info("Skipping test class: [{}]", description.getClassName());
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/main/java/org/xwiki/test/integration/maven/ArtifactResolver.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/main/java/org/xwiki/test/integration/maven/ArtifactResolver.java
@@ -159,7 +159,7 @@ public class ArtifactResolver
             DependencyNode node = collectResult.getRoot();
 
             if (this.isVerbose) {
-                LOGGER.info("collect = {} ms", (System.currentTimeMillis() - t1));
+                LOGGER.info("collect = [{}] ms", (System.currentTimeMillis() - t1));
                 node.accept(new FilteringDependencyVisitor(new DebuggingDependencyVisitor(), filter));
             }
 
@@ -168,7 +168,7 @@ public class ArtifactResolver
             DependencyResult dependencyResult = this.repositoryResolver.getSystem().resolveDependencies(
                 this.repositoryResolver.getSession(), request);
             if (this.isVerbose) {
-                LOGGER.info("resolve = {} ms", (System.currentTimeMillis() - t1));
+                LOGGER.info("resolve = [{}] ms", (System.currentTimeMillis() - t1));
             }
 
             if (!dependencyResult.getCollectExceptions().isEmpty()) {

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/main/java/org/xwiki/test/integration/maven/DebuggingDependencyVisitor.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/main/java/org/xwiki/test/integration/maven/DebuggingDependencyVisitor.java
@@ -57,6 +57,6 @@ public class DebuggingDependencyVisitor implements DependencyVisitor
 
     private void printInfoLog(DependencyNode dependencyNode)
     {
-        LOGGER.info(StringUtils.repeat(" ", this.level) + "{}", dependencyNode.getArtifact());
+        LOGGER.info("{}[{}]", StringUtils.repeat(" ", this.level), dependencyNode.getArtifact());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestDebugger.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestDebugger.java
@@ -80,19 +80,19 @@ public class TestDebugger extends TestWatcher
     @Override
     protected void starting(Description description)
     {
-        LOGGER.info("{} started", getTestName(description));
+        LOGGER.info("[{}] started", getTestName(description));
     }
 
     @Override
     protected void succeeded(Description description)
     {
-        LOGGER.info("{} passed", getTestName(description));
+        LOGGER.info("[{}] passed", getTestName(description));
     }
 
     @Override
     protected void failed(Throwable e, Description description)
     {
-        LOGGER.info("{} failed", getTestName(description));
+        LOGGER.info("[{}] failed", getTestName(description));
         takeScreenshot(description);
         LOGGER.info("Current page URL is [{}]", driver.getCurrentUrl());
         LOGGER.info("Current page source is [{}]", driver.getPageSource());

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
@@ -72,6 +72,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.hc.core5.net.URIBuilder;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Cookie;
@@ -522,7 +523,8 @@ public class TestUtils
             LOGGER.debug("Sent the requests of the page being unloaded: {}", sentRequests);
         } catch (WebDriverException e) {
             // Not a reason to fail the test: unloading the page below still cancels all the other pending requests.
-            LOGGER.warn("Failed to send the requests of the page being unloaded, some tests might be flaky.", e);
+            LOGGER.warn("Failed to send the requests of the page being unloaded, some tests might be flaky. Root "
+                + "cause is [{}]", ExceptionUtils.getRootCauseMessage(e));
         }
 
         // Navigating to a blank page unloads the current page without triggering any request of its own.
@@ -1667,7 +1669,8 @@ public class TestUtils
             this.secretToken = htmlElement.getDomAttribute("data-xwiki-form-token");
         } catch (NoSuchElementException exception) {
             // Something is really wrong if this happens.
-            LOGGER.warn("Failed to cache anti-CSRF secret token, some tests might fail!", exception);
+            LOGGER.warn("Failed to cache anti-CSRF secret token, some tests might fail! Root cause is [{}]",
+                ExceptionUtils.getRootCauseMessage(exception));
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
@@ -523,8 +523,8 @@ public class TestUtils
             LOGGER.debug("Sent the requests of the page being unloaded: {}", sentRequests);
         } catch (WebDriverException e) {
             // Not a reason to fail the test: unloading the page below still cancels all the other pending requests.
-            LOGGER.warn("Failed to send the requests of the page being unloaded, some tests might be flaky. Root "
-                + "cause is [{}]", ExceptionUtils.getRootCauseMessage(e));
+            LOGGER.warn("Failed to send the requests of the page being unloaded, some tests might be flaky. Call "
+                + "stack is [{}]", ExceptionUtils.getStackTrace(e));
         }
 
         // Navigating to a blank page unloads the current page without triggering any request of its own.
@@ -1669,8 +1669,8 @@ public class TestUtils
             this.secretToken = htmlElement.getDomAttribute("data-xwiki-form-token");
         } catch (NoSuchElementException exception) {
             // Something is really wrong if this happens.
-            LOGGER.warn("Failed to cache anti-CSRF secret token, some tests might fail! Root cause is [{}]",
-                ExceptionUtils.getRootCauseMessage(exception));
+            LOGGER.warn("Failed to cache anti-CSRF secret token, some tests might fail! Call stack is [{}]",
+                ExceptionUtils.getStackTrace(exception));
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/XWikiWebDriver.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/XWikiWebDriver.java
@@ -29,6 +29,7 @@ import java.util.function.Supplier;
 import java.util.logging.Level;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Dimension;
@@ -784,7 +785,8 @@ public class XWikiWebDriver extends RemoteWebDriver
             LOGGER.warn("The currently running test wasted [{}] ms waiting for element [{}] which was not found. "
                 + "Tests should look for elements that are expected to be present; to check for the absence of an "
                 + "element or to avoid waiting, use findElementWithoutWaiting(), hasElementWithoutWaiting() or "
-                + "waitUntilElementDisappears() instead.", elapsedMillis, by, locationException);
+                + "waitUntilElementDisappears() instead. Call stack is [{}]", elapsedMillis, by,
+                ExceptionUtils.getStackTrace(locationException));
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
@@ -737,7 +737,7 @@ public class BasePage extends BaseElement
             if (wcagContext.shouldWCAGStopOnError()) {
                 throw e;
             } else {
-                LOGGER.debug("Error during WCAG execution, but ignored thanks to wcagStopOnError flag: ", e);
+                LOGGER.debug("Error during WCAG execution, but ignored thanks to wcagStopOnError flag:", e);
             }
         }
     }


### PR DESCRIPTION
Continues the repo-wide logging best-practices pass (after #6055 and #6056, which cleared `xwiki-platform-oldcore`), applying the [logging rules](https://dev.xwiki.org/xwiki/bin/view/Community/CodeStyle/JavaCodeStyle/#HLoggingBestPractices) to `xwiki-platform-test`.

### Changes

The audit found 39 sites in this module; 25 needed a change.

* **Placeholder values surrounded with `[]`** so they are visually delimited — `WARBuilder`, `XWikiDockerExtension`, `ConfigurationFilesGenerator`, `DatabaseContainerExecutor`, `ServletContainerExecutor`, `XWikiExecutorSuite`, `ArtifactResolver`, `TestDebugger`.
* **`warn()` no longer passes a Throwable**, so stack traces stay reserved for `error()`. The Throwable leaves the SLF4J slot in every case, but what replaces it depends on whether the trace was the diagnostic payload:
  * `DockerTestUtils` and `StopFileWatcher` name the failing operation (and the file) in the message itself, so the root cause via `ExceptionUtils.getRootCauseMessage()` is all that was missing.
  * `XWikiWebDriver` logs a *synthetic* exception built only to capture the wasteful `findElement()` caller, and the two `TestUtils` warnings are emitted from helpers that arbitrary test code calls — in all three the caller frame is what tells you which test tripped the warning. They keep the **full** trace, moved into a `Call stack is [{}]` placeholder via `ExceptionUtils.getStackTrace()`.
* **String concatenation removed** from `DebuggingDependencyVisitor`, whose indentation prefix becomes a leading `{}` placeholder.
* **Trailing whitespace trimmed** before the stack trace logged by `BasePage` (SLF4J already separates the message from the trace).

`DockerTestUtils` was importing the Plexus `ExceptionUtils`, which has no `getRootCauseMessage()`. It now uses the Commons Lang one, whose `getRootCause()` serves the existing `EOFException` check just as well.

### Deliberately not changed

The 14 remaining flagged sites fall under the audit's own exclusions:

* values that already bracket themselves — a `List` in `WARBuilder`, a `Collection` in `RestExtensionInstaller`, the script result in `TestUtils`, the `[\n{}\n]` blocks in `LogCaptureValidator`;
* the compound `[{} : {}]` / `[{}/{}]` identifiers in `WCAGContext`, `WCAGUtils` and `BasePage`;
* `MavenResolver`, where `ModelProblem.getMessage()` is not an exception message;
* the `warn()` with a stack trace in `ValidateConsoleExtensionTest`, which is the fixture that test validates.

### Verification

* `mvn -B -ntp compile` — BUILD SUCCESS
* `mvn -B -ntp test` — 10 tests, 0 failures
* `mvn -B -ntp checkstyle:check -Plegacy,quality` — BUILD SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
