### PR TITLE
[Misc] Fix the build broken by the oldcore logging best practices pass

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactory.java
@@ -69,6 +69,9 @@ public class FileSystemURLFactory extends XWikiServletURLFactory
     /** Context key under which the resource-key-to-temporary-file mapping is stored during the export. */
     private static final String FILE_MAPPING_KEY = "pdfexport-file-mapping";
 
+    /** Logged when an attachment cannot be copied to the temporary export folder. */
+    private static final String SAVE_IMAGE_ERROR = "Failed to save image for PDF export. Root cause is [{}]";
+
     private LegacySpaceResolver legacySpaceResolver = Utils.getComponent(LegacySpaceResolver.class);
 
     private ContextualAuthorizationManager authorization = Utils.getComponent(ContextualAuthorizationManager.class);
@@ -100,8 +103,7 @@ public class FileSystemURLFactory extends XWikiServletURLFactory
         try {
             return getURL(wiki, spaces, name, filename, null, context);
         } catch (Exception ex) {
-            LOGGER.warn("Failed to save image for PDF export. Root cause is [{}]",
-                ExceptionUtils.getRootCauseMessage(ex));
+            LOGGER.warn(SAVE_IMAGE_ERROR, ExceptionUtils.getRootCauseMessage(ex));
             return super.createAttachmentURL(filename, spaces, name, action, null, wiki, context);
         }
     }
@@ -113,8 +115,7 @@ public class FileSystemURLFactory extends XWikiServletURLFactory
         try {
             return getURL(wiki, spaces, name, filename, revision, context);
         } catch (Exception ex) {
-            LOGGER.warn("Failed to save image for PDF export. Root cause is [{}]",
-                ExceptionUtils.getRootCauseMessage(ex));
+            LOGGER.warn(SAVE_IMAGE_ERROR, ExceptionUtils.getRootCauseMessage(ex));
             return super.createAttachmentRevisionURL(filename, spaces, name, revision, wiki, context);
         }
     }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultModelBridgeTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultModelBridgeTest.java
@@ -101,6 +101,13 @@ import static org.mockito.Mockito.when;
 @ComponentTest
 class DefaultModelBridgeTest
 {
+    /**
+     * The root cause reported when the recycle bin rights check fails, because this test doesn't load all the oldcore
+     * components that check needs.
+     */
+    private static final String RIGHTS_CHECK_CAUSE = "ComponentLookupException: Can't find descriptor for the component "
+        + "with type [javax.inject.Provider<org.xwiki.model.reference.DocumentReference>] and hint [default]";
+
     @RegisterExtension
     private LogCaptureExtension logCapture = new LogCaptureExtension();
 
@@ -677,8 +684,9 @@ class DefaultModelBridgeTest
 
         // this could be improved later: right now we don't get the rights in the test because the components are not
         // all properly loaded from oldcore.
-        assertLog(0, Level.WARN, "Exception while checking if entry [{}] can be removed from the recycle bin",
-            deletedDocumentId);
+        assertLog(0, Level.WARN,
+            "Failed to check if entry [{}] can be removed from the recycle bin. Root cause is [{}]", deletedDocumentId,
+            RIGHTS_CHECK_CAUSE);
     }
 
     @Test
@@ -876,8 +884,9 @@ class DefaultModelBridgeTest
 
         assertFalse(this.modelBridge.permanentlyDeleteDocument(deletedDocumentId, request));
 
-        assertLog(0, Level.WARN, "Exception while checking if entry [{}] can be removed from the recycle bin",
-            deletedDocumentId);
+        assertLog(0, Level.WARN,
+            "Failed to check if entry [{}] can be removed from the recycle bin. Root cause is [{}]", deletedDocumentId,
+            RIGHTS_CHECK_CAUSE);
         assertLog(1, Level.ERROR, "You are not allowed to permanently delete document [{}] with ID [{}]",
             documentReference, deletedDocumentId);
         verify(recycleBin, never()).deleteFromRecycleBin(anyLong(), any(), anyBoolean());


### PR DESCRIPTION
# Jira URL

None — this is a `[Misc]` build repair.

# Changes

## Description

Fixes the two `master` failures reported in #6067, both introduced by 642bf7f4 (*Finish applying the
logging best practices to xwiki-platform-oldcore*, #6056). #6067 deliberately left them alone so that
an unrelated repair wouldn't ride along in a Sonar cleanup PR; this is that repair.

### 1. `xwiki-platform-oldcore` — Checkstyle `MultipleStringLiterals`

642bf7f4 unified two differently-worded warnings in `FileSystemURLFactory` into the same
`"Failed to save image for PDF export. Root cause is [{}]"` text, used from both
`createAttachmentURL` and `createAttachmentRevisionURL`. Checkstyle rejects the duplicate literal:

```
FileSystemURLFactory.java:103: String "Failed to save image for PDF export. Root cause is [{}]" appears 2 times in the file. [MultipleStringLiterals]
```

The message moves to a `SAVE_IMAGE_ERROR` constant, alongside the class's other constants. Both call
sites now fit on one line. No behaviour change — the logged output is identical.

### 2. `xwiki-platform-refactoring-default` — 2 failing assertions in `DefaultModelBridgeTest`

`DeletedDocument#canDelete()` and `DeletedAttachment#canDelete()` used to log
`"Exception while checking if entry [{}] can be removed from the recycle bin"` with the id and the
`Throwable`; 642bf7f4 changed them to
`"Failed to check if entry [{}] can be removed from the recycle bin. Root cause is [{}]"` with the id
and `ExceptionUtils.getRootCauseMessage(ex)`. Logback strips a trailing `Throwable` from the argument
array but keeps a `String`, so both the message *and* the argument count changed, and
`permanentlyDeleteDeletedDocumentWrongRights` / `permanentlyDeleteDeletedDocumentNoRights` failed:

```
expected: <Exception while checking if entry [{}] can be removed from the recycle bin>
 but was: <Failed to check if entry [{}] can be removed from the recycle bin. Root cause is [{}]>
```

Both `assertLog(0, Level.WARN, …)` calls are updated to the new message and now also assert the root
cause. That root cause is a `ComponentLookupException` on
`Provider<DocumentReference>` — an artefact of the incomplete oldcore component setup these two tests
already document ("*right now we don't get the rights in the test because the components are not all
properly loaded from oldcore*"). It's shared by both tests, so it lives in a `RIGHTS_CHECK_CAUSE`
constant whose Javadoc records why it is what it is.

No production code changes in `xwiki-platform-refactoring-default`; no test changes in
`xwiki-platform-oldcore`.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

Both affected modules, full `quality` profile (Checkstyle included):

```
mvn install -Plegacy,quality -pl xwiki-platform-core/xwiki-platform-oldcore
mvn install -Plegacy,quality -pl xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default
```

* `xwiki-platform-oldcore` — **BUILD SUCCESS**, Tests run: 1140, Failures: 0, Errors: 0, Skipped: 0,
  and `checkstyle-result.xml` now holds **0** violations (was 1).
* `xwiki-platform-refactoring-default` — **BUILD SUCCESS**, Tests run: 84, Failures: 0, Errors: 0,
  Skipped: 0 (`DefaultModelBridgeTest`: 35/35).

I also swept every string literal 642bf7f4 removed from `src/main` against all platform `src/test`
sources to check no other test asserts on a message that commit reworded — `DefaultModelBridgeTest`
is the only one.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None — 642bf7f4 is only on `master`, so neither regression exists elsewhere.
