### PR TITLE
[Misc] Apply the logging best practices to 5 more platform modules

### DIFF
--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-multi/src/main/java/org/xwiki/component/internal/DocumentDeletedListener.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-multi/src/main/java/org/xwiki/component/internal/DocumentDeletedListener.java
@@ -86,7 +86,7 @@ public class DocumentDeletedListener implements EventListener
             try {
                 disposable.dispose();
             } catch (ComponentLifecycleException e) {
-                this.logger.error(String.format("Failed to dispose component manager for document [%s]", document), e);
+                this.logger.error("Failed to dispose component manager for document [{}]", document, e);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-multi/src/main/java/org/xwiki/component/internal/WikiDeletedListener.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-multi/src/main/java/org/xwiki/component/internal/WikiDeletedListener.java
@@ -86,7 +86,7 @@ public class WikiDeletedListener implements EventListener
             try {
                 disposable.dispose();
             } catch (ComponentLifecycleException e) {
-                this.logger.error(String.format("Failed to dispose component manager for wiki [%s]", wiki), e);
+                this.logger.error("Failed to dispose component manager for wiki [{}]", wiki, e);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/DefaultWikiComponentInvocationHandler.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/DefaultWikiComponentInvocationHandler.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.component.descriptor.ComponentDescriptor;
@@ -122,9 +123,9 @@ public class DefaultWikiComponentInvocationHandler implements InvocationHandler
                     componentDependency = componentManager.getInstance(cd.getRoleType(), cd.getRoleHint());
                 }
             } catch (ComponentLookupException e) {
-                this.logger.warn(String.format(
-                    "No component found for role [%s] with hint [%s], declared as dependency for wiki component [%s]",
-                    cd.getRoleType().toString(), cd.getRoleHint(), this.wikiComponent.getDocumentReference()));
+                this.logger.warn("No component found for role [{}] with hint [{}], declared as dependency for wiki "
+                    + "component [{}]. Root cause is [{}]", cd.getRoleType(), cd.getRoleHint(),
+                    this.wikiComponent.getDocumentReference(), ExceptionUtils.getRootCauseMessage(e));
             }
             methodContext.put(dependency.getKey(), componentDependency);
         }

--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/DefaultWikiComponentManagerEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/DefaultWikiComponentManagerEventListener.java
@@ -125,13 +125,14 @@ public class DefaultWikiComponentManagerEventListener extends AbstractEventListe
                         List<WikiComponent> components = provider.buildComponents(reference);
                         this.wikiComponentManagerEventListenerHelper.registerComponentList(components);
                     } catch (WikiComponentException e) {
-                        this.logger.warn("Failed to build the wiki component located in the document [{}]: {}",
+                        this.logger.warn("Failed to build the wiki component located in the document [{}]: [{}]",
                                 reference, ExceptionUtils.getRootCauseMessage(e));
                     }
                 }
             }
         } catch (ComponentLookupException e) {
-            this.logger.warn(String.format("Unable to get a list of registered WikiComponentBuilder: %s", e));
+            this.logger.warn("Unable to get a list of registered WikiComponentBuilder: [{}]",
+                ExceptionUtils.getRootCauseMessage(e));
         }
     }
 
@@ -156,7 +157,7 @@ public class DefaultWikiComponentManagerEventListener extends AbstractEventListe
                     List<WikiComponent> components = provider.buildComponents(documentReference);
                     this.wikiComponentManagerEventListenerHelper.registerComponentList(components);
                 } catch (WikiComponentException e) {
-                    this.logger.warn("Failed to create wiki component(s) for document [{}]: {}", documentReference,
+                    this.logger.warn("Failed to create wiki component(s) for document [{}]: [{}]", documentReference,
                             ExceptionUtils.getRootCauseMessage(e));
                 }
                 break;

--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/WikiComponentManagerEventListenerHelper.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/WikiComponentManagerEventListenerHelper.java
@@ -66,7 +66,7 @@ public class WikiComponentManagerEventListenerHelper
             try {
                 this.wikiComponentManager.registerWikiComponent(component);
             } catch (WikiComponentException e) {
-                this.logger.warn("Unable to register component(s) from document [{}]: {}",
+                this.logger.warn("Unable to register component(s) from document [{}]: [{}]",
                         component.getDocumentReference(), ExceptionUtils.getRootCauseMessage(e));
             }
         }
@@ -82,7 +82,7 @@ public class WikiComponentManagerEventListenerHelper
         try {
             this.wikiComponentManager.unregisterWikiComponents(entityReference);
         } catch (WikiComponentException e) {
-            this.logger.warn("Unable to unregister component(s) from the entity [{}]: {}", entityReference,
+            this.logger.warn("Unable to unregister component(s) from the entity [{}]: [{}]", entityReference,
                     ExceptionUtils.getRootCauseMessage(e));
         }
     }

--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/bridge/DefaultWikiObjectComponentManagerEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/bridge/DefaultWikiObjectComponentManagerEventListener.java
@@ -180,8 +180,8 @@ public class DefaultWikiObjectComponentManagerEventListener extends AbstractEven
              * As we test if a component is present in the component manager before fetching it, we shouldn't get any
              * exception at this point.
              */
-            this.logger.error(String.format(
-                "Unable to find a WikiObjectComponentBuilder associated to the helper [%s]: %s", xClassReference, e));
+            this.logger.error("Unable to find a WikiObjectComponentBuilder associated to the helper [{}]",
+                xClassReference, e);
 
             return null;
         }

--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/bridge/WikiObjectComponentManagerEventListenerProxy.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/bridge/WikiObjectComponentManagerEventListenerProxy.java
@@ -145,8 +145,8 @@ public class WikiObjectComponentManagerEventListenerProxy
                     }
                 }
             } catch (Exception e) {
-                logger.warn(String.format("Unable to register the components for [%s] XObjects: %s", xObjectClass,
-                    ExceptionUtils.getRootCauseMessage(e)));
+                logger.warn("Unable to register the components for [{}] XObjects: [{}]", xObjectClass,
+                    ExceptionUtils.getRootCauseMessage(e));
             }
         }
     }
@@ -182,8 +182,8 @@ public class WikiObjectComponentManagerEventListenerProxy
 
             this.wikiComponentManagerEventListenerHelper.registerComponentList(wikiComponents);
         } catch (WikiComponentException e) {
-            logger.warn(String.format("Unable to register the component associated to [%s]: %s", objectReference,
-                ExceptionUtils.getRootCauseMessage(e)));
+            logger.warn("Unable to register the component associated to [{}]: [{}]", objectReference,
+                ExceptionUtils.getRootCauseMessage(e));
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/AbstractRecordableEventDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/AbstractRecordableEventDescriptor.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.component.manager.NamespacedComponentManager;
@@ -92,7 +93,8 @@ public abstract class AbstractRecordableEventDescriptor implements RecordableEve
                         () -> contextualLocalizationManager.getTranslationPlain(key));
                 } catch (Exception e) {
                     logger.warn("Failed to render the translation key [{}] in the namespace [{}] for the event "
-                            + "descriptor of [{}].", key, namespaceOfTheDescriptor, getEventType(), e);
+                            + "descriptor of [{}]. Root cause is [{}]", key, namespaceOfTheDescriptor, getEventType(),
+                        ExceptionUtils.getRootCauseMessage(e));
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/AbstractAsynchronousEventStore.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/AbstractAsynchronousEventStore.java
@@ -32,6 +32,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.descriptor.ComponentDescriptor;
 import org.xwiki.component.manager.ComponentLifecycleException;
@@ -314,8 +315,8 @@ public abstract class AbstractAsynchronousEventStore implements EventStore, Init
             try {
                 firstTask = this.queue.take();
             } catch (InterruptedException e) {
-                this.logger.warn("The thread handling asynchronous storage for event store [{}] has been interrupted",
-                    this.descriptor.getRoleHint(), e);
+                this.logger.warn("The thread handling asynchronous storage for event store [{}] has been interrupted. "
+                    + "Root cause is [{}]", this.descriptor.getRoleHint(), ExceptionUtils.getRootCauseMessage(e));
 
                 Thread.currentThread().interrupt();
                 break;
@@ -575,8 +576,8 @@ public abstract class AbstractAsynchronousEventStore implements EventStore, Init
         try {
             this.thread.join(10000);
         } catch (InterruptedException e) {
-            this.logger.warn("The thread handling asynchronous storage for event store [{}] has been interrupted",
-                this.descriptor.getRoleHint(), e);
+            this.logger.warn("The thread handling asynchronous storage for event store [{}] has been interrupted. "
+                + "Root cause is [{}]", this.descriptor.getRoleHint(), ExceptionUtils.getRootCauseMessage(e));
 
             this.thread.interrupt();
         }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/AbstractRecordableEventDescriptorTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/AbstractRecordableEventDescriptorTest.java
@@ -138,12 +138,14 @@ class AbstractRecordableEventDescriptorTest
                 fakeRecordableEventDescriptor.getDescription());
         assertEquals(1, this.logCapture.size());
         assertEquals("Failed to render the translation key [descriptionKey] in the namespace [wiki:subwiki] "
-                + "for the event descriptor of [fake].", this.logCapture.getMessage(0));
+                + "for the event descriptor of [fake]. Root cause is [Exception: some error]",
+            this.logCapture.getMessage(0));
         assertEquals("My nice application name",
                 fakeRecordableEventDescriptor.getApplicationName());
         assertEquals(2, this.logCapture.size());
         assertEquals("Failed to render the translation key [applicationKey] in the namespace [wiki:subwiki] "
-                + "for the event descriptor of [fake].", this.logCapture.getMessage(1));
+                + "for the event descriptor of [fake]. Root cause is [Exception: some error]",
+            this.logCapture.getMessage(1));
     }
 
     private class OtherFakeRecordableEventDescriptor extends AbstractRecordableEventDescriptor

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/main/java/org/xwiki/eventstream/internal/DefaultUntypedRecordableEventDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/main/java/org/xwiki/eventstream/internal/DefaultUntypedRecordableEventDescriptor.java
@@ -22,6 +22,7 @@ package org.xwiki.eventstream.internal;
 import java.lang.reflect.Type;
 import java.util.List;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.component.namespace.Namespace;
@@ -304,7 +305,8 @@ public class DefaultUntypedRecordableEventDescriptor implements UntypedRecordabl
             );
         } catch (Exception e) {
             LOGGER.warn("Failed to render the translation key [{}] in the namespace [{}] for the event "
-                    + "descriptor of [{}].", key, namespaceOfTheDescriptor, getEventType(), e);
+                    + "descriptor of [{}]. Root cause is [{}]", key, namespaceOfTheDescriptor, getEventType(),
+                ExceptionUtils.getRootCauseMessage(e));
             return contextualLocalizationManager.getTranslationPlain(key);
         }
     }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/main/java/org/xwiki/eventstream/internal/UntypedEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/main/java/org/xwiki/eventstream/internal/UntypedEventListener.java
@@ -31,6 +31,7 @@ import javax.inject.Singleton;
 import javax.script.ScriptContext;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentLookupException;
@@ -201,7 +202,8 @@ public class UntypedEventListener extends AbstractEventListener
             return "true".equals(render);
 
         } catch (Exception e) {
-            logger.warn("Unable to render a notification validation template.", e);
+            logger.warn("Unable to render a notification validation template. Root cause is [{}]",
+                ExceptionUtils.getRootCauseMessage(e));
             return false;
         }
     }
@@ -230,7 +232,8 @@ public class UntypedEventListener extends AbstractEventListener
             }
 
         } catch (Exception e) {
-            logger.warn("Unable to render the target template.", e);
+            logger.warn("Unable to render the target template. Root cause is [{}]",
+                ExceptionUtils.getRootCauseMessage(e));
         }
 
         // Fallback to empty set

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/test/java/org/xwiki/eventstream/internal/DefaultUntypedRecordableEventDescriptorTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/test/java/org/xwiki/eventstream/internal/DefaultUntypedRecordableEventDescriptorTest.java
@@ -181,7 +181,8 @@ class DefaultUntypedRecordableEventDescriptorTest
             .thenThrow(new Exception("Some error"));
         assertEquals("applicationName", this.descriptor.getApplicationName());
         assertEquals("Failed to render the translation key [applicationName] in the namespace "
-            + "[wiki:someWiki] for the event descriptor of [eventType].", this.logCapture.getMessage(0));
+            + "[wiki:someWiki] for the event descriptor of [eventType]. Root cause is [Exception: Some error]",
+            this.logCapture.getMessage(0));
     }
 
     @Test
@@ -194,6 +195,7 @@ class DefaultUntypedRecordableEventDescriptorTest
         when(this.namespaceContextExecutor.execute(any(Namespace.class), any(Callable.class))).thenThrow(e);
         assertEquals("eventDescription", this.descriptor.getDescription());
         assertEquals("Failed to render the translation key [eventDescription] in the namespace "
-            + "[wiki:someWiki] for the event descriptor of [eventType].", this.logCapture.getMessage(0));
+            + "[wiki:someWiki] for the event descriptor of [eventType]. Root cause is [Exception: Some error]",
+            this.logCapture.getMessage(0));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-common/src/main/java/org/xwiki/eventstream/store/internal/DocumentEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-common/src/main/java/org/xwiki/eventstream/store/internal/DocumentEventListener.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.annotation.event.AnnotationAddedEvent;
 import org.xwiki.annotation.event.AnnotationDeletedEvent;
@@ -123,7 +124,8 @@ public class DocumentEventListener extends AbstractEventListener
             }
 
         } catch (Exception e) {
-            logger.warn("Failed to save the event [{}].", event.getClass().getCanonicalName(), e);
+            logger.warn("Failed to save the event [{}]. Root cause is [{}]", event.getClass().getCanonicalName(),
+                ExceptionUtils.getRootCauseMessage(e));
         } finally {
             this.execution.getContext().removeProperty(AbstractEventStreamEvent.EVENT_LOOP_CONTEXT_LOCK_PROPERTY);
         }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-common/src/main/java/org/xwiki/eventstream/store/internal/RecordableEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-common/src/main/java/org/xwiki/eventstream/store/internal/RecordableEventListener.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentManager;
@@ -96,11 +97,13 @@ public class RecordableEventListener extends AbstractEventListener
         try {
             this.eventStore.saveEvent(convertEvent(event, source, data)).whenComplete((e, ex) -> {
                 if (ex != null) {
-                    logger.warn("Failed to save the event [{}].", event.getClass().getCanonicalName(), ex);
+                    logger.warn("Failed to save the event [{}]. Root cause is [{}]",
+                        event.getClass().getCanonicalName(), ExceptionUtils.getRootCauseMessage(ex));
                 }
             });
         } catch (Exception e) {
-            logger.warn("Failed to convert event [{}].", event.getClass().getCanonicalName(), e);
+            logger.warn("Failed to convert event [{}]. Root cause is [{}]", event.getClass().getCanonicalName(),
+                ExceptionUtils.getRootCauseMessage(e));
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-distribution/src/main/java/org/xwiki/extension/distribution/internal/DefaultDistributionManager.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-distribution/src/main/java/org/xwiki/extension/distribution/internal/DefaultDistributionManager.java
@@ -289,7 +289,7 @@ public class DefaultDistributionManager implements DistributionManager, Initiali
                 return (DistributionJob) this.jobExecutor.execute(DefaultDistributionJob.HINT, request);
             }
         } catch (Exception e) {
-            this.logger.error("Failed to create distribution job for wiki [" + wiki + "]", e);
+            this.logger.error("Failed to create distribution job for wiki [{}]", wiki, e);
         }
 
         return null;

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/handler/XarExtensionJobFinishedListener.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/handler/XarExtensionJobFinishedListener.java
@@ -34,6 +34,7 @@ import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.extension.ExtensionContext;
@@ -190,8 +191,8 @@ public class XarExtensionJobFinishedListener implements EventListener
                             }
                         }
                     } catch (Exception e) {
-                        this.logger.warn("Exception when cleaning pages removed since previous xar extension version",
-                            e);
+                        this.logger.warn("Exception when cleaning pages removed since previous xar extension version. "
+                            + "Root cause is [{}]", ExceptionUtils.getRootCauseMessage(e));
                     }
                 }
             }
@@ -260,7 +261,8 @@ public class XarExtensionJobFinishedListener implements EventListener
                 try {
                     job.getStatus().ask(question);
                 } catch (InterruptedException e) {
-                    this.logger.warn("The thread has been interrupted", e);
+                    this.logger.warn("The thread has been interrupted. Root cause is [{}]",
+                        ExceptionUtils.getRootCauseMessage(e));
 
                     // The thread has been interrupted, do nothing
                     return;

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/job/RepairXarJob.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/job/RepairXarJob.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.extension.Extension;
 import org.xwiki.extension.ExtensionDependency;
@@ -321,7 +322,8 @@ public class RepairXarJob extends AbstractExtensionJob<InstallRequest, DefaultJo
                             extensionDependency.getVersionConstraint().getVersion()),
                         namespace, true, new ExtensionPlanContext(extensionContext, extensionDependency));
                 } catch (InstallException e) {
-                    this.logger.warn("Failed to repair dependency [{}]", extensionDependency, e);
+                    this.logger.warn("Failed to repair dependency [{}]. Root cause is [{}]", extensionDependency,
+                        ExceptionUtils.getRootCauseMessage(e));
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/job/diff/AbstractUnifiedDiffBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/job/diff/AbstractUnifiedDiffBuilder.java
@@ -109,7 +109,7 @@ public abstract class AbstractUnifiedDiffBuilder
             return this.unifiedDiffDisplayer.display(diffResult, config);
         } catch (DiffException e) {
             this.logger
-                .warn("Failed to compute the differences. Root cause: {}", ExceptionUtils.getRootCauseMessage(e));
+                .warn("Failed to compute the differences. Root cause: [{}]", ExceptionUtils.getRootCauseMessage(e));
             return Collections.emptyList();
         }
     }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/job/diff/AttachmentUnifiedDiffBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/job/diff/AttachmentUnifiedDiffBuilder.java
@@ -131,7 +131,7 @@ public class AttachmentUnifiedDiffBuilder extends AbstractUnifiedDiffBuilder
                 nextContent = nextAttachment.getContentInputStream(xcontext);
                 return IOUtils.contentEquals(previousContent, nextContent);
             } catch (Exception e) {
-                this.logger.warn("Failed to compare the content of attachment [{}]. Root cause: {}",
+                this.logger.warn("Failed to compare the content of attachment [{}]. Root cause: [{}]",
                     previousAttachment.getFilename(), ExceptionUtils.getRootCauseMessage(e));
                 return false;
             } finally {
@@ -155,7 +155,7 @@ public class AttachmentUnifiedDiffBuilder extends AbstractUnifiedDiffBuilder
             try (InputStream stream = attachment.getContentInputStream(this.xcontextProvider.get())) {
                 return IOUtils.toString(stream);
             } catch (Exception e) {
-                this.logger.warn("Failed to read the content of attachment [{}]. Root cause: {}",
+                this.logger.warn("Failed to read the content of attachment [{}]. Root cause: [{}]",
                     attachment.getFilename(), ExceptionUtils.getRootCauseMessage(e));
             }
         }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/DefaultExtensionIndex.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/DefaultExtensionIndex.java
@@ -104,7 +104,7 @@ public class DefaultExtensionIndex extends AbstractAdvancedSearchableExtensionRe
         try {
             return this.store.getSolrExtension(extensionId);
         } catch (Exception e) {
-            this.logger.warn("Failed to get the extension [{}] from the index: {}", extensionId,
+            this.logger.warn("Failed to get the extension [{}] from the index: [{}]", extensionId,
                 ExceptionUtils.getRootCauseMessage(e));
         }
 

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/job/ExtensionIndexJob.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/job/ExtensionIndexJob.java
@@ -579,7 +579,7 @@ public class ExtensionIndexJob extends AbstractJob<ExtensionIndexRequest, Defaul
                 try {
                     updated |= addRemoteExtensions(searchableRepository, indexedExtensions);
                 } catch (Exception e) {
-                    this.logger.warn("Failed to get remote extension from repository [{}]: {}",
+                    this.logger.warn("Failed to get remote extension from repository [{}]: [{}]",
                         repository.getDescriptor(), ExceptionUtils.getRootCauseMessage(e));
                 }
             }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-velocity/src/main/java/org/xwiki/rendering/internal/macro/velocity/filter/HTMLVelocityMacroFilter.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-velocity/src/main/java/org/xwiki/rendering/internal/macro/velocity/filter/HTMLVelocityMacroFilter.java
@@ -171,7 +171,7 @@ public class HTMLVelocityMacroFilter implements VelocityMacroFilter, Initializab
                     continue;
                 }
             } catch (InvalidVelocityException e) {
-                this.logger.debug("Not a valid velocity keyword at char [" + i + "]", e);
+                this.logger.debug("Not a valid velocity keyword at char [{}]", i, e);
             }
 
             flushWhiteSpaces(contentBuffer, filterContext, false);

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/internal/macro/wikibridge/WikiMacroEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/internal/macro/wikibridge/WikiMacroEventListener.java
@@ -123,7 +123,7 @@ public class WikiMacroEventListener implements EventListener
             try {
                 wikiMacro = this.macroFactory.createWikiMacro(documentReference);
             } catch (WikiMacroException e) {
-                this.logger.error(String.format("Failed to create wiki macro [%s]", documentReference), e);
+                this.logger.error("Failed to create wiki macro [{}]", documentReference, e);
                 return;
             }
             if (wikiMacro != null) {
@@ -149,11 +149,11 @@ public class WikiMacroEventListener implements EventListener
         try {
             this.wikiMacroManager.registerWikiMacro(documentReference, wikiMacro);
         } catch (WikiMacroException e) {
-            this.logger.debug(String.format("Unable to register macro [%s] in document [%s]",
-                wikiMacro.getDescriptor().getId().getId(), documentReference), e);
+            this.logger.debug("Unable to register macro [{}] in document [{}]",
+                wikiMacro.getDescriptor().getId().getId(), documentReference, e);
         } catch (InsufficientPrivilegesException e) {
-            this.logger.debug(String.format("Insufficient privileges for registering macro [%s] in document [%s]",
-                wikiMacro.getDescriptor().getId().getId(), documentReference), e);
+            this.logger.debug("Insufficient privileges for registering macro [{}] in document [{}]",
+                wikiMacro.getDescriptor().getId().getId(), documentReference, e);
         }
     }
 
@@ -170,7 +170,7 @@ public class WikiMacroEventListener implements EventListener
             try {
                 this.wikiMacroManager.unregisterWikiMacro(documentReference);
             } catch (WikiMacroException e) {
-                this.logger.debug(String.format("Unable to unregister macro in document [%s]", documentReference), e);
+                this.logger.debug("Unable to unregister macro in document [{}]", documentReference, e);
                 result = false;
             }
         }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroInitializer.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.context.Execution;
@@ -184,7 +185,8 @@ public class DefaultWikiMacroInitializer implements WikiMacroInitializer, WikiMa
                 registerMacro(wikiMacroDocumentReference, (String) wikiMacroDocumentData[2], xcontext);
             }
         } catch (Exception ex) {
-            this.logger.warn("Failed to register macros for wiki [{}]: {}", wikiName, ex.getMessage());
+            this.logger.warn("Failed to register macros for wiki [{}]: [{}]", wikiName,
+                ExceptionUtils.getRootCauseMessage(ex));
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/RegisterMacrosOnImportListener.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/RegisterMacrosOnImportListener.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.context.Execution;
@@ -102,7 +103,8 @@ public class RegisterMacrosOnImportListener implements EventListener
             String currentWiki = xcontext.getWikiId();
             macroInitializer.registerExistingWikiMacros(currentWiki);
         } catch (Exception e) {
-            this.logger.warn("Could not register existing macros on import", e);
+            this.logger.warn("Could not register existing macros on import. Root cause is [{}]",
+                ExceptionUtils.getRootCauseMessage(e));
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/java/org/xwiki/security/authentication/internal/DefaultAuthenticationFailureManager.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/java/org/xwiki/security/authentication/internal/DefaultAuthenticationFailureManager.java
@@ -138,7 +138,7 @@ public class DefaultAuthenticationFailureManager implements AuthenticationFailur
                 this.failureStrategyList
                     .add(this.componentManager.getInstance(AuthenticationFailureStrategy.class, failureStrategyName));
             } catch (ComponentLookupException e) {
-                logger.error("Error while getting authentication failure strategy [{}]. ", failureStrategyName, e);
+                logger.error("Error while getting authentication failure strategy [{}].", failureStrategyName, e);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/java/org/xwiki/security/authentication/internal/R140600000XWIKI19869DataMigrationListener.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/java/org/xwiki/security/authentication/internal/R140600000XWIKI19869DataMigrationListener.java
@@ -170,7 +170,7 @@ public class R140600000XWIKI19869DataMigrationListener extends AbstractEventList
             this.logger.warn("Error when handling user [{}] for sending security and/or reset password email: [{}]",
                 userReference,
                 ExceptionUtils.getRootCauseMessage(e));
-            this.logger.debug("Full stack trace for the reset password request: ", e);
+            this.logger.debug("Full stack trace for the reset password request:", e);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/DefaultAuthorizationManager.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/DefaultAuthorizationManager.java
@@ -115,9 +115,9 @@ public class DefaultAuthorizationManager implements AuthorizationManager
         try {
             return hasSecurityAccess(right, userReference, entityReference, false);
         } catch (Exception e) {
-            this.logger.error(String.format("Failed to load rights for user [%s] on [%s].",
+            this.logger.error("Failed to load rights for user [{}] on [{}].",
                 (userReference == null) ? AuthorizationException.NULL_USER : userReference,
-                (entityReference == null) ? AuthorizationException.NULL_ENTITY : entityReference), e);
+                (entityReference == null) ? AuthorizationException.NULL_ENTITY : entityReference, e);
             return false;
         }
     }
@@ -269,7 +269,7 @@ public class DefaultAuthorizationManager implements AuthorizationManager
             if (entry == null) {
                 SecurityAccess access = securityCacheLoader.load(user, entity).getAccess();
 
-                this.logger.debug("1. Loaded a new entry for user {} on {} into cache: [{}]", user, entity, access);
+                this.logger.debug("1. Loaded a new entry for user [{}] on [{}] into cache: [{}]", user, entity, access);
 
                 return access;
             }
@@ -278,13 +278,13 @@ public class DefaultAuthorizationManager implements AuthorizationManager
                 if (accessEntry == null) {
                     SecurityAccess access = securityCacheLoader.load(user, entity).getAccess();
 
-                    logger.debug("2. Loaded a new entry for user {} on {} into cache: [{}]", user, entity, access);
+                    logger.debug("2. Loaded a new entry for user [{}] on [{}] into cache: [{}]", user, entity, access);
 
                     return access;
                 } else {
                     SecurityAccess access = accessEntry.getAccess();
 
-                    logger.debug("3. Got entry for user {} on {} from cache: [{}]", user, entity, access);
+                    logger.debug("3. Got entry for user [{}] on [{}] from cache: [{}]", user, entity, access);
 
                     return access;
                 }
@@ -293,7 +293,7 @@ public class DefaultAuthorizationManager implements AuthorizationManager
 
         SecurityAccess access = securityCacheLoader.load(user, entity).getAccess();
 
-        logger.debug("4. Loaded a new default entry for user {} on {} into cache: [{}]", user, entity, access);
+        logger.debug("4. Loaded a new default entry for user [{}] on [{}] into cache: [{}]", user, entity, access);
 
         return access;
     }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/main/java/org/xwiki/security/internal/DocumentInitializerRightsManager.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/main/java/org/xwiki/security/internal/DocumentInitializerRightsManager.java
@@ -101,8 +101,8 @@ public class DocumentInitializerRightsManager
             setRights(object, rights);
             updated = true;
         } catch (XWikiException e) {
-            this.logger.error(String.format("Error adding a [%s] object to the document [%s]", LOCAL_CLASS_REFERENCE,
-                document.getDocumentReference()));
+            this.logger.error("Error adding a [{}] object to the document [{}]", LOCAL_CLASS_REFERENCE,
+                document.getDocumentReference(), e);
         }
 
         return updated;

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/analyzer/DefaultMacroBlockRequiredRightAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/analyzer/DefaultMacroBlockRequiredRightAnalyzer.java
@@ -201,7 +201,7 @@ public class DefaultMacroBlockRequiredRightAnalyzer extends AbstractMacroBlockRe
             this.logger.warn(
                 "The macro block required rights analyzer for macro [{}] failed to be initialized, root cause: [{}]",
                 macroId, ExceptionUtils.getRootCauseMessage(e));
-            this.logger.debug("Full exception trace: ", e);
+            this.logger.debug("Full exception trace:", e);
         }
 
         return Optional.empty();


### PR DESCRIPTION
Continues the repo-wide logging best-practices audit
(<https://dev.xwiki.org/xwiki/bin/view/Community/CodeStyle/JavaCodeStyle/#HLoggingBestPractices>),
after #6055, #6056, #6057, #6058, #6059 and #6060.

This one bundles several modules instead of one per PR: **46 call sites** across
`xwiki-platform-component` (11), `xwiki-platform-extension` (9), `xwiki-platform-security` (9),
`xwiki-platform-eventstream` (9) and `xwiki-platform-rendering` (8).

## What changed

* **`String.format()` / string concatenation in the message** → `{}` placeholders + arguments.
* **`warn()` passing a Throwable** → the Throwable leaves the SLF4J slot (stack traces are reserved
  for `error()`) and the cause is appended as `ExceptionUtils.getRootCauseMessage(e)`. `error()`
  calls keep their Throwable — several of them now log it for the first time, because the old
  `String.format(...)` form passed the exception as a `%s` argument or dropped it entirely
  (`DocumentInitializerRightsManager`, `DefaultWikiObjectComponentManagerEventListener`,
  `DefaultWikiComponentInvocationHandler`).
* **Bare `{}` placeholders** wrapped in `[]` — the four cache-debug messages of
  `DefaultAuthorizationManager`, and the `: {}` root-cause suffixes.
* **Trailing whitespace** trimmed from three messages.

## Tests

`AbstractRecordableEventDescriptorTest` and `DefaultUntypedRecordableEventDescriptorTest` compare
the rendered message via `LogCaptureExtension`; their assertions now include the appended root
cause.

## Verification

For each of the five modules, run from the module directory:

* `mvn -B -ntp test` — pass.
* `mvn -B -ntp checkstyle:check -Plegacy,quality` — pass.
