### PR TITLE
[Misc] Apply the logging best practices to xwiki-platform-notifications

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/DeletedDocumentCleanUpFilterProcessingQueue.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/DeletedDocumentCleanUpFilterProcessingQueue.java
@@ -29,6 +29,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.apache.commons.lang3.Strings;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentLifecycleException;
@@ -135,7 +136,8 @@ public class DeletedDocumentCleanUpFilterProcessingQueue implements Initializabl
             try {
                 cleanUpFilterData = this.cleanupQueue.take();
             } catch (InterruptedException e) {
-                this.logger.warn("The thread handling filter clean up has been interrupted", e);
+                this.logger.warn("The thread handling filter clean up has been interrupted. Root cause is [{}]",
+                    ExceptionUtils.getRootCauseMessage(e));
                 Thread.currentThread().interrupt();
                 break;
             }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilter.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilter.java
@@ -110,7 +110,7 @@ public class ScopeNotificationFilter implements NotificationFilter
             }
 
             case CUSTOM ->
-                this.logger.error("Filtering of event should never return custom. Event: [{}]. User: [{}] ",
+                this.logger.error("Filtering of event should never return custom. Event: [{}]. User: [{}]",
                     event, user);
 
             default -> {

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/user/EventUserFilterPreferencesGetter.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/user/EventUserFilterPreferencesGetter.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.apache.commons.lang3.Strings;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.notifications.NotificationFormat;
@@ -132,7 +133,8 @@ public class EventUserFilterPreferencesGetter
                     && matchAllEvents(pref)
             );
         } catch (Exception e) {
-            logger.warn("Failed to get the list of UserFilter notification preferences.", e);
+            logger.warn("Failed to get the list of UserFilter notification preferences. Root cause is [{}]",
+                ExceptionUtils.getRootCauseMessage(e));
             return Stream.empty();
         }
     }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/migrators/ScopeNotificationFilterClassMigrator.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/migrators/ScopeNotificationFilterClassMigrator.java
@@ -103,7 +103,7 @@ public class ScopeNotificationFilterClassMigrator extends AbstractHibernateDataM
         try {
             return context.getWiki().exists(classReference, context);
         } catch (XWikiException e) {
-            this.logger.warn("Failed to check the existence of the class with reference [{}]: {}", classReference,
+            this.logger.warn("Failed to check the existence of the class with reference [{}]: [{}]", classReference,
                 ExceptionUtils.getRootCauseMessage(e));
         }
 
@@ -131,7 +131,8 @@ public class ScopeNotificationFilterClassMigrator extends AbstractHibernateDataM
                 try {
                     migrateDocument(userDocument);
                 } catch (XWikiException e) {
-                    logger.warn("Failed to migrate document [{}].", result, e);
+                    logger.warn("Failed to migrate document [{}]. Root cause is [{}]", result,
+                        ExceptionUtils.getRootCauseMessage(e));
                 }
             }
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/main/java/org/xwiki/notifications/filters/watch/internal/AutomaticWatchModeListener.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/main/java/org/xwiki/notifications/filters/watch/internal/AutomaticWatchModeListener.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.bridge.event.DocumentCreatedEvent;
 import org.xwiki.bridge.event.DocumentUpdatedEvent;
@@ -142,8 +143,8 @@ public class AutomaticWatchModeListener extends AbstractEventListener
                 watchedEntitiesManager.watchEntity(
                         factory.createWatchedLocationReference(currentDoc.getDocumentReference()), userReference);
             } catch (NotificationException e) {
-                logger.warn("Failed to watch document [{}] for user [{}]", currentDoc.getDocumentReference(),
-                        userReference, e);
+                logger.warn("Failed to watch document [{}] for user [{}]. Root cause is [{}]",
+                        currentDoc.getDocumentReference(), userReference, ExceptionUtils.getRootCauseMessage(e));
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/PrefilteringLiveNotificationEmailManager.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/PrefilteringLiveNotificationEmailManager.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentLifecycleException;
@@ -104,7 +105,8 @@ public class PrefilteringLiveNotificationEmailManager implements Initializable, 
             try {
                 event = this.preQueue.take();
             } catch (InterruptedException e) {
-                this.logger.warn("The thread handling live event optimization has been interrupted", e);
+                this.logger.warn("The thread handling live event optimization has been interrupted. Root cause is "
+                    + "[{}]", ExceptionUtils.getRootCauseMessage(e));
 
                 Thread.currentThread().interrupt();
                 break;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/UserEventDispatcher.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/UserEventDispatcher.java
@@ -176,7 +176,7 @@ public class UserEventDispatcher
                     try {
                         completableFutures.add(prefilterEvent(event, types));
                     } catch (Exception e) {
-                        this.logger.warn("Failed to pre filter event with id [{}]: {}", event.getId(),
+                        this.logger.warn("Failed to pre filter event with id [{}]: [{}]", event.getId(),
                             ExceptionUtils.getRootCauseMessage(e));
                         // Remember the failed event to not query it again
                         failedEvents.add(event.getId());
@@ -253,7 +253,7 @@ public class UserEventDispatcher
                     this.logger.warn("Failed to verify if user [{}] exists. Cause: [{}]", userReference,
                         ExceptionUtils.getRootCauseMessage(e));
                 } catch (GroupException e) {
-                    this.logger.warn("Failed to get the member of the entity [{}]: {}", entity,
+                    this.logger.warn("Failed to get the member of the entity [{}]: [{}]", entity,
                         ExceptionUtils.getRootCauseMessage(e));
                 }
             }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/UserEventManager.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/UserEventManager.java
@@ -221,7 +221,7 @@ public class UserEventManager implements Initializable
             }
             return allPreferences.isEmpty();
         } catch (NotificationException e) {
-            this.logger.warn("Unable to retrieve the notifications preferences of [{}]: {}", user,
+            this.logger.warn("Unable to retrieve the notifications preferences of [{}]: [{}]", user,
                 ExceptionUtils.getRootCauseMessage(e));
         }
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/AbstractMimeMessageIterator.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/AbstractMimeMessageIterator.java
@@ -238,7 +238,7 @@ public abstract class AbstractMimeMessageIterator implements Iterator<MimeMessag
                         userReference,
                         this.interval,
                         ExceptionUtils.getRootCauseMessage(e));
-                this.logger.debug("Root cause of the error was: ", e);
+                this.logger.debug("Root cause of the error was:", e);
             }
         } else {
             this.logger.warn("Cannot find a NotificationEmailGroupingStrategy with hint [{}] for user [{}] "
@@ -350,7 +350,7 @@ public abstract class AbstractMimeMessageIterator implements Iterator<MimeMessag
         try {
             getAttachments().add(this.logoAttachmentExtractor.getLogo());
         } catch (Exception e) {
-            this.logger.warn("Failed to get the logo.", e);
+            this.logger.warn("Failed to get the logo. Root cause is [{}]", ExceptionUtils.getRootCauseMessage(e));
         }
     }
 
@@ -378,7 +378,8 @@ public abstract class AbstractMimeMessageIterator implements Iterator<MimeMessag
             try {
                 attachments.add(userAvatarAttachmentExtractor.getUserAvatar(userAvatar, 32));
             } catch (Exception e) {
-                this.logger.warn("Failed to add the avatar of [{}] in the email.", userAvatar, e);
+                this.logger.warn("Failed to add the avatar of [{}] in the email. Root cause is [{}]", userAvatar,
+                    ExceptionUtils.getRootCauseMessage(e));
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/UserAvatarAttachmentExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/UserAvatarAttachmentExtractor.java
@@ -30,6 +30,7 @@ import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.environment.Environment;
@@ -112,7 +113,8 @@ public class UserAvatarAttachmentExtractor
                     return attachment.getContentInputStream(context);
                 }
             } catch (Exception e) {
-                logger.warn("Failed to get the avatar of [{}]. Fallback to default one.", userReference, e);
+                logger.warn("Failed to get the avatar of [{}]. Fallback to default one. Root cause is [{}]",
+                    userReference, ExceptionUtils.getRootCauseMessage(e));
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/main/java/org/xwiki/notifications/preferences/internal/DefaultNotificationPreferenceManager.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/main/java/org/xwiki/notifications/preferences/internal/DefaultNotificationPreferenceManager.java
@@ -175,8 +175,7 @@ public class DefaultNotificationPreferenceManager implements NotificationPrefere
                 provider.savePreferences(entry.getValue());
 
             } catch (ComponentLookupException e) {
-                logger.error("Unable to retrieve the notification preference provide for hint {}: {}",
-                        providerHint, e);
+                logger.error("Unable to retrieve the notification preference provider for hint [{}]", providerHint, e);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-default/src/main/java/org/xwiki/notifications/preferences/internal/email/DefaultNotificationEmailUserPreferenceManager.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-default/src/main/java/org/xwiki/notifications/preferences/internal/email/DefaultNotificationEmailUserPreferenceManager.java
@@ -29,6 +29,7 @@ import javax.inject.Singleton;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.BaseObject;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.bridge.DocumentAccessBridge;
 import org.xwiki.component.annotation.Component;
@@ -190,7 +191,8 @@ public class DefaultNotificationEmailUserPreferenceManager implements Notificati
                 }
             }
         } catch (Exception e) {
-            logger.warn("Failed to get the email property [{}] for the user [{}].", propertyName, user, e);
+            logger.warn("Failed to get the email property [{}] for the user [{}]. Root cause is [{}]", propertyName,
+                user, ExceptionUtils.getRootCauseMessage(e));
         }
 
         return returnValue;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/TagNotificationFilter.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/TagNotificationFilter.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.eventstream.Event;
@@ -119,7 +120,8 @@ public class TagNotificationFilter implements NotificationFilter
             return value(EventProperty.PAGE).inStrings(pagesHoldingTags)
                     .and(value(EventProperty.WIKI).eq(value(currentWiki)));
         } catch (QueryException e) {
-            logger.warn("Failed to get the list of documents holding some tags.", e);
+            logger.warn("Failed to get the list of documents holding some tags. Root cause is [{}]",
+                ExceptionUtils.getRootCauseMessage(e));
             return null;
         }
     }


### PR DESCRIPTION
Continues the repo-wide logging best-practices pass (after #6055, #6056 for `xwiki-platform-oldcore`, #6057 for `xwiki-platform-test` and #6058 for `xwiki-platform-search`), applying the [logging rules](https://dev.xwiki.org/xwiki/bin/view/Community/CodeStyle/JavaCodeStyle/#HLoggingBestPractices) to `xwiki-platform-notifications`.

### Changes

All 17 sites the audit found in this module.

* **`warn()` no longer passes a Throwable**, so stack traces stay reserved for `error()` — `DeletedDocumentCleanUpFilterProcessingQueue`, `EventUserFilterPreferencesGetter`, `ScopeNotificationFilterClassMigrator`, `AutomaticWatchModeListener`, `PrefilteringLiveNotificationEmailManager`, `AbstractMimeMessageIterator`, `UserAvatarAttachmentExtractor`, `DefaultNotificationEmailUserPreferenceManager`, `TagNotificationFilter`. The root cause is surfaced with `ExceptionUtils.getRootCauseMessage()` instead.
* **Placeholder values surrounded with `[]`** — `ScopeNotificationFilterClassMigrator`, `UserEventDispatcher`, `UserEventManager`.
* **Trailing whitespace trimmed** — after the logged user in `ScopeNotificationFilter`, and before the stack trace in `AbstractMimeMessageIterator`.

### A real bug found along the way

`DefaultNotificationPreferenceManager` was passing the caught `ComponentLookupException` as a *placeholder argument*:

```java
logger.error("Unable to retrieve the notification preference provide for hint {}: {}", providerHint, e);
```

With two placeholders and two arguments, SLF4J puts the exception in the second placeholder, so the log showed only `e.toString()` and **no stack trace at all**. It now goes in the Throwable slot, where it is actually rendered. The same message read *"preference provide"* rather than *"preference provider"*.

### Verification

* `mvn -B -ntp test` — BUILD SUCCESS
* `mvn -B -ntp checkstyle:check -Plegacy,quality` — BUILD SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
