### PR TITLE
[Misc] Apply the logging best practices to xwiki-platform-search

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrIndexer.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrIndexer.java
@@ -35,6 +35,7 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.solr.common.SolrInputDocument;
 import org.slf4j.Logger;
 import org.xwiki.bridge.internal.DocumentContextExecutor;
@@ -241,8 +242,8 @@ public class DefaultSolrIndexer implements SolrIndexer, Initializable, Disposabl
                 try {
                     dispatchQueueEntry(queueEntry);
                 } catch (Throwable e) {
-                    logger.warn("Failed to apply operation [{}] on root reference [{}]", queueEntry.operation,
-                        queueEntry.reference, e);
+                    logger.warn("Failed to apply operation [{}] on root reference [{}]. Root cause is [{}]",
+                        queueEntry.operation, queueEntry.reference, ExceptionUtils.getRootCauseMessage(e));
                 } finally {
                     // Decrement only for entries submitted via addToQueue(); READY_MARKER entries come from
                     // waitReady() which does not increment pendingResolveItems.
@@ -302,7 +303,8 @@ public class DefaultSolrIndexer implements SolrIndexer, Initializable, Disposabl
                 queueEntry = resolveQueue.take();
                 DefaultSolrIndexer.this.resolveQueueRemovalCounter.incrementAndGet();
             } catch (InterruptedException e) {
-                logger.warn("The SOLR resolve thread has been interrupted", e);
+                logger.warn("The SOLR resolve thread has been interrupted. Root cause is [{}]",
+                    ExceptionUtils.getRootCauseMessage(e));
                 queueEntry = RESOLVE_QUEUE_ENTRY_STOP;
             }
             return queueEntry;
@@ -522,7 +524,8 @@ public class DefaultSolrIndexer implements SolrIndexer, Initializable, Disposabl
             try {
                 queueEntry = this.indexQueue.take();
             } catch (InterruptedException e) {
-                this.logger.warn("The SOLR index thread has been interrupted", e);
+                this.logger.warn("The SOLR index thread has been interrupted. Root cause is [{}]",
+                    ExceptionUtils.getRootCauseMessage(e));
 
                 queueEntry = INDEX_QUEUE_ENTRY_STOP;
             }
@@ -756,7 +759,8 @@ public class DefaultSolrIndexer implements SolrIndexer, Initializable, Disposabl
         try {
             result = this.componentManager.getInstance(SolrMetadataExtractor.class, entityType.name().toLowerCase());
         } catch (ComponentLookupException e) {
-            this.logger.warn("Unsupported entity type: [{}]", entityType.toString(), e);
+            this.logger.warn("Unsupported entity type: [{}]. Root cause is [{}]", entityType.toString(),
+                ExceptionUtils.getRootCauseMessage(e));
         }
 
         return result;

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/IndexingUserConfigurationInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/IndexingUserConfigurationInitializer.java
@@ -82,9 +82,8 @@ public class IndexingUserConfigurationInitializer extends AbstractMandatoryDocum
                 document.newXObject(DefaultIndexingUserConfig.CONFIG_CLASS, context);
                 needsUpdate = true;
             } catch (XWikiException e) {
-                // using String.format here so the exception is logged with stack trace
-                logger.error(String.format("Error adding the [%s] object to the document [%s]",
-                    DefaultIndexingUserConfig.CONFIG_CLASS, document.getDocumentReference()), e);
+                logger.error("Error adding the [{}] object to the document [{}]",
+                    DefaultIndexingUserConfig.CONFIG_CLASS, document.getDocumentReference(), e);
             }
         }
         return needsUpdate;

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/job/IndexerJob.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/job/IndexerJob.java
@@ -188,7 +188,7 @@ public class IndexerJob extends AbstractJob<IndexerRequest, DefaultJobStatus<Ind
             }
 
             this.logger.info(
-                "{} documents added, {} deleted and {} updated during the synchronization of the Solr index.",
+                "[{}] documents added, [{}] deleted and [{}] updated during the synchronization of the Solr index.",
                 counter[Action.ADD.ordinal()], counter[Action.DELETE.ordinal()], counter[Action.UPDATE.ordinal()]);
 
             if (getRequest().isCleanInvalid()) {

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/reference/DefaultSolrReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/reference/DefaultSolrReferenceResolver.java
@@ -105,7 +105,7 @@ public class DefaultSolrReferenceResolver implements SolrReferenceResolver
                     try {
                         currentIterator = getReferences(new WikiReference(wiki)).iterator();
                     } catch (SolrIndexerException e) {
-                        logger.error("Failed to get references for wiki [" + wiki + "]", e);
+                        logger.error("Failed to get references for wiki [{}]", wiki, e);
                     }
 
                     if (!currentIterator.hasNext()) {

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/reference/DocumentSolrReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/reference/DocumentSolrReferenceResolver.java
@@ -147,7 +147,7 @@ public class DocumentSolrReferenceResolver extends AbstractSolrReferenceResolver
             try {
                 this.attachmentResolverProvider.get().getReferences(attachmentReference).forEach(result::add);
             } catch (Exception e) {
-                this.logger.error("Failed to resolve references for attachment [" + attachmentReference + "]", e);
+                this.logger.error("Failed to resolve references for attachment [{}]", attachmentReference, e);
             }
         }
     }
@@ -167,7 +167,7 @@ public class DocumentSolrReferenceResolver extends AbstractSolrReferenceResolver
                     try {
                         this.objectResolverProvider.get().getReferences(objectReference).forEach(result::add);
                     } catch (Exception e) {
-                        this.logger.error("Failed to resolve references for object [" + objectReference + "]", e);
+                        this.logger.error("Failed to resolve references for object [{}]", objectReference, e);
                     }
                 }
             }

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/reference/ObjectSolrReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/reference/ObjectSolrReferenceResolver.java
@@ -104,8 +104,8 @@ public class ObjectSolrReferenceResolver extends AbstractSolrReferenceResolver
                     this.objectPropertyResolverProvider.get().getReferences(objectPropertyReference)
                         .forEach(result::add);
                 } catch (Exception e) {
-                    this.logger.error("Failed to resolve references for object property [" + objectPropertyReference
-                        + "]", e);
+                    this.logger.error("Failed to resolve references for object property [{}]", objectPropertyReference,
+                        e);
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/reference/SpaceSolrReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/reference/SpaceSolrReferenceResolver.java
@@ -97,7 +97,7 @@ public class SpaceSolrReferenceResolver extends AbstractSolrReferenceResolver
             try {
                 this.documentResolverProvider.get().getReferences(documentReference).forEach(result::add);
             } catch (Exception e) {
-                this.logger.error("Failed to resolve references for document [" + documentReference + "]", e);
+                this.logger.error("Failed to resolve references for document [{}]", documentReference, e);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/reference/WikiSolrReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/reference/WikiSolrReferenceResolver.java
@@ -89,7 +89,7 @@ public class WikiSolrReferenceResolver extends AbstractSolrReferenceResolver
             try {
                 this.spaceResolverProvider.get().getReferences(spaceReference).forEach(result::add);
             } catch (Exception e) {
-                this.logger.error("Failed to resolve references for space [" + spaceReference + "]", e);
+                this.logger.error("Failed to resolve references for space [{}]", spaceReference, e);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/job/IndexerJobTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/job/IndexerJobTest.java
@@ -207,7 +207,7 @@ class IndexerJobTest
 
     private void assertLog(int added, int deleted, int updated)
     {
-        assertEquals("%d documents added, %d deleted and %d updated during the synchronization of the Solr index."
+        assertEquals("[%d] documents added, [%d] deleted and [%d] updated during the synchronization of the Solr index."
             .formatted(added, deleted, updated), this.logCapture.getLogEvent(0).getFormattedMessage());
     }
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-embedded/src/main/java/org/xwiki/search/solr/internal/EmbeddedSolr.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-embedded/src/main/java/org/xwiki/search/solr/internal/EmbeddedSolr.java
@@ -294,7 +294,7 @@ public class EmbeddedSolr extends AbstractSolr implements Disposable, Initializa
                 }
             }
         } catch (Exception e) {
-            this.logger.warn("Failed to parse Solr configuration at [{}]: {}", solrconfigFile,
+            this.logger.warn("Failed to parse Solr configuration at [{}]: [{}]", solrconfigFile,
                 ExceptionUtils.getRootCauseMessage(e));
         }
 
@@ -329,7 +329,7 @@ public class EmbeddedSolr extends AbstractSolr implements Disposable, Initializa
                 }
             }
         } catch (Exception e) {
-            this.logger.warn("Failed to parse Solr configuration at [{}]: {}", schemaFile,
+            this.logger.warn("Failed to parse Solr configuration at [{}]: [{}]", schemaFile,
                 ExceptionUtils.getRootCauseMessage(e));
         }
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-query/src/main/java/org/xwiki/query/solr/internal/SolrQueryExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-query/src/main/java/org/xwiki/query/solr/internal/SolrQueryExecutor.java
@@ -30,6 +30,7 @@ import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
@@ -243,7 +244,8 @@ public class SolrQueryExecutor extends AbstractQueryExecutor
             } catch (Exception e) {
                 // Don't take any risk of including a result for which we cannot determine the document reference and
                 // thus cannot determine if the given users have access to it or not.
-                this.logger.warn("Removing bad result: {}", result, e);
+                this.logger.warn("Removing bad result: [{}]. Root cause is [{}]", result,
+                    ExceptionUtils.getRootCauseMessage(e));
             }
 
             // FIXME: We should update maxScore as well when removing the top scored item. How do we do that?

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-query/src/main/java/org/xwiki/query/solr/internal/SolrSearchExclusionsQueryFilter.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-query/src/main/java/org/xwiki/query/solr/internal/SolrSearchExclusionsQueryFilter.java
@@ -121,7 +121,7 @@ public class SolrSearchExclusionsQueryFilter implements QueryFilter
         } catch (WikiManagerException e) {
             this.logger.warn("Failed to get the search exclusions. Root cause: [{}]",
                 ExceptionUtils.getRootCauseMessage(e));
-            this.logger.debug("Full stack trace: ", e);
+            this.logger.debug("Full stack trace:", e);
             return Set.of();
         }
     }

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-query/src/test/java/org/xwiki/query/solr/internal/SolrQueryExecutorTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-query/src/test/java/org/xwiki/query/solr/internal/SolrQueryExecutorTest.java
@@ -275,8 +275,11 @@ class SolrQueryExecutorTest
         assertEquals(0, results.getNumFound());
 
         // One warning for Alice in the previous execution, two for Alice and Bob in this one.
-        assertEquals("Removing bad result: SolrDocument{}", this.logCapture.getMessage(0));
-        assertEquals("Removing bad result: SolrDocument{}", this.logCapture.getMessage(1));
-        assertEquals("Removing bad result: SolrDocument{}", this.logCapture.getMessage(2));
+        assertEquals("Removing bad result: [SolrDocument{}]. Root cause is [RuntimeException: Alice]",
+            this.logCapture.getMessage(0));
+        assertEquals("Removing bad result: [SolrDocument{}]. Root cause is [RuntimeException: Alice]",
+            this.logCapture.getMessage(1));
+        assertEquals("Removing bad result: [SolrDocument{}]. Root cause is [RuntimeException: Bob]",
+            this.logCapture.getMessage(2));
     }
 }


### PR DESCRIPTION
Continues the repo-wide logging best-practices pass (after #6055, #6056 for `xwiki-platform-oldcore` and #6057 for `xwiki-platform-test`), applying the [logging rules](https://dev.xwiki.org/xwiki/bin/view/Community/CodeStyle/JavaCodeStyle/#HLoggingBestPractices) to `xwiki-platform-search`.

### Changes

The audit found 18 sites in this module; 17 needed a change.

* **String concatenation and `String.format()` replaced** by the parameterized SLF4J signatures — the six `*SolrReferenceResolver` classes and `IndexingUserConfigurationInitializer`.
  The latter carried a comment saying `String.format()` was used *"so the exception is logged with stack trace"*. That is not a real constraint: `error()` accepts `{}` placeholders **and** a trailing `Throwable`, so the stack trace is preserved and the comment goes away.
* **Placeholder values surrounded with `[]`** — `IndexerJob`, `EmbeddedSolr`, `SolrQueryExecutor`.
* **`warn()` no longer passes a Throwable**, so stack traces stay reserved for `error()` — `DefaultSolrIndexer` (4 sites) and `SolrQueryExecutor`, which now surface the root cause via `ExceptionUtils.getRootCauseMessage()`.
* **Trailing whitespace trimmed** before the stack trace logged by `SolrSearchExclusionsQueryFilter`.

### Test updates

`IndexerJobTest` and `SolrQueryExecutorTest` assert on the formatted log message, so both were updated. In `SolrQueryExecutorTest` the three assertions were previously identical; now that the message carries the root cause, the third one correctly names `Bob` rather than `Alice` — which is precisely the diagnostic value the change adds.

### Deliberately not changed

`AbstractSolrCoreInitializer`'s unbracketed placeholder holds the `" dynamic"` sentence fragment rather than a datum, which the audit excludes.

### Verification

* `mvn -B -ntp test` — BUILD SUCCESS
* `mvn -B -ntp checkstyle:check -Plegacy,quality` — BUILD SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
