### PR TITLE
[Misc] Apply the logging best practices to oldcore and 5 more platform modules

### DIFF
--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-versioncheck/src/main/java/org/xwiki/extension/versioncheck/internal/VersionCheckInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-versioncheck/src/main/java/org/xwiki/extension/versioncheck/internal/VersionCheckInitializer.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.phase.InitializationException;
@@ -70,7 +71,8 @@ public class VersionCheckInitializer extends AbstractEventListener
             try {
                 environmentVersionCheckTimer.initialize();
             } catch (InitializationException e) {
-                logger.warn("Failed to initialize timer for checking new environment versions: [{}]", e);
+                logger.warn("Failed to initialize timer for checking new environment versions. Root cause is [{}]",
+                    ExceptionUtils.getRootCauseMessage(e));
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/thread/MailSenderInitializerListener.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/thread/MailSenderInitializerListener.java
@@ -120,7 +120,7 @@ public class MailSenderInitializerListener implements EventListener, Disposable
             this.sendMailThread.interrupt();
             // Wait till the thread goes away
             this.sendMailThread.join();
-            SHUTDOWN_LOGGER.debug(String.format("Mail Prepare Thread has been stopped"));
+            SHUTDOWN_LOGGER.debug("Mail Sender Thread has been stopped");
         }
 
         // Step 2: Stop the Mail Prepare Thread
@@ -131,7 +131,7 @@ public class MailSenderInitializerListener implements EventListener, Disposable
             this.prepareMailThread.interrupt();
             // Wait till the thread goes away
             this.prepareMailThread.join();
-            SHUTDOWN_LOGGER.debug(String.format("Mail Sender Thread has been stopped"));
+            SHUTDOWN_LOGGER.debug("Mail Prepare Thread has been stopped");
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -3317,7 +3317,8 @@ public class XWiki implements EventListener
             try {
                 defaultLocale = LocaleUtils.toLocale(Util.normalizeLanguage(defaultLanguage));
             } catch (Exception e) {
-                LOGGER.warn("Invalid locale [{}] set as default locale in the preferences", defaultLanguage);
+                LOGGER.warn("Invalid locale [{}] set as default locale in the preferences. Root cause is [{}]",
+                    defaultLanguage, ExceptionUtils.getRootCauseMessage(e));
                 defaultLocale = Locale.ENGLISH;
             }
         }
@@ -3343,7 +3344,8 @@ public class XWiki implements EventListener
                 try {
                     locales.add(LocaleUtils.toLocale(language));
                 } catch (Exception e) {
-                    LOGGER.warn("Invalid locale [{}] listed as available in the preferences", language);
+                    LOGGER.warn("Invalid locale [{}] listed as available in the preferences. Root cause is [{}]",
+                        language, ExceptionUtils.getRootCauseMessage(e));
                 }
             }
         }
@@ -6402,8 +6404,8 @@ public class XWiki implements EventListener
         try {
             return getVelocityEvaluator().evaluateVelocity(content, namespace, vcontext);
         } catch (XWikiException xe) {
-            LOGGER.error("Error while parsing velocity template namespace [{}] with content:\n[{}]", namespace, content,
-                xe.getCause());
+            LOGGER.error("Error while parsing velocity template namespace [{}] with content [{}]", namespace, content,
+                xe);
             return Util.getHTMLExceptionMessage(xe, null);
         }
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/User.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/User.java
@@ -19,8 +19,7 @@
  */
 package com.xpn.xwiki.api;
 
-import java.text.MessageFormat;
-
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.model.EntityType;
@@ -123,8 +122,8 @@ public class User extends Api
                 result = this.user.isUserInGroup(groupName, getXWikiContext());
             }
         } catch (Exception ex) {
-            LOGGER.warn(new MessageFormat("Unhandled exception while checking if user {0}"
-                + " belongs to group {1}").format(new java.lang.Object[] { this.user, groupName }), ex);
+            LOGGER.warn("Unhandled exception while checking if user [{}] belongs to group [{}]. Root cause is [{}]",
+                this.user, groupName, ExceptionUtils.getRootCauseMessage(ex));
         }
         return result;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/context/RequestInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/context/RequestInitializer.java
@@ -31,6 +31,7 @@ import javax.inject.Singleton;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpSession;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.container.Container;
@@ -84,7 +85,8 @@ public class RequestInitializer
             try {
                 url = xcontext.getWiki().getServerURL(requestWiki, xcontext);
             } catch (MalformedURLException e) {
-                this.logger.warn("Failed to get the URL for stored context wiki [{}]", requestWiki);
+                this.logger.warn("Failed to get the URL for stored context wiki [{}]. Root cause is [{}]", requestWiki,
+                    ExceptionUtils.getRootCauseMessage(e));
             }
 
             // Assume we always want to behave as a HTTP request when the wiki request is provided

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/model/reference/DocumentReferenceConverter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/model/reference/DocumentReferenceConverter.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
@@ -80,7 +81,8 @@ public class DocumentReferenceConverter extends AbstractConverter<DocumentRefere
                     result = converter.convert(DocumentReference.class, value);
                 } catch (ConversionException e) {
                     logger.warn("The type [{}] cannot be converted natively to DocumentReference, "
-                        + "falling back on using toString to convert it.", value.getClass().getName());
+                        + "falling back on using toString to convert it. Root cause is [{}]",
+                        value.getClass().getName(), ExceptionUtils.getRootCauseMessage(e));
                     result = this.stringResolver.resolve(value.toString());
                 }
             } else {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/pdf/FOPXSLFORenderer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/pdf/FOPXSLFORenderer.java
@@ -258,7 +258,8 @@ public class FOPXSLFORenderer implements XSLFORenderer, Initializable
             this.logger.warn("Starting with 1.5, XWiki uses the WEB-INF/fonts/ directory as the font directory, "
                 + "and it should contain the FreeFont (http://savannah.gnu.org/projects/freefont/) fonts. "
                 + "FOP cannot access this directory. If this is an upgrade from a previous version, "
-                + "make sure you also copy the WEB-INF/fonts directory from the new distribution package.");
+                + "make sure you also copy the WEB-INF/fonts directory from the new distribution package. "
+                + "Root cause is [{}]", ExceptionUtils.getRootCauseMessage(e));
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/sheet/AbstractSheetBinder.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/sheet/AbstractSheetBinder.java
@@ -195,7 +195,8 @@ public abstract class AbstractSheetBinder implements SheetBinder, Initializable
             String docStringReference =
                 this.defaultEntityReferenceSerializer.serialize(document.getDocumentReference());
 
-            this.logger.warn("Failed to bind sheet [{}] to document [{}].", sheetReferenceString, docStringReference);
+            this.logger.warn("Failed to bind sheet [{}] to document [{}]. Root cause is [{}]", sheetReferenceString,
+                docStringReference, ExceptionUtils.getRootCauseMessage(e));
 
             return false;
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/sheet/DefaultModelBridge.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/sheet/DefaultModelBridge.java
@@ -71,8 +71,9 @@ public class DefaultModelBridge implements ModelBridge
         try {
             return ((XWikiDocument) document).getDefaultEditMode(this.xcontextProvider.get());
         } catch (XWikiException e) {
-            this.logger.warn("Failed to get the default edit mode for [{}].",
-                this.defaultEntityReferenceSerializer.serialize(document.getDocumentReference()));
+            this.logger.warn("Failed to get the default edit mode for [{}]. Root cause is [{}]",
+                this.defaultEntityReferenceSerializer.serialize(document.getDocumentReference()),
+                ExceptionUtils.getRootCauseMessage(e));
             return null;
         }
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/skin/AbstractSkin.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/skin/AbstractSkin.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.rendering.parser.ParseException;
 import org.xwiki.rendering.syntax.Syntax;
@@ -160,7 +161,8 @@ public abstract class AbstractSkin implements Skin
         try {
             return Syntax.valueOf(syntax);
         } catch (ParseException e) {
-            logger.warn("Failed to parse the syntax [{}] configured by the skin [{}].", syntax, skin.getId());
+            logger.warn("Failed to parse the syntax [{}] configured by the skin [{}]. Root cause is [{}]", syntax,
+                skin.getId(), ExceptionUtils.getRootCauseMessage(e));
         }
 
         // let getOutputSyntax() do the proper fallback

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/PropertyConverter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/PropertyConverter.java
@@ -25,6 +25,7 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 
@@ -87,8 +88,9 @@ public class PropertyConverter
                     try {
                         newProperty = modifiedPropertyClass.fromString(storedProperty.toText());
                     } catch (XWikiException ex) {
-                        this.logger.warn(errorLog,
-                            modifiedPropertyClass.getName(), modifiedPropertyClass.getClassName(), ex);
+                        this.logger.warn("Incompatible data migration when changing field [{}] of class [{}]. Root "
+                            + "cause is [{}]", modifiedPropertyClass.getName(), modifiedPropertyClass.getClassName(),
+                            ExceptionUtils.getRootCauseMessage(ex));
                     }
                 }
                 if (newProperty != null) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/template/InternalTemplateManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/template/InternalTemplateManager.java
@@ -1098,7 +1098,8 @@ public class InternalTemplateManager implements Initializable, Disposable
         try {
             url = ClassLoaderUtils.getResource(classloader, prefixPath, templateName);
         } catch (IllegalArgumentException e) {
-            this.logger.warn("The template name [{}] is trying to execute a path traversal attack!", templateName);
+            this.logger.warn("The template name [{}] is trying to execute a path traversal attack! Root cause is [{}]",
+                templateName, ExceptionUtils.getRootCauseMessage(e));
 
             return null;
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseElement.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseElement.java
@@ -649,7 +649,7 @@ public abstract class BaseElement<R extends EntityReference> implements ElementI
                 result = true;
             } catch (XWikiException e) {
                 LOGGER.error("Error while trying to load document [{}] as owner document of [{}]", documentReference,
-                    this);
+                    this, e);
             }
         }
         return result;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/PdfExportImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/PdfExportImpl.java
@@ -501,7 +501,8 @@ public class PdfExportImpl implements PdfExport
                  this.dab.getDocumentInstance(templateReference).getAuthors().getEffectiveMetadataAuthor());
         } catch (Exception e) {
             LOGGER.warn("Error fetching the author of template [{}] during PDF conversion. Using the [{}] property of "
-                + "the document's value without applying Velocity.", templateName, propertyName);
+                + "the document's value without applying Velocity. Root cause is [{}]", templateName, propertyName,
+                ExceptionUtils.getRootCauseMessage(e));
             return result;
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateAttachmentStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateAttachmentStore.java
@@ -346,8 +346,9 @@ public class XWikiHibernateAttachmentStore extends XWikiHibernateBaseStore imple
                 try {
                     session.delete(new XWikiAttachmentContent(attachment));
                 } catch (Exception e) {
-                    this.logger.warn("Error deleting attachment content [{}] of document [{}]",
-                        attachment.getFilename(), attachment.getDoc().getDocumentReference());
+                    this.logger.warn("Error deleting attachment content [{}] of document [{}]. Root cause is [{}]",
+                        attachment.getFilename(), attachment.getDoc().getDocumentReference(),
+                        ExceptionUtils.getRootCauseMessage(e));
                 }
 
                 AttachmentVersioningStore store = resolveAttachmentVersioningStore(attachment, context);
@@ -356,8 +357,9 @@ public class XWikiHibernateAttachmentStore extends XWikiHibernateBaseStore imple
                 try {
                     session.delete(attachment);
                 } catch (Exception e) {
-                    this.logger.warn("Error deleting attachment meta data [{}] of document [{}]",
-                        attachment.getFilename(), attachment.getDoc().getDocumentReference());
+                    this.logger.warn("Error deleting attachment meta data [{}] of document [{}]. Root cause is [{}]",
+                        attachment.getFilename(), attachment.getDoc().getDocumentReference(),
+                        ExceptionUtils.getRootCauseMessage(e));
                 }
 
                 try {
@@ -373,8 +375,9 @@ public class XWikiHibernateAttachmentStore extends XWikiHibernateBaseStore imple
                         context.getWiki().getStore().saveXWikiDoc(attachment.getDoc(), context, false);
                     }
                 } catch (Exception e) {
-                    this.logger.warn("Error updating document when deleting attachment [{}] of document [{}]",
-                        attachment.getFilename(), attachment.getDoc().getDocumentReference());
+                    this.logger.warn("Error updating document when deleting attachment [{}] of document [{}]. Root "
+                        + "cause is [{}]", attachment.getFilename(), attachment.getDoc().getDocumentReference(),
+                        ExceptionUtils.getRootCauseMessage(e));
                 }
 
                 if (bTransaction) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R35102XWIKI7771DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R35102XWIKI7771DataMigration.java
@@ -34,6 +34,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.jdbc.Work;
@@ -179,7 +180,8 @@ public class R35102XWIKI7771DataMigration extends AbstractHibernateDataMigration
                             // way of getting back the missing bytes, we can just empty the value set in this row.
                             // Start a new transaction
                             connection.rollback();
-                            this.logger.warn("[{}] [{}] cannot be recovered", this.dataType, lob.getValue());
+                            this.logger.warn("[{}] [{}] cannot be recovered. Root cause is [{}]", this.dataType,
+                                lob.getValue(), ExceptionUtils.getRootCauseMessage(ex));
                             emptyLob.setString(1, lob.getKey());
                             emptyLob.executeUpdate();
                             removeLob.setLong(1, Long.valueOf(lob.getKey()));

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/util/Util.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/util/Util.java
@@ -47,6 +47,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.oro.text.PatternCache;
 import org.apache.oro.text.PatternCacheLRU;
 import org.apache.oro.text.perl.Perl5Util;
@@ -841,7 +842,8 @@ public class Util
             l.getISO3Language();
             return result;
         } catch (MissingResourceException ex) {
-            LOGGER.warn("Invalid language: [{}]", languageCode);
+            LOGGER.warn("Invalid language [{}]. Root cause is [{}]", languageCode,
+                ExceptionUtils.getRootCauseMessage(ex));
         }
         return defaultLanguage;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiAction.java
@@ -717,7 +717,9 @@ public abstract class XWikiAction implements LegacyAction
                     return;
                 } catch (XWikiException ex) {
                     if (ex.getCode() == XWikiException.ERROR_XWIKI_APP_SEND_RESPONSE_EXCEPTION) {
-                        LOGGER.error("Connection aborted");
+                        // No stack trace here: an aborted connection is a client-side event, and the surrounding
+                        // code already suppresses traces for it.
+                        LOGGER.error("Connection aborted. Root cause is [{}]", ExceptionUtils.getRootCauseMessage(ex));
                     }
                 } catch (Exception e2) {
                     // I hope this never happens

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
@@ -234,7 +234,8 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
             try {
                 return normalizeURL(surl, context);
             } catch (MalformedURLException e) {
-                LOGGER.warn("Could not create URL from xwiki.cfg xwiki.home parameter [{}]. Ignoring parameter.", surl);
+                LOGGER.warn("Could not create URL from xwiki.cfg xwiki.home parameter [{}]. Ignoring parameter. "
+                    + "Root cause is [{}]", surl, ExceptionUtils.getRootCauseMessage(e));
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/internal/document/DocumentRequiredRightsReader.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/internal/document/DocumentRequiredRightsReader.java
@@ -28,6 +28,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.EntityType;
@@ -137,7 +138,8 @@ public class DocumentRequiredRightsReader
                 } catch (IllegalArgumentException e) {
                     // Ensure that we return an illegal right even if the right part of the value could be parsed.
                     right = Right.ILLEGAL;
-                    this.logger.warn("Illegal required right value [{}] in object [{}]", value, object.getReference());
+                    this.logger.warn("Illegal required right value [{}] in object [{}]. Root cause is [{}]", value,
+                        object.getReference(), ExceptionUtils.getRootCauseMessage(e));
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/document/DocumentRequiredRightsReaderTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/document/DocumentRequiredRightsReaderTest.java
@@ -99,8 +99,9 @@ class DocumentRequiredRightsReaderTest
 
         List<String> invalidValues = values.stream().filter(v -> Strings.CS.startsWith(v, "foo")).toList();
         for (int i = 0; i < invalidValues.size(); i++) {
-            assertEquals("Illegal required right value [%s] in object [%s]".formatted(invalidValues.get(i),
-                objectReferenceName), this.logCapture.getMessage(i));
+            assertEquals(("Illegal required right value [%s] in object [%s]. Root cause is "
+                + "[IllegalArgumentException: No enum constant org.xwiki.model.EntityType.FOO]")
+                .formatted(invalidValues.get(i), objectReferenceName), this.logCapture.getMessage(i));
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/XWikiResource.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/XWikiResource.java
@@ -174,7 +174,7 @@ public class XWikiResource implements XWikiRestComponent, Initializable
     {
         objectFactory = new ObjectFactory();
 
-        this.slf4Jlogger.trace("Resource {} initialized. Serving user: '{}'\n", getClass().getName(),
+        this.slf4Jlogger.trace("Resource [{}] initialized. Serving user [{}]", getClass().getName(),
             this.xcontextProvider.get().getUserReference());
     }
 

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/sx/AbstractSxAction.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/sx/AbstractSxAction.java
@@ -24,6 +24,7 @@ import java.util.Date;
 
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 
 import com.xpn.xwiki.XWikiContext;
@@ -114,7 +115,7 @@ public abstract class AbstractSxAction extends XWikiAction
             response.setContentLength(extensionContent.getBytes(RESPONSE_CHARACTER_SET).length);
             response.getOutputStream().write(extensionContent.getBytes(RESPONSE_CHARACTER_SET));
         } catch (IOException ex) {
-            getLogger().warn("Failed to send SX content: [{}]", ex.getMessage());
+            getLogger().warn("Failed to send SX content. Root cause is [{}]", ExceptionUtils.getRootCauseMessage(ex));
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/provisioning/DefaultWikiCopier.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/provisioning/DefaultWikiCopier.java
@@ -115,11 +115,11 @@ public class DefaultWikiCopier implements WikiCopier
         } catch (QueryException e) {
             WikiManagerException thrownException =
                 new WikiManagerException("Unable to get the list of wiki documents to copy.", e);
-            logger.error(thrownException.getMessage(), thrownException);
+            logger.error("Unable to get the list of wiki documents to copy", thrownException);
             throw thrownException;
         } catch (XWikiException e) {
             WikiManagerException thrownException = new WikiManagerException("Failed to copy documents.", e);
-            logger.error(thrownException.getMessage(), thrownException);
+            logger.error("Failed to copy documents", thrownException);
             throw thrownException;
         } finally {
             this.progress.popLevelProgress(this);


### PR DESCRIPTION
Continues the SLF4J logging best-practices sweep ([rules](https://dev.xwiki.org/xwiki/bin/view/Community/CodeStyle/JavaCodeStyle/#HLoggingBestPractices)) after #6055–#6065. **29 sites across 6 modules.** This closes the backlog: a fresh parser run reports nothing further outside the still-open #6063/#6064/#6065.

## What this is

The bulk is the `xwiki-platform-oldcore` follow-up that #6065 deliberately left out (bundling it there would have doubled that diff): `warn()`/`error()` calls sitting inside a `catch` that throw away the exception they are holding. `warn()` must not print a stack trace, so those append `. Root cause is [{}]`; `error()` gets the caught exception in the SLF4J Throwable slot.

## Real defects found along the way

These are not cosmetic — each one silently lost information:

- **`XWiki.evaluateVelocity`** passed `xe.getCause()`. `getCause()` is `null` when the `XWikiException` has no cause, and a `null` last argument is not a Throwable, so SLF4J trimmed nothing and **no stack trace was logged at all**. Now passes `xe`.
- **`VersionCheckInitializer`** wrote `warn("...: [{}]", e)`. SLF4J always trims a trailing Throwable regardless of placeholder count, so the `{}` rendered as the literal text `{}` **and** a warning printed a full stack trace. Both wrong, both fixed.
- **`MailSenderInitializerListener`** had its two shutdown messages swapped: the line after `sendMailThread.join()` announced the *Prepare* thread, and the line after `prepareMailThread.join()` announced the *Sender* thread.
- **`DefaultWikiCopier`** used the message-less `error(e.getMessage(), e)` form — no literal in the source to grep for, and no indication of which operation failed.
- **`AbstractSxAction`** used `ex.getMessage()` rather than the root cause. This one was invisible to every earlier pass because it logs through a `getLogger()` receiver, which the parsers did not recognise.

Plus `User.isUserInGroup` (message built with `MessageFormat`, Throwable passed to `warn()`) and `XWikiResource` (unbracketed placeholders, quotes standing in for brackets, trailing `\n`).

## Deliberately not fixed

`EditForm` (×3) and `ObjectRemoveForm` catch `NumberFormatException` from `Integer.parseInt`, whose message is `For input string: "…"` — the bad value is already the message's placeholder, so the exception adds nothing. `XWikiHibernateStore`'s `ObjectNotFoundException` catch documents the empty property table as the *accepted* outcome, where a stack trace would be pure noise. `XWikiAction`'s `"Connection aborted"` keeps the root-cause message but no trace, matching the broken-pipe handling a few lines above that exists specifically to suppress traces for client disconnects.

## Verification

`mvn -B -ntp test` and `mvn -B -ntp checkstyle:check -Plegacy,quality` from each of the six module directories — all green. `DocumentRequiredRightsReaderTest` compares the rendered message via `LogCaptureExtension` and was updated to match; `PropertyConverterTest` asserts on the sibling call outside the catch and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
