### PR TITLE
[Misc] Apply the logging best practices to xwiki-platform-legacy

### DIFF
--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-events-hibernate/xwiki-platform-legacy-events-hibernate-api/src/main/java/org/xwiki/eventstream/internal/LegacyEventMigrationJob.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-events-hibernate/xwiki-platform-legacy-events-hibernate-api/src/main/java/org/xwiki/eventstream/internal/LegacyEventMigrationJob.java
@@ -119,7 +119,8 @@ public class LegacyEventMigrationJob
                 events = this.eventStream.searchEvents(query);
 
                 if (getRequest().isVerbose()) {
-                    this.logger.info("Synchronizing legacy events from index {} to {}", offset, offset + events.size());
+                    this.logger.info("Synchronizing legacy events from index [{}] to [{}]", offset,
+                        offset + events.size());
                 }
 
                 if (!events.isEmpty()) {
@@ -154,7 +155,7 @@ public class LegacyEventMigrationJob
         }
 
         if (getRequest().isVerbose()) {
-            this.logger.info("{} events were saved in the new store because they did not already exist",
+            this.logger.info("[{}] events were saved in the new store because they did not already exist",
                 eventsToSave.size());
         }
     }

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-messagestream/xwiki-platform-legacy-messagestream-api/src/main/java/org/xwiki/messagestream/internal/DefaultMessageStream.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-messagestream/xwiki-platform-legacy-messagestream-api/src/main/java/org/xwiki/messagestream/internal/DefaultMessageStream.java
@@ -190,7 +190,8 @@ public class DefaultMessageStream implements MessageStream
 
             result = this.eventStore.search(query).stream().toList();
         } catch (EventStreamException ex) {
-            this.logger.warn("Failed to search personal messages: {}", ex.getMessage());
+            this.logger.warn("Failed to search personal messages. Root cause is [{}]",
+                ExceptionUtils.getRootCauseMessage(ex));
         }
         return result;
     }
@@ -211,7 +212,8 @@ public class DefaultMessageStream implements MessageStream
 
             result = this.eventStore.search(query).stream().toList();
         } catch (EventStreamException ex) {
-            this.logger.warn("Failed to search direct messages: {}", ex.getMessage());
+            this.logger.warn("Failed to search direct messages. Root cause is [{}]",
+                ExceptionUtils.getRootCauseMessage(ex));
         }
         return result;
     }
@@ -232,7 +234,8 @@ public class DefaultMessageStream implements MessageStream
 
             result = this.eventStore.search(query).stream().toList();
         } catch (EventStreamException ex) {
-            this.logger.warn("Failed to search group messages: {}", ex.getMessage());
+            this.logger.warn("Failed to search group messages. Root cause is [{}]",
+                ExceptionUtils.getRootCauseMessage(ex));
         }
         return result;
     }
@@ -251,7 +254,7 @@ public class DefaultMessageStream implements MessageStream
                 throw new IllegalArgumentException("You are not authorized to delete this message");
             }
         } catch (Exception e) {
-            this.logger.warn("Failed to delete message: {}", ExceptionUtils.getRootCauseMessage(e));
+            this.logger.warn("Failed to delete message. Root cause is [{}]", ExceptionUtils.getRootCauseMessage(e));
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-notifications/xwiki-platform-legacy-notifications-notifiers/xwiki-platform-legacy-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/LiveNotificationEmailListener.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-notifications/xwiki-platform-legacy-notifications-notifiers/xwiki-platform-legacy-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/LiveNotificationEmailListener.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
@@ -145,7 +146,8 @@ public class LiveNotificationEmailListener extends AbstractEventListener
                 }
 
             } catch (EventStreamException e) {
-                logger.warn("Unable to retrieve a full list of RecordableEventDescriptor.", e);
+                logger.warn("Unable to retrieve a full list of RecordableEventDescriptor. Root cause is [{}]",
+                    ExceptionUtils.getRootCauseMessage(e));
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/internal/web/XWikiConfigurationService.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/internal/web/XWikiConfigurationService.java
@@ -66,7 +66,7 @@ public class XWikiConfigurationService
             try (InputStream xwikicfgis = getStream(context)) {
                 config = new XWikiConfig(xwikicfgis);
             } catch (Exception e) {
-                LOGGER.error("Faile to lod configuration", e);
+                LOGGER.error("Failed to load the configuration", e);
 
                 config = new XWikiConfig();
             }
@@ -88,20 +88,20 @@ public class XWikiConfigurationService
         } catch (Exception e) {
             // Error loading the file. Most likely, the Security Manager prevented it.
             // We'll try loading it as a resource below.
-            LOGGER.debug(
-                "Failed to load the file [" + configurationLocation + "] using direct " + "file access. The error was ["
-                    + e.getMessage() + "]. Trying to load it " + "as a resource using the Servlet Context...");
+            LOGGER.debug("Failed to load the file [{}] using direct file access. The error was [{}]. Trying to load "
+                + "it as a resource using the Servlet Context...", configurationLocation, e.getMessage());
         }
 
         // Second, try loading it as a resource using the Servlet Context
         if (context != null) {
             InputStream xwikicfgis = context.getResourceAsStream(configurationLocation);
-            LOGGER.debug("Failed to load the file [" + configurationLocation + "] as a resource "
-                + "using the Servlet Context. Trying to load it as classpath resource...");
 
             if (xwikicfgis != null) {
                 return xwikicfgis;
             }
+
+            LOGGER.debug("Failed to load the file [{}] as a resource using the Servlet Context. Trying to load it as "
+                + "classpath resource...", configurationLocation);
         } else {
             LOGGER.debug("No Servlet Context available. Trying to load it as classpath resource...");
         }

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/web/TempResourceAction.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/web/TempResourceAction.java
@@ -37,6 +37,7 @@ import javax.inject.Singleton;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.tika.mime.MimeTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -117,9 +118,8 @@ public class TempResourceAction extends XWikiAction
         try {
             contentType = TikaUtils.detect(tempFile);
         } catch (IOException ex) {
-            LOGGER.warn(
-                String.format("Unable to determine mime type for temporary resource [%s]", tempFile.getAbsolutePath()),
-                ex);
+            LOGGER.warn("Unable to determine mime type for temporary resource [{}]. Root cause is [{}]",
+                tempFile.getAbsolutePath(), ExceptionUtils.getRootCauseMessage(ex));
         }
         response.setContentType(contentType);
         if ("1".equals(request.getParameter("force-download"))) {


### PR DESCRIPTION
Continues the repo-wide logging best-practices pass (after #6055, #6056 for `xwiki-platform-oldcore`, #6057 for `xwiki-platform-test`, #6058 for `xwiki-platform-search` and #6059 for `xwiki-platform-notifications`), applying the [logging rules](https://dev.xwiki.org/xwiki/bin/view/Community/CodeStyle/JavaCodeStyle/#HLoggingBestPractices) to `xwiki-platform-legacy`.

### Changes

All 13 sites the audit found in this module.

* **Placeholder values surrounded with `[]`** — `LegacyEventMigrationJob` (the batch indices and the saved-event count), `DefaultMessageStream` (the four search/delete warnings).
* **`getMessage()` replaced with `ExceptionUtils.getRootCauseMessage()`** — the three `DefaultMessageStream` search warnings, which were only reporting the wrapper exception's message.
* **`warn()` no longer passes a Throwable**, so stack traces stay reserved for `error()` — `LiveNotificationEmailListener`. The root cause is surfaced with `ExceptionUtils.getRootCauseMessage()` instead.
* **String concatenation replaced with `{}` placeholders** — the two `XWikiConfigurationService` debug messages.
* **`String.format()` replaced with `{}` placeholders** — `TempResourceAction`.

### Two extras found along the way

Both in `XWikiConfigurationService`, while rewriting its concatenated messages:

* `LOGGER.error("Faile to lod configuration", e)` — two typos in five words.
* The *"Failed to load the file [...] as a resource using the Servlet Context. Trying to load it as classpath resource..."* debug message was logged **unconditionally, before** the success path returned, so it claimed a failure every time the Servlet Context lookup actually worked. It now fires only when `getResourceAsStream()` returns `null`.

### Verification

* `mvn -B -ntp test` — the only failure is `VelocityContextInitializerTest.velocityBridges` in `xwiki-platform-legacy-office-importer`, which is **pre-existing and unrelated**: it reproduces identically on a clean `master` with these changes stashed. Every other test in the module passes (verified with `-Dmaven.test.failure.ignore=true`).
* `mvn -B -ntp checkstyle:check -Plegacy,quality` — BUILD SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
