### PR TITLE
[Misc] Apply the logging best practices to 15 more platform modules

### DIFF
--- a/xwiki-platform-core/xwiki-platform-configuration/xwiki-platform-configuration-default/src/main/java/org/xwiki/configuration/internal/XWikiPropertiesConfigurationSource.java
+++ b/xwiki-platform-core/xwiki-platform-configuration/xwiki-platform-configuration-default/src/main/java/org/xwiki/configuration/internal/XWikiPropertiesConfigurationSource.java
@@ -32,6 +32,7 @@ import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
 import org.apache.commons.configuration2.builder.fluent.Parameters;
 import org.apache.commons.configuration2.convert.DefaultListDelimiterHandler;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.phase.InitializationException;
@@ -87,7 +88,8 @@ public class XWikiPropertiesConfigurationSource extends AbstractCommonsConfigura
             } catch (Exception e) {
                 // Note: if we cannot read the configuration file for any reason we log a warning but continue since
                 // XWiki will use default values for all configurable elements.
-                this.logger.warn("Failed to load configuration file [{}]: {}", file, e.getMessage());
+                this.logger.warn("Failed to load configuration file [{}]: [{}]", file,
+                    ExceptionUtils.getRootCauseMessage(e));
             }
         }
 
@@ -114,7 +116,7 @@ public class XWikiPropertiesConfigurationSource extends AbstractCommonsConfigura
             // will use default values for all configurable elements.
             this.logger.warn(
                 "Failed to load configuration file [{}]. Using default configuration values. Internal error [{}]",
-                XWIKI_PROPERTIES_WARPATH, e.getMessage());
+                XWIKI_PROPERTIES_WARPATH, ExceptionUtils.getRootCauseMessage(e));
         }
 
         // If no Commons Properties Configuration has been set, use a default empty Commons Configuration

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/main/java/org/xwiki/display/internal/AbstractDocumentTitleDisplayer.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/main/java/org/xwiki/display/internal/AbstractDocumentTitleDisplayer.java
@@ -29,6 +29,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.bridge.DocumentAccessBridge;
 import org.xwiki.bridge.DocumentModelBridge;
@@ -157,7 +158,8 @@ public abstract class AbstractDocumentTitleDisplayer implements DocumentDisplaye
 
                 return parseTitle(title);
             } catch (Exception e) {
-                logger.warn("Failed to interpret title of document [{}].", document.getDocumentReference(), e);
+                logger.warn("Failed to interpret title of document [{}]. Root cause is [{}]",
+                    document.getDocumentReference(), ExceptionUtils.getRootCauseMessage(e));
             }
         }
 
@@ -169,8 +171,8 @@ public abstract class AbstractDocumentTitleDisplayer implements DocumentDisplaye
                     return title;
                 }
             } catch (Exception e) {
-                logger.warn("Failed to extract title from content of document [{}].", document.getDocumentReference(),
-                    e);
+                logger.warn("Failed to extract title from content of document [{}]. Root cause is [{}]",
+                    document.getDocumentReference(), ExceptionUtils.getRootCauseMessage(e));
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/main/java/org/xwiki/display/internal/DocumentContentAsyncExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/main/java/org/xwiki/display/internal/DocumentContentAsyncExecutor.java
@@ -295,7 +295,7 @@ public class DocumentContentAsyncExecutor
                 // Failed to get the Velocity Engine and thus to clear Velocity Macro cache. Log this as a warning but
                 // continue since it's not absolutely critical.
                 this.logger.warn("Failed to notify Velocity Macro cache for closing the [{}] namespace. Reason = [{}]",
-                    this.transformationId, e.getMessage());
+                    this.transformationId, ExceptionUtils.getRootCauseMessage(e));
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
@@ -36,6 +36,7 @@ import java.util.Vector;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.cache.Cache;
@@ -415,7 +416,7 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
                     }
                     map.put(feedDocName, e);
                     // and log it
-                    LOGGER.error("Failed to update feeds in document " + feedDocName, e);
+                    LOGGER.error("Failed to update feeds in document [{}]", feedDocName, e);
                 }
             }
         }
@@ -680,7 +681,7 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
             // If some day wiki syntax is supported in document titles, we might want to convert to wiki syntax instead.
             title = this.stripHtmlTags(entry.getTitle());
         } catch (ConversionException e) {
-            LOGGER.warn("Failed to strip HTML tags from entry title : " + e.getMessage());
+            LOGGER.warn("Failed to strip HTML tags from entry title: [{}]", ExceptionUtils.getRootCauseMessage(e));
             // Nevermind, we will use the original title
             title = entry.getTitle();
         }

--- a/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/util/TidyMessageLogger.java
+++ b/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/util/TidyMessageLogger.java
@@ -41,7 +41,7 @@ public class TidyMessageLogger implements TidyMessageListener
         // All JTidy messages should be considered as DEBUG messages since they're not causing any problem with XWiki
         // per see. However if the code calling Tidy need to do something different based on the fact that the
         // tidying generated errors or warnings, it should act on tidy.getParseErrors() or tidy.getParseWarnings().
-        this.logger.debug("[JTidy] line {} column {} - {}", message.getLine(), message.getColumn(),
+        this.logger.debug("[JTidy] line [{}] column [{}] - [{}]", message.getLine(), message.getColumn(),
             message.getMessage());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/main/java/org/xwiki/test/SecurityCachePerformanceTestScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/main/java/org/xwiki/test/SecurityCachePerformanceTestScriptService.java
@@ -110,7 +110,7 @@ public class SecurityCachePerformanceTestScriptService implements ScriptService
 
         // Perform two runs to have some warm-up for the caches.
         for (Integer i : List.of(100, 200)) {
-            this.logger.warn("Test run with {} pages.", i);
+            this.logger.warn("Test run with [{}] pages.", i);
             logResults(performTest(i, allPages, userReferences, errorOutput));
         }
 
@@ -193,7 +193,7 @@ public class SecurityCachePerformanceTestScriptService implements ScriptService
         throws XWikiException
     {
         List<Double> saveTimes = new ArrayList<>();
-        this.logger.warn("Starting {} updates of rights.", pagesToUpdate.size());
+        this.logger.warn("Starting [{}] updates of rights.", pagesToUpdate.size());
         XWikiContext context = this.contextProvider.get();
         XWiki apiWiki = new XWiki(context.getWiki(), context);
 
@@ -319,7 +319,7 @@ public class SecurityCachePerformanceTestScriptService implements ScriptService
     private void logResults(Map<String, Double> results)
     {
         for (Map.Entry<String, Double> result : results.entrySet()) {
-            this.logger.warn("\t{}: {}", result.getKey(), result.getValue());
+            this.logger.warn("\t[{}]: [{}]", result.getKey(), result.getValue());
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-plugin/src/main/java/com/xpn/xwiki/plugin/image/ImagePlugin.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-plugin/src/main/java/com/xpn/xwiki/plugin/image/ImagePlugin.java
@@ -154,9 +154,9 @@ public class ImagePlugin extends XWikiDefaultPlugin
                 try {
                     this.capacity = Integer.parseInt(capacityParam.trim());
                 } catch (NumberFormatException e) {
-                    LOG.warn(String.format(
-                        "Failed to parse xwiki.plugin.image.cache.capacity configuration parameter. "
-                            + "Using %s as the cache capacity.", this.capacity), e);
+                    LOG.warn("Failed to parse the [xwiki.plugin.image.cache.capacity] configuration parameter. "
+                        + "Using [{}] as the cache capacity. Root cause is [{}]", this.capacity,
+                        ExceptionUtils.getRootCauseMessage(e));
                 }
             }
             lru.setMaxEntries(this.capacity);
@@ -224,7 +224,7 @@ public class ImagePlugin extends XWikiDefaultPlugin
                     LOG.warn("Failed to transform image attachment [{}] for scaling, falling back to original "
                         + "attachment. Root error: [{}]", attachment.getFilename(),
                         ExceptionUtils.getRootCauseMessage(e));
-                    LOG.debug("Full stack trace for image attachment scaling error: ", e);
+                    LOG.debug("Full stack trace for image attachment scaling error:", e);
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-plugin/src/main/java/com/xpn/xwiki/plugin/image/ImagePluginAPI.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-plugin/src/main/java/com/xpn/xwiki/plugin/image/ImagePluginAPI.java
@@ -70,7 +70,7 @@ public class ImagePluginAPI extends PluginApi<ImagePlugin>
         try {
             return getProtectedPlugin().getHeight(getAttachment(pageName, attachmentName), getXWikiContext());
         } catch (Exception e) {
-            LOG.error(String.format("Failed to detect the height of %s attached to %s.", attachmentName, pageName), e);
+            LOG.error("Failed to detect the height of [{}] attached to [{}].", attachmentName, pageName, e);
             return -1;
         }
     }
@@ -87,7 +87,7 @@ public class ImagePluginAPI extends PluginApi<ImagePlugin>
         try {
             return getProtectedPlugin().getWidth(getAttachment(pageName, attachmentName), getXWikiContext());
         } catch (Exception e) {
-            LOG.error(String.format("Failed to detect the width of %s attached to %s.", attachmentName, pageName), e);
+            LOG.error("Failed to detect the width of [{}] attached to [{}].", attachmentName, pageName, e);
             return -1;
         }
     }

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/AbstractMailListener.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/AbstractMailListener.java
@@ -78,7 +78,7 @@ public abstract class AbstractMailListener implements MailListener
     @Override
     public void onPrepareFatalError(Exception exception, Map<String, Object> parameters)
     {
-        logger.debug("Failure during preparation phase of thread [" + batchId + "]");
+        logger.debug("Failure during preparation phase of thread [{}]", batchId, exception);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/MailConfigMandatoryDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/MailConfigMandatoryDocumentInitializer.java
@@ -189,9 +189,8 @@ public class MailConfigMandatoryDocumentInitializer implements MandatoryDocument
                 }
                 needsUpdate = true;
             } catch (XWikiException e) {
-                this.logger.error(
-                    String.format("Error adding a [%s] object to the document [%s]",
-                        classReference.toString(), document.getDocumentReference().toString()));
+                this.logger.error("Error adding a [{}] object to the document [{}]", classReference,
+                    document.getDocumentReference(), e);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/MemoryMailListener.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/MemoryMailListener.java
@@ -72,7 +72,7 @@ public class MemoryMailListener extends AbstractMailListener
         super.onPrepareFatalError(exception, parameters);
 
         //TODO: Store failure exception
-        logger.error("Failure during preparation phase of thread [" + getBatchId() + "]");
+        logger.error("Failure during preparation phase of thread [{}]", getBatchId(), exception);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/factory/html/HTMLMimeBodyPartFactory.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/factory/html/HTMLMimeBodyPartFactory.java
@@ -128,7 +128,7 @@ public class HTMLMimeBodyPartFactory extends AbstractMimeBodyPartFactory<String>
                     this.attachmentPartFactory.create(attachment, Collections.<String, Object>emptyMap()));
             } catch (MessagingException e) {
                 // There is no reason to fail the whole mail for a broken attachment
-                this.logger.warn("Failed to add attachment [{}@{}] to the mail: {}",
+                this.logger.warn("Failed to add attachment [{}@{}] to the mail: [{}]",
                     attachment.getDocument().getDocumentReference(), attachment.getFilename(),
                     ExceptionUtils.getRootCauseMessage(e));
             }

--- a/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/main/java/org/xwiki/observation/remote/internal/DefaultRemoteObservationManager.java
+++ b/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/main/java/org/xwiki/observation/remote/internal/DefaultRemoteObservationManager.java
@@ -128,7 +128,7 @@ public class DefaultRemoteObservationManager implements RemoteObservationManager
             try {
                 startChannel(channelId);
             } catch (RemoteEventException e) {
-                this.logger.error("Failed to start channel [" + channelId + "]", e);
+                this.logger.error("Failed to start channel [{}]", channelId, e);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/main/java/org/xwiki/observation/remote/internal/jgroups/JGroupsNetworkChannel.java
+++ b/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/main/java/org/xwiki/observation/remote/internal/jgroups/JGroupsNetworkChannel.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Inject;
 import javax.management.MBeanServer;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jgroups.Address;
 import org.jgroups.Global;
 import org.jgroups.JChannel;
@@ -184,7 +185,8 @@ public class JGroupsNetworkChannel implements NetworkChannel, Receiver
             MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
             JmxConfigurator.registerChannel(this.jchannel, mbs, this.jchannel.getClusterName() + '-' + currentMemberId);
         } catch (Exception e) {
-            this.logger.warn("Failed to register channel [" + getId() + "] against the JMX Server", e);
+            this.logger.warn("Failed to register channel [{}] against the JMX Server. Root cause is [{}]", getId(),
+                ExceptionUtils.getRootCauseMessage(e));
         }
 
         // Create the mapping between JGroups member address and XWiki observation id
@@ -221,7 +223,8 @@ public class JGroupsNetworkChannel implements NetworkChannel, Receiver
             JmxConfigurator.unregisterChannel(this.jchannel, mbs,
                 this.jchannel.getClusterName() + '-' + currentMemberId);
         } catch (Exception e) {
-            this.logger.warn("Failed to unregister channel [{}] from the JMX Server", this.id, e);
+            this.logger.warn("Failed to unregister channel [{}] from the JMX Server. Root cause is [{}]", this.id,
+                ExceptionUtils.getRootCauseMessage(e));
         }
 
         // Unregister the channel

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentTest.java
@@ -877,7 +877,8 @@ class XWikiDocumentTest
 
         assertEquals("Page", this.document.getRenderedTitle(this.oldcore.getXWikiContext()));
 
-        assertEquals("Failed to interpret title of document [Wiki:Space.Page].", this.logCapture.getLogEvent(0).getFormattedMessage());
+        assertEquals("Failed to interpret title of document [Wiki:Space.Page]. Root cause is "
+            + "[XWikiVelocityException: message]", this.logCapture.getLogEvent(0).getFormattedMessage());
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/migration/R120901000XWIKI17761DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/migration/R120901000XWIKI17761DataMigration.java
@@ -114,7 +114,7 @@ public class R120901000XWIKI17761DataMigration extends AbstractHibernateDataMigr
                 numberOfPagesToHandle, totalNumberOfXObjectsMigrated);
             if (!this.pagesWithNotMigratedRatings.isEmpty()) {
                 logger.info("Some ratings xobject have not been migrated because of the ratings configuration. "
-                    + "Here's the list of pages with ratings values not migrated: ");
+                    + "Here's the list of pages with ratings values not migrated:");
                 for (Map.Entry<String, Pair<Integer, Integer>> entry : pagesWithNotMigratedRatings.entrySet()) {
                     logger.info("Page: [{}]. Migrated: [{}]. Not migrated: [{}]", entry.getKey(),
                         entry.getValue().getLeft(), entry.getValue().getRight());

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/migration/SolrDocumentMigration120900000.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/migration/SolrDocumentMigration120900000.java
@@ -112,7 +112,7 @@ public class SolrDocumentMigration120900000
                 }
                 startIndex += BATCH_MIGRATION_SIZE;
                 totalMigrated += documentList.size();
-                logger.info("[{}] {} information migrated.", totalMigrated, managerId);
+                logger.info("[{}] information migrated for the ratings manager [{}].", totalMigrated, managerId);
             } catch (SolrServerException | IOException e) {
                 throw new SolrException("Error when executing query to perform 120700000 documents migration", e);
             }

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/script/RatingsScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/script/RatingsScriptService.java
@@ -98,14 +98,11 @@ public class RatingsScriptService extends AbstractScriptRatingsManager implement
                 scriptRatingsManager.setRatingsManager(ratingsManager);
                 executionContext.setProperty(executionContextCacheKey, scriptRatingsManager);
             } catch (RatingsException e) {
-                this.logger.error(
-                    String.format("Error when trying to retrieve RatingsManager instance with hint [%s]", managerHint),
+                this.logger.error("Error when trying to retrieve RatingsManager instance with hint [{}]", managerHint,
                     e);
             } catch (ComponentLookupException e) {
-                this.logger.error(
-                    String.format("Error when trying to retrieve DefaultScriptRatingsManager instance with hint [%s]",
-                        managerHint),
-                    e);
+                this.logger.error("Error when trying to retrieve DefaultScriptRatingsManager instance with hint [{}]",
+                    managerHint, e);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-jersey/src/main/java/org/xwiki/rest/jersey/internal/ConsumedBodyRestoringRequestWrapper.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-jersey/src/main/java/org/xwiki/rest/jersey/internal/ConsumedBodyRestoringRequestWrapper.java
@@ -44,6 +44,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.Part;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -213,7 +214,7 @@ class ConsumedBodyRestoringRequestWrapper extends HttpServletRequestWrapper
             parts = getParts();
         } catch (ServletException e) {
             LOGGER.warn("The multipart request body was consumed and its parts could not be retrieved to restore it: "
-                + "{}", e.getMessage());
+                + "[{}]", ExceptionUtils.getRootCauseMessage(e));
 
             return false;
         }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
@@ -1203,7 +1203,7 @@ public class ModelFactory
             try {
                 status.setLog(toRestJobLog(jobStatus.getLogTail(), self, null, logFromLevel));
             } catch (IOException e) {
-                this.logger.error("Failed to access the log of job {}", jobStatus.getRequest().getId(), e);
+                this.logger.error("Failed to access the log of job [{}]", jobStatus.getRequest().getId(), e);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/PreMatchingRequestFilter.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/PreMatchingRequestFilter.java
@@ -259,7 +259,7 @@ public class PreMatchingRequestFilter implements ContainerRequestFilter, XWikiRe
                     mediaType = MediaType.valueOf(mediaOverride);
                 } catch (IllegalArgumentException e) {
                     // Ignore badly formed media type
-                    this.logger.warn("Bad media type value [{}] provided: {}", mediaOverride,
+                    this.logger.warn("Bad media type value [{}] provided: [{}]", mediaOverride,
                         ExceptionUtils.getRootCauseMessage(e));
                 }
             }

--- a/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/SchedulerPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/SchedulerPlugin.java
@@ -908,7 +908,7 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
                 try {
                     unregister(originalJobObj);
                 } catch (SchedulerPluginException e) {
-                    LOGGER.warn("Failed to register job in document [{}]: {}", document.getDocumentReference(),
+                    LOGGER.warn("Failed to unregister job in document [{}]: [{}]", document.getDocumentReference(),
                         ExceptionUtils.getRootCauseMessage(e));
                 }
             }
@@ -922,7 +922,7 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
 
                     register(jobObject, xcontext);
                 } catch (Exception e) {
-                    LOGGER.warn("Failed to register job in document [{}]: {}", document.getDocumentReference(),
+                    LOGGER.warn("Failed to register job in document [{}]: [{}]", document.getDocumentReference(),
                         ExceptionUtils.getRootCauseMessage(e));
                 }
             }

--- a/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/internal/StatusListener.java
+++ b/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/internal/StatusListener.java
@@ -113,7 +113,7 @@ public class StatusListener implements SchedulerListener, JobListener
     @Override
     public void jobWasExecuted(JobExecutionContext context, JobExecutionException e)
     {
-        LOGGER.info("Task [{}] executed: ", context.getJobDetail().getKey(), e);
+        LOGGER.info("Task [{}] executed", context.getJobDetail().getKey(), e);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/AbstractDocumentSkinExtensionPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/AbstractDocumentSkinExtensionPlugin.java
@@ -318,7 +318,7 @@ public abstract class AbstractDocumentSkinExtensionPlugin extends AbstractSkinEx
         } catch (XWikiException e) {
             LOGGER.error("Error while loading [{}] for checking script right: [{}]", documentReference,
                 ExceptionUtils.getRootCauseMessage(e));
-            LOGGER.debug("Original error stack trace: ", e);
+            LOGGER.debug("Original error stack trace:", e);
             return false;
         }
     }

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/sx/CssExtension.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/sx/CssExtension.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +62,8 @@ public class CssExtension implements Extension
                 compressor.compress(out, -1);
                 return out.toString();
             } catch (IOException ex) {
-                LOGGER.warn("Exception compressing SSX code", ex);
+                LOGGER.warn("Failed to compress the SSX code. Root cause is [{}]",
+                    ExceptionUtils.getRootCauseMessage(ex));
             }
             return source;
         };

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-migrations/src/main/java/org/xwiki/store/filesystem/internal/migration/R1100000XWIKI15620DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-migrations/src/main/java/org/xwiki/store/filesystem/internal/migration/R1100000XWIKI15620DataMigration.java
@@ -99,7 +99,7 @@ public class R1100000XWIKI15620DataMigration extends AbstractFileStoreDataMigrat
         try {
             Files.delete(directory.toPath());
         } catch (Exception e) {
-            this.logger.warn("Failed to clean legacy folder [{}]: {}", directory,
+            this.logger.warn("Failed to clean legacy folder [{}]: [{}]", directory,
                 ExceptionUtils.getRootCauseMessage(e));
         }
     }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentStore.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentStore.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hibernate.Session;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
@@ -531,7 +532,8 @@ public class FilesystemAttachmentStore implements XWikiAttachmentStoreInterface
             try {
                 return this.componentManager.getInstance(AttachmentVersioningStore.class, storeType);
             } catch (ComponentLookupException e) {
-                this.logger.warn("Can't find attachment versionning store for type [{}]", storeType, e);
+                this.logger.warn("Can't find attachment versioning store for type [{}]. Root cause is [{}]", storeType,
+                    ExceptionUtils.getRootCauseMessage(e));
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/main/java/org/xwiki/url/script/URLSecurityScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/main/java/org/xwiki/url/script/URLSecurityScriptService.java
@@ -74,7 +74,7 @@ public class URLSecurityScriptService implements ScriptService
         } catch (SecurityException e)
         {
             this.logger.info("The URI [{}] is considered not safe: [{}]", uriRepresentation, e.getMessage());
-            this.logger.debug("Security exception stack trace: ", e);
+            this.logger.debug("Security exception stack trace:", e);
             return null;
         }
     }

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/main/java/org/xwiki/url/internal/DefaultURLSecurityManager.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/main/java/org/xwiki/url/internal/DefaultURLSecurityManager.java
@@ -225,12 +225,12 @@ public class DefaultURLSecurityManager implements URLSecurityManager
             } catch (MalformedURLException e) {
                 logger.error("Error while transforming URI [{}] to URL: [{}]", uri,
                     ExceptionUtils.getRootCauseMessage(e));
-                this.logger.debug("Full error stack trace of the URL resolution: ", e);
+                this.logger.debug("Full error stack trace of the URL resolution:", e);
                 result = false;
             } catch (URISyntaxException e) {
                 logger.error("Error while transforming URI [{}] to absolute URI with http scheme: [{}]", uri,
                     ExceptionUtils.getRootCauseMessage(e));
-                this.logger.debug("Full error stack trace of the URI resolution: ", e);
+                this.logger.debug("Full error stack trace of the URI resolution:", e);
             }
         }
         return result;

--- a/xwiki-platform-core/xwiki-platform-websocket/src/main/java/org/xwiki/websocket/AbstractXWikiEndpoint.java
+++ b/xwiki-platform-core/xwiki-platform-websocket/src/main/java/org/xwiki/websocket/AbstractXWikiEndpoint.java
@@ -144,7 +144,8 @@ public abstract class AbstractXWikiEndpoint extends Endpoint implements Endpoint
         try {
             session.close(new CloseReason(closeCode, reasonPhrase));
         } catch (IOException e) {
-            this.logger.warn("Failed to close the session.", e);
+            this.logger.warn("Failed to close the session. Root cause is [{}]",
+                ExceptionUtils.getRootCauseMessage(e));
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-websocket/src/main/java/org/xwiki/websocket/internal/DefaultWebSocketContext.java
+++ b/xwiki-platform-core/xwiki-platform-websocket/src/main/java/org/xwiki/websocket/internal/DefaultWebSocketContext.java
@@ -30,6 +30,7 @@ import jakarta.websocket.Session;
 import jakarta.websocket.server.HandshakeRequest;
 import jakarta.websocket.server.ServerEndpointConfig;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.container.Container;
@@ -215,8 +216,8 @@ public class DefaultWebSocketContext implements WebSocketContext
                     xcontext.setUserReference(xwikiUser.getUserReference());
                 }
             } catch (Exception e) {
-                this.logger.warn("Failed to authenticate the user for [{}]. Root cause is:", request.getRequestURI(),
-                    e);
+                this.logger.warn("Failed to authenticate the user for [{}]. Root cause is [{}]",
+                    request.getRequestURI(), ExceptionUtils.getRootCauseMessage(e));
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-websocket/src/main/java/org/xwiki/websocket/internal/StaticEchoEndpoint.java
+++ b/xwiki-platform-core/xwiki-platform-websocket/src/main/java/org/xwiki/websocket/internal/StaticEchoEndpoint.java
@@ -30,6 +30,7 @@ import jakarta.websocket.OnOpen;
 import jakarta.websocket.Session;
 import jakarta.websocket.server.ServerEndpoint;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.bridge.DocumentAccessBridge;
 import org.xwiki.component.annotation.Component;
@@ -76,7 +77,8 @@ public class StaticEchoEndpoint implements EndpointComponent
                     session.close(new CloseReason(CloseReason.CloseCodes.CANNOT_ACCEPT,
                         "We don't accept connections from guest users. Please login first."));
                 } catch (IOException e) {
-                    this.logger.warn("Failed to close the session.", e);
+                    this.logger.warn("Failed to close the session. Root cause is [{}]",
+                        ExceptionUtils.getRootCauseMessage(e));
                 }
             }
         });

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-creationjob/src/main/java/org/xwiki/platform/wiki/creationjob/script/WikiCreationJobScriptServices.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-creationjob/src/main/java/org/xwiki/platform/wiki/creationjob/script/WikiCreationJobScriptServices.java
@@ -25,6 +25,7 @@ import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.context.Execution;
@@ -104,7 +105,7 @@ public class WikiCreationJobScriptServices implements ScriptService
             
         } catch (WikiCreationException e) {
             setLastError(e);
-            logger.warn("Failed to create a new wiki.", e);
+            logger.warn("Failed to create a new wiki. Root cause is [{}]", ExceptionUtils.getRootCauseMessage(e));
         } catch (AccessDeniedException e) {
             setLastError(e);
         }

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-creationjob/src/test/java/org/xwiki/platform/wiki/creationjob/script/WikiCreationJobScriptServicesTest.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-creationjob/src/test/java/org/xwiki/platform/wiki/creationjob/script/WikiCreationJobScriptServicesTest.java
@@ -21,6 +21,7 @@ package org.xwiki.platform.wiki.creationjob.script;
 
 import javax.inject.Provider;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -127,7 +128,8 @@ class WikiCreationJobScriptServicesTest
         Exception lastError = this.wikiCreationJobScriptServices.getLastError();
         assertNotNull(lastError);
         assertEquals("The extension [badExtension/version] is not authorized.", lastError.getMessage());
-        verify(this.logger).warn("Failed to create a new wiki.", lastError);
+        verify(this.logger).warn("Failed to create a new wiki. Root cause is [{}]",
+            ExceptionUtils.getRootCauseMessage(lastError));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/descriptor/migrator/WikiDescriptorMigrator.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/descriptor/migrator/WikiDescriptorMigrator.java
@@ -139,8 +139,8 @@ public class WikiDescriptorMigrator extends AbstractHibernateDataMigration
             xwiki.saveDocument(document, "[UPGRADE] Set a default pretty name.", context);
         } catch (XWikiException e) {
             logger.warn("Failed to get or save the wiki descriptor document [{}]. You will not see the"
-                    + " corresponding wiki in the Wiki Index unless you give it a Pretty Name manually. {}",
-                    documentName, ExceptionUtils.getRootCauseMessage(e));
+                    + " corresponding wiki in the Wiki Index unless you give it a Pretty Name manually."
+                    + " Root cause is [{}]", documentName, ExceptionUtils.getRootCauseMessage(e));
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/descriptor/properties/DefaultWikiPropertyGroupManager.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/descriptor/properties/DefaultWikiPropertyGroupManager.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.wiki.descriptor.WikiDescriptor;
@@ -57,7 +58,8 @@ public class DefaultWikiPropertyGroupManager implements WikiPropertyGroupManager
             try {
                 descriptor.addPropertyGroup(provider.get(wikiId));
             } catch (WikiPropertyGroupException e) {
-                logger.warn(String.format("Unable to load property groups [%s].", propertyGroupName), e);
+                logger.warn("Unable to load property groups [{}]. Root cause is [{}]", propertyGroupName,
+                    ExceptionUtils.getRootCauseMessage(e));
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/test/java/org/xwiki/wiki/internal/descriptor/migrator/WikiDescriptorMigratorTest.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/test/java/org/xwiki/wiki/internal/descriptor/migrator/WikiDescriptorMigratorTest.java
@@ -156,7 +156,8 @@ class WikiDescriptorMigratorTest
         // Verify
         verify(this.logger).warn(
             "Failed to get or save the wiki descriptor document [{}]. You"
-                + " will not see the corresponding wiki in the Wiki Index unless you give it a Pretty Name manually. {}",
+                + " will not see the corresponding wiki in the Wiki Index unless you give it a Pretty Name manually."
+                + " Root cause is [{}]",
             documentList.getFirst(), ExceptionUtils.getRootCauseMessage(exception));
     }
 


### PR DESCRIPTION
Batch 3 of the repo-wide sweep applying the [logging best practices](https://dev.xwiki.org/xwiki/bin/view/Community/CodeStyle/JavaCodeStyle/#HLoggingBestPractices), following #6055, #6056, #6057, #6058, #6059, #6060, #6061 and #6062. **49 sites across 15 modules**: `mail`, `ratings`, `rest`, `image`, `configuration`, `feed`, `flamingo`, `scheduler`, `skin`, `store`, `wiki`, `display`, `observation`, `websocket`, `url`.

47 sites fixed, 2 deliberately left alone (see below). This is the second-to-last batch; 21 sites remain.

## What changed

| Category | Sites |
|---|---:|
| Placeholder not surrounded with `[]` | 16 |
| `warn()` passing a Throwable | 9 |
| Message built with `String.format()` | 7 |
| Trailing whitespace | 7 |
| String concatenation in the message | 6 |
| `warn()` using `e.getMessage()` | 4 |

`warn()` gives up the SLF4J Throwable slot (stack traces are reserved for `error()`) and gains `Root cause is [{}]` / `: [{}]` with `ExceptionUtils.getRootCauseMessage(e)` instead. `error()` and `debug()` keep their Throwable.

## Bugs found along the way

* **`MemoryMailListener`, `AbstractMailListener` and `MailConfigMandatoryDocumentInitializer` logged nothing at all about the exception they had in scope** — rewriting the concatenation / `String.format()` made it visible. All three now pass it in the Throwable slot.
* **`SchedulerPlugin` logged "Failed to register job"** on the job-*deleted* branch, which calls `unregister()`. It now says "unregister".
* **`FilesystemAttachmentStore`** misspelled "versionning".
* **`StatusListener`** had its trailing space *after* a colon introducing a stack trace that Quartz often does not provide (it passes a null `JobExecutionException` on success), so the colon went away rather than just the space.

## Deliberately not changed

* `SxDocumentSource` — `[{}#{}]` is the compound-identifier form, like the already-excluded `[{}@{}]` / `[{}.{}]` / `[{}:{}]`.
* `AbstractXWIKI14697DataMigration` — the argument is a `List`, whose `toString()` already brackets.

## Tests

Three tests asserted on messages that changed: `WikiCreationJobScriptServicesTest` and `WikiDescriptorMigratorTest` (both `verify()` the pattern handed to a mock `Logger`), and `XWikiDocumentTest` **in `xwiki-platform-oldcore`**, which asserts the rendered message produced by `xwiki-platform-display`'s `AbstractDocumentTitleDisplayer`.

`mvn test` and `mvn checkstyle:check -Plegacy,quality` pass from each of the 15 module directories. The oldcore test was verified separately against a locally rebuilt `xwiki-platform-display-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
