### PR TITLE
[Misc] Apply the logging best practices to oldcore and 10 more platform modules

### DIFF
--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/DefaultWikiComponentInvocationHandler.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/DefaultWikiComponentInvocationHandler.java
@@ -55,7 +55,7 @@ public class DefaultWikiComponentInvocationHandler implements InvocationHandler
     /**
      * The logger to log.
      */
-    private final Logger logger = LoggerFactory.getLogger(DefaultWikiComponentInvocationHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultWikiComponentInvocationHandler.class);
 
     /**
      * Our component manager.
@@ -123,7 +123,7 @@ public class DefaultWikiComponentInvocationHandler implements InvocationHandler
                     componentDependency = componentManager.getInstance(cd.getRoleType(), cd.getRoleHint());
                 }
             } catch (ComponentLookupException e) {
-                this.logger.warn("No component found for role [{}] with hint [{}], declared as dependency for wiki "
+                LOGGER.warn("No component found for role [{}] with hint [{}], declared as dependency for wiki "
                     + "component [{}]. Root cause is [{}]", cd.getRoleType(), cd.getRoleHint(),
                     this.wikiComponent.getDocumentReference(), ExceptionUtils.getRootCauseMessage(e));
             }

--- a/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-default/src/main/java/org/xwiki/export/pdf/internal/chrome/ChromeManager.java
+++ b/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-default/src/main/java/org/xwiki/export/pdf/internal/chrome/ChromeManager.java
@@ -278,10 +278,8 @@ public class ChromeManager implements BrowserManager, Initializable, Disposable
 
     private void handleInterruptedException(InterruptedException e)
     {
-        if (this.logger.isWarnEnabled()) {
-            this.logger.warn("Interrupted thread [{}]. Root cause: [{}].", Thread.currentThread().getName(),
-                ExceptionUtils.getRootCauseMessage(e));
-        }
+        this.logger.warn("Interrupted thread [{}]. Root cause: [{}].", Thread.currentThread().getName(),
+            ExceptionUtils.getRootCauseMessage(e));
         // Restore the interrupted state.
         Thread.currentThread().interrupt();
     }

--- a/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
@@ -999,7 +999,7 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
             writer.close();
             return writer.toString();
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.error("Failed to serialize the feed to the [{}] format", type, e);
             return "";
         }
     }

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-plugin/src/main/java/com/xpn/xwiki/plugin/image/ImagePlugin.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-plugin/src/main/java/com/xpn/xwiki/plugin/image/ImagePlugin.java
@@ -54,7 +54,7 @@ public class ImagePlugin extends XWikiDefaultPlugin
     /**
      * Logging helper object.
      */
-    private static final Logger LOG = LoggerFactory.getLogger(ImagePlugin.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ImagePlugin.class);
 
     /**
      * The name used for retrieving this plugin from the context.
@@ -127,7 +127,7 @@ public class ImagePlugin extends XWikiDefaultPlugin
             try {
                 this.defaultQuality = Math.max(0, Math.min(1, Float.parseFloat(defaultQualityParam.trim())));
             } catch (NumberFormatException e) {
-                LOG.warn("Failed to parse [{}] configuration parameter. Using [{}] as the default image quality. "
+                LOGGER.warn("Failed to parse [{}] configuration parameter. Using [{}] as the default image quality. "
                     + "Root cause is [{}].", DEFAULT_QUALITY_PARAM, this.defaultQuality,
                     ExceptionUtils.getRootCauseMessage(e));
             }
@@ -155,7 +155,7 @@ public class ImagePlugin extends XWikiDefaultPlugin
                 try {
                     this.capacity = Integer.parseInt(capacityParam.trim());
                 } catch (NumberFormatException e) {
-                    LOG.warn("Failed to parse the [xwiki.plugin.image.cache.capacity] configuration parameter. "
+                    LOGGER.warn("Failed to parse the [xwiki.plugin.image.cache.capacity] configuration parameter. "
                         + "Using [{}] as the cache capacity. Root cause is [{}]", this.capacity,
                         ExceptionUtils.getRootCauseMessage(e));
                 }
@@ -165,7 +165,7 @@ public class ImagePlugin extends XWikiDefaultPlugin
             try {
                 this.imageCache = Utils.getComponent(CacheManager.class).createNewLocalCache(configuration);
             } catch (CacheException e) {
-                LOG.error("Error initializing the image cache.", e);
+                LOGGER.error("Error initializing the image cache.", e);
             }
         }
     }
@@ -222,10 +222,10 @@ public class ImagePlugin extends XWikiDefaultPlugin
                     // Transform the image attachment before is it downloaded.
                     result = downloadImage(attachment, width, height, quality, context);
                 } catch (Exception e) {
-                    LOG.warn("Failed to transform image attachment [{}] for scaling, falling back to original "
+                    LOGGER.warn("Failed to transform image attachment [{}] for scaling, falling back to original "
                         + "attachment. Root error: [{}]", attachment.getFilename(),
                         ExceptionUtils.getRootCauseMessage(e));
-                    LOG.debug("Full stack trace for image attachment scaling error:", e);
+                    LOGGER.debug("Full stack trace for image attachment scaling error:", e);
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-plugin/src/main/java/com/xpn/xwiki/plugin/image/ImagePluginAPI.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-plugin/src/main/java/com/xpn/xwiki/plugin/image/ImagePluginAPI.java
@@ -37,7 +37,7 @@ import com.xpn.xwiki.web.Utils;
 public class ImagePluginAPI extends PluginApi<ImagePlugin>
 {
     /** Logging helper object. */
-    private static final Logger LOG = LoggerFactory.getLogger(ImagePluginAPI.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ImagePluginAPI.class);
 
     /**
      * Used to resolve a string into a proper Document Reference using the current document's reference to fill the
@@ -70,7 +70,7 @@ public class ImagePluginAPI extends PluginApi<ImagePlugin>
         try {
             return getProtectedPlugin().getHeight(getAttachment(pageName, attachmentName), getXWikiContext());
         } catch (Exception e) {
-            LOG.error("Failed to detect the height of [{}] attached to [{}].", attachmentName, pageName, e);
+            LOGGER.error("Failed to detect the height of [{}] attached to [{}].", attachmentName, pageName, e);
             return -1;
         }
     }
@@ -87,7 +87,7 @@ public class ImagePluginAPI extends PluginApi<ImagePlugin>
         try {
             return getProtectedPlugin().getWidth(getAttachment(pageName, attachmentName), getXWikiContext());
         } catch (Exception e) {
-            LOG.error("Failed to detect the width of [{}] attached to [{}].", attachmentName, pageName, e);
+            LOGGER.error("Failed to detect the width of [{}] attached to [{}].", attachmentName, pageName, e);
             return -1;
         }
     }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/rest/model/jaxb/StringMap.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/rest/model/jaxb/StringMap.java
@@ -50,7 +50,7 @@ public class StringMap extends HashMap<String, Object>
      */
     private static final long serialVersionUID = 1L;
 
-    private static Logger LOGGER = LoggerFactory.getLogger(StringMap.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(StringMap.class);
 
     /**
      * Parses the given JSON representation of a string map.

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/AbstractMailListener.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/AbstractMailListener.java
@@ -60,19 +60,15 @@ public abstract class AbstractMailListener implements MailListener
     @Override
     public void onPrepareMessageSuccess(ExtendedMimeMessage message, Map<String, Object> parameters)
     {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Mail preparation succeed for message [{}] of batch [{}].",
-                message.getUniqueMessageId(), batchId);
-        }
+        logger.debug("Mail preparation succeed for message [{}] of batch [{}].",
+            message.getUniqueMessageId(), batchId);
     }
 
     @Override
     public void onPrepareMessageError(ExtendedMimeMessage message, Exception exception, Map<String, Object> parameters)
     {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Mail preparation failed for message [{}] of batch [{}].",
-                message.getUniqueMessageId(), batchId, exception);
-        }
+        logger.debug("Mail preparation failed for message [{}] of batch [{}].",
+            message.getUniqueMessageId(), batchId, exception);
     }
 
     @Override
@@ -90,19 +86,15 @@ public abstract class AbstractMailListener implements MailListener
     @Override
     public void onSendMessageSuccess(ExtendedMimeMessage message, Map<String, Object> parameters)
     {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Mail sent successfully for message [{}] of batch [{}].",
-                message.getUniqueMessageId(), batchId);
-        }
+        logger.debug("Mail sent successfully for message [{}] of batch [{}].",
+            message.getUniqueMessageId(), batchId);
     }
 
     @Override
     public void onSendMessageError(ExtendedMimeMessage message, Exception exception, Map<String, Object> parameters)
     {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Mail sending failed for message [{}] of batch [{}].",
-                message.getUniqueMessageId(), batchId, exception);
-        }
+        logger.debug("Mail sending failed for message [{}] of batch [{}].",
+            message.getUniqueMessageId(), batchId, exception);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -2763,9 +2763,7 @@ public class XWiki implements EventListener
                 return urlFactory.getURL(url, context);
             }
         } catch (Exception e) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Exception while getting skin file [{}] from skin [{}]", fileName, skinId, e);
-            }
+            LOGGER.debug("Exception while getting skin file [{}] from skin [{}]", fileName, skinId, e);
         }
 
         return null;
@@ -6097,14 +6095,10 @@ public class XWiki implements EventListener
 
                 String rightsClass = getConfiguration().getProperty("xwiki.authentication.rightsclass");
                 if (rightsClass != null && !DEFAULT_RIGHT_SERVICE_CLASS.equals(rightsClass)) {
-                    if (LOGGER.isDebugEnabled()) {
-                        LOGGER.warn("Using custom Right Service [{}].", rightsClass);
-                    }
+                    LOGGER.warn("Using custom Right Service [{}].", rightsClass);
                 } else {
                     rightsClass = DEFAULT_RIGHT_SERVICE_CLASS;
-                    if (LOGGER.isDebugEnabled()) {
-                        LOGGER.debug("Using default Right Service [{}].", rightsClass);
-                    }
+                    LOGGER.debug("Using default Right Service [{}].", rightsClass);
                 }
 
                 try {
@@ -6179,9 +6173,7 @@ public class XWiki implements EventListener
         String urlFactoryServiceClass = getConfiguration().getProperty("xwiki.urlfactory.serviceclass");
         if (urlFactoryServiceClass != null) {
             try {
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("Using custom URLFactory Service Class [{}]", urlFactoryServiceClass);
-                }
+                LOGGER.debug("Using custom URLFactory Service Class [{}]", urlFactoryServiceClass);
                 factoryService = (XWikiURLFactoryService) Class.forName(urlFactoryServiceClass)
                     .getConstructor(XWiki.class).newInstance(this);
             } catch (Exception e) {
@@ -6190,9 +6182,7 @@ public class XWiki implements EventListener
             }
         }
         if (factoryService == null) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Using default URLFactory Service Class [{}]", urlFactoryServiceClass);
-            }
+            LOGGER.debug("Using default URLFactory Service Class [{}]", urlFactoryServiceClass);
             factoryService = new XWikiURLFactoryServiceImpl(this);
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/legacy/LegacySessionImplementor.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/legacy/LegacySessionImplementor.java
@@ -31,7 +31,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.logging.LoggerConfiguration;
 
-import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.internal.store.hibernate.query.HqlQueryUtils;
 
 /**
@@ -48,7 +47,7 @@ import com.xpn.xwiki.internal.store.hibernate.query.HqlQueryUtils;
 @Deprecated
 public class LegacySessionImplementor extends SessionDelegatorBaseImpl
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(XWiki.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LegacySessionImplementor.class);
 
     private static final String LEGACY_ORDINAL_PARAMS_PREFIX =
         QueryTranslator.ERROR_LEGACY_ORDINAL_PARAMS_NO_LONGER_SUPPORTED.substring(0, 115);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/user/UserAuthenticatedEventNotifier.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/user/UserAuthenticatedEventNotifier.java
@@ -74,9 +74,7 @@ public class UserAuthenticatedEventNotifier
      */
     private void notify(UserAuthenticatedEvent event)
     {
-        if (this.logger.isDebugEnabled()) {
-            this.logger.debug("User authenticated for [{}]", event.getUserReference());
-        }
+        this.logger.debug("User authenticated for [{}]", event.getUserReference());
         this.observationManager.notify(event, null);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/stats/impl/xwiki/VisitStatsStoreItem.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/stats/impl/xwiki/VisitStatsStoreItem.java
@@ -92,9 +92,7 @@ public class VisitStatsStoreItem extends AbstractStatsStoreItem
                     // TODO Fix use of deprecated call.
                     store.deleteXWikiCollection(oldVisitStats, this.context, true, true);
                 } catch (Exception e) {
-                    if (LOGGER.isWarnEnabled()) {
-                        LOGGER.error("Failed to delete old visit statistics object from database [{}]", getId(), e);
-                    }
+                    LOGGER.error("Failed to delete old visit statistics object from database [{}]", getId(), e);
                 }
             }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateBaseStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateBaseStore.java
@@ -637,9 +637,7 @@ public class XWikiHibernateBaseStore extends AbstractXWikiStore
         try {
             Session session = this.store.getCurrentSession();
             if (session != null) {
-                if (LOGGER.isWarnEnabled()) {
-                    LOGGER.warn("Cleanup of session was needed: [{}]", session);
-                }
+                LOGGER.warn("Cleanup of session was needed: [{}]", session);
 
                 this.store.endTransaction(false);
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/HibernateAttachmentVersioningStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/HibernateAttachmentVersioningStore.java
@@ -22,10 +22,11 @@ package com.xpn.xwiki.store.hibernate;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import jakarta.inject.Inject;
+
 import org.hibernate.ObjectNotFoundException;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.xwiki.component.annotation.Component;
 
 import com.xpn.xwiki.XWikiContext;
@@ -47,7 +48,8 @@ import com.xpn.xwiki.store.XWikiHibernateBaseStore;
 public class HibernateAttachmentVersioningStore extends XWikiHibernateBaseStore implements AttachmentVersioningStore
 {
     /** logger. */
-    private static final Logger LOGGER = LoggerFactory.getLogger(HibernateAttachmentVersioningStore.class);
+    @Inject
+    private Logger logger;
 
     /**
      * @param context the current context.
@@ -116,7 +118,7 @@ public class HibernateAttachmentVersioningStore extends XWikiHibernateBaseStore 
                 return null;
             });
         } catch (Exception e) {
-            LOGGER.warn("Error deleting attachment archive [{}] of doc [{}]. Root cause is [{}]",
+            this.logger.warn("Error deleting attachment archive [{}] of doc [{}]. Root cause is [{}]",
                 attachment.getFilename(), attachment.getDoc().getDocumentReference(),
                 ExceptionUtils.getRootCauseMessage(e));
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R35102XWIKI7771DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R35102XWIKI7771DataMigration.java
@@ -110,6 +110,9 @@ public class R35102XWIKI7771DataMigration extends AbstractHibernateDataMigration
      */
     private static class R35102Work implements Work
     {
+        /** Logging helper object. */
+        private static final Logger LOGGER = LoggerFactory.getLogger(R35102Work.class);
+
         /** The name of the table to fix. */
         private String tableName;
 
@@ -121,9 +124,6 @@ public class R35102XWIKI7771DataMigration extends AbstractHibernateDataMigration
 
         /** What kind of data is corrupt when a migration fails. */
         private String dataType;
-
-        /** Logging helper object. */
-        private Logger logger = LoggerFactory.getLogger(R35102Work.class);
 
         /**
          * Constructor specifying the table and columns to fix.
@@ -180,7 +180,7 @@ public class R35102XWIKI7771DataMigration extends AbstractHibernateDataMigration
                             // way of getting back the missing bytes, we can just empty the value set in this row.
                             // Start a new transaction
                             connection.rollback();
-                            this.logger.warn("[{}] [{}] cannot be recovered. Root cause is [{}]", this.dataType,
+                            LOGGER.warn("[{}] [{}] cannot be recovered. Root cause is [{}]", this.dataType,
                                 lob.getValue(), ExceptionUtils.getRootCauseMessage(ex));
                             emptyLob.setString(1, lob.getKey());
                             emptyLob.executeUpdate();

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R40000XWIKI6990DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R40000XWIKI6990DataMigration.java
@@ -1385,9 +1385,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
         }
 
         logProgress("%d schema updates required.", this.logCount);
-        if (this.logger.isDebugEnabled()) {
-            this.logger.debug("About to execute this Liquibase XML: [{}]", sb);
-        }
+        this.logger.debug("About to execute this Liquibase XML: [{}]", sb);
         return sb.toString();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R4359XWIKI1459DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R4359XWIKI1459DataMigration.java
@@ -124,10 +124,7 @@ public class R4359XWIKI1459DataMigration extends AbstractHibernateDataMigration
                             session.createSQLQuery("update xwikidoc set XWD_ARCHIVE=' ' where XWD_ID=?");
 
                     for (Object[] result : rs) {
-                        if (R4359XWIKI1459DataMigration.this.logger.isInfoEnabled()) {
-                            R4359XWIKI1459DataMigration.this.logger
-                                    .info("Updating document [{}]...", result[2].toString());
-                        }
+                        R4359XWIKI1459DataMigration.this.logger.info("Updating document [{}]...", result[2]);
                         long docId = Long.parseLong(result[0].toString());
                         String sArchive = result[1].toString();
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R6079XWIKI1878DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R6079XWIKI1878DataMigration.java
@@ -122,9 +122,7 @@ public class R6079XWIKI1878DataMigration extends AbstractHibernateDataMigration
 
                     while (it.hasNext()) {
                         Object[] result = it.next();
-                        if (R6079XWIKI1878DataMigration.this.logger.isInfoEnabled()) {
-                            R6079XWIKI1878DataMigration.this.logger.info("Fixing document [{}]...", result[2]);
-                        }
+                        R6079XWIKI1878DataMigration.this.logger.info("Fixing document [{}]...", result[2]);
 
                         // Reconstruct a XWikiRCSNodeContent object with isDiff set to false and update it.
                         XWikiRCSNodeId nodeId = (XWikiRCSNodeId) result[0];

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/api/XWikiUser.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/api/XWikiUser.java
@@ -65,6 +65,8 @@ public class XWikiUser
     public static final LocalDocumentReference ACCOUNT_VALIDATION_DOCUMENT_REFERENCE =
         new LocalDocumentReference(XWiki.SYSTEM_SPACE, "AccountValidation");
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(XWikiUser.class);
+
     /**
      * @see com.xpn.xwiki.internal.model.reference.CurrentMixedStringDocumentReferenceResolver
      */
@@ -75,8 +77,6 @@ public class XWikiUser
     private ContextualLocalizationManager localization;
 
     private UserReferenceResolver<DocumentReference> documentReferenceUserReferenceResolver;
-
-    private Logger logger = LoggerFactory.getLogger(XWikiUser.class);
 
     private String fullName;
 
@@ -281,7 +281,7 @@ public class XWikiUser
                 // Default value of email_checked should be 1 (i.e. checked) if not set.
                 isChecked = userdoc.getIntValue(userClassReference, EMAIL_CHECKED_PROPERTY, 1) != 0;
             } catch (XWikiException e) {
-                this.logger.error("Error while checking email_checked status of user [{}]", getUser(), e);
+                LOGGER.error("Error while checking email_checked status of user [{}]", getUser(), e);
                 isChecked = true;
             }
         }
@@ -309,7 +309,7 @@ public class XWikiUser
                 context.getWiki().saveDocument(userdoc, localizePlainOrKey(
                     "core.users." + (checked ? EMAIL_CHECKED_PROPERTY : "email_unchecked") + ".saveComment"), context);
             } catch (XWikiException e) {
-                this.logger.error("Error while setting email_checked status of user [{}]", getUser(), e);
+                LOGGER.error("Error while setting email_checked status of user [{}]", getUser(), e);
             }
         }
     }
@@ -334,7 +334,7 @@ public class XWikiUser
                 // Default value of active should be 1 (i.e. active) if not set
                 disabled = userdoc.getIntValue(userClassReference, ACTIVE_PROPERTY, 1) == 0;
             } catch (XWikiException e) {
-                this.logger.error("Error while checking active status of user [{}]", getUser(), e);
+                LOGGER.error("Error while checking active status of user [{}]", getUser(), e);
                 disabled = false;
             }
         }
@@ -371,7 +371,7 @@ public class XWikiUser
                 context.getWiki().saveDocument(userdoc,
                     localizePlainOrKey("core.users." + (disable ? "disable" : "enable") + ".saveComment"), context);
             } catch (XWikiException e) {
-                this.logger.error("Error while setting active status of user [{}]", getUser(), e);
+                LOGGER.error("Error while setting active status of user [{}]", getUser(), e);
             }
         }
     }
@@ -388,7 +388,7 @@ public class XWikiUser
             XWikiDocument userdoc = getUserDocument(context);
             exists = !userdoc.isNew();
         } catch (XWikiException e) {
-            this.logger.error("Error while checking existing status of user [{}]", getUser(), e);
+            LOGGER.error("Error while checking existing status of user [{}]", getUser(), e);
         }
         return exists;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyFormAuthenticator.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyFormAuthenticator.java
@@ -160,9 +160,7 @@ public class MyFormAuthenticator extends FormAuthenticator implements XWikiAuthe
                 principal = authenticate(username, password, context);
 
                 if (principal != null) {
-                    if (LOGGER.isDebugEnabled()) {
-                        LOGGER.debug("User [{}] has been authentified from cookie", principal.getName());
-                    }
+                    LOGGER.debug("User [{}] has been authentified from cookie", principal.getName());
 
                     // make sure the Principal contains wiki name information
                     if (!StringUtils.contains(principal.getName(), ':')) {
@@ -213,9 +211,7 @@ public class MyFormAuthenticator extends FormAuthenticator implements XWikiAuthe
             Utils.getComponent(AuthenticationFailureManager.class);
         if (principal != null && authenticationFailureManager.validateForm(username, request)) {
             // login successful
-            if (LOGGER.isInfoEnabled()) {
-                LOGGER.info("User [{}] has been logged-in", principal.getName());
-            }
+            LOGGER.info("User [{}] has been logged-in", principal.getName());
 
             authenticationFailureManager.resetAuthenticationFailureCounter(username);
 
@@ -254,9 +250,7 @@ public class MyFormAuthenticator extends FormAuthenticator implements XWikiAuthe
         } else {
             // login failed
             // set response status and forward to error page
-            if (LOGGER.isInfoEnabled()) {
-                LOGGER.info("User [{}] login has failed", username);
-            }
+            LOGGER.info("User [{}] login has failed", username);
 
             authenticationFailureManager.recordAuthenticationFailure(username, request);
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiAuthServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiAuthServiceImpl.java
@@ -209,9 +209,7 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
 
             // Process logout (this only works with Forms)
             if (auth.processLogout(wrappedRequest, response, new URLPatternMatcher())) {
-                if (LOGGER.isInfoEnabled()) {
-                    LOGGER.info("User [{}] has been logged-out", context.getUser());
-                }
+                LOGGER.info("User [{}] has been logged-out", context.getUser());
                 wrappedRequest.setUserPrincipal(null);
                 return null;
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiGroupServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiGroupServiceImpl.java
@@ -70,7 +70,7 @@ public class XWikiGroupServiceImpl implements XWikiGroupService, EventListener
     public static final EntityReference GROUPCLASS_REFERENCE = new EntityReference(CLASS_SUFFIX_XWIKIGROUPS,
         EntityType.DOCUMENT, new EntityReference(XWiki.SYSTEM_SPACE, EntityType.SPACE));
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(XWikiDocument.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(XWikiGroupServiceImpl.class);
 
     /**
      * Name of the "XWiki.XWikiUsers" class without the space name.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiRightServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiRightServiceImpl.java
@@ -356,9 +356,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
 
         List<BaseObject> rightObjects = doc.getXObjects(rightClassReference);
         if (rightObjects != null) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Checking objects [{}]", rightObjects.size());
-            }
+            LOGGER.debug("Checking objects [{}]", rightObjects.size());
 
             for (int i = 0; i < rightObjects.size(); i++) {
                 LOGGER.debug("Checking object [{}]", i);
@@ -446,9 +444,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
                 userOrGroupDocumentReference, grouplist, context);
         }
 
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Searching for matching rights for [{}] groups: [{}]", grouplist.size(), grouplist);
-        }
+        LOGGER.debug("Searching for matching rights for [{}] groups: [{}]", grouplist.size(), grouplist);
 
         for (String group : grouplist) {
             try {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/AdminAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/AdminAction.java
@@ -22,8 +22,9 @@ package com.xpn.xwiki.web;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import jakarta.inject.Inject;
+
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.xwiki.component.annotation.Component;
 
 import com.xpn.xwiki.XWikiContext;
@@ -42,7 +43,8 @@ import com.xpn.xwiki.doc.XWikiLock;
 public class AdminAction extends XWikiAction
 {
     /** The logger. */
-    private static final Logger LOGGER = LoggerFactory.getLogger(AdminAction.class);
+    @Inject
+    private Logger logger;
 
     /**
      * Default constructor.
@@ -146,7 +148,7 @@ public class AdminAction extends XWikiAction
             } catch (Exception e) {
                 // Lock should never make XWiki fail
                 // But we should log any related information
-                LOGGER.error("Exception while setting up lock", e);
+                this.logger.error("Exception while setting up lock", e);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/CommentAddAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/CommentAddAction.java
@@ -29,7 +29,6 @@ import javax.script.ScriptContext;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.xwiki.captcha.Captcha;
 import org.xwiki.captcha.CaptchaConfiguration;
 import org.xwiki.component.annotation.Component;
@@ -66,7 +65,8 @@ public class CommentAddAction extends XWikiAction
     /** The name of the space where user profiles are kept. */
     private static final String USER_SPACE_PREFIX = "XWiki.";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CommentAddAction.class);
+    @Inject
+    private Logger logger;
 
     @Inject
     private UserReferenceResolver<CurrentUserReference> currentUserReferenceUserReferenceResolver;
@@ -183,7 +183,8 @@ public class CommentAddAction extends XWikiAction
 
                 return captcha.isValid();
             } catch (Exception e) {
-                LOGGER.error("Failed to verify CAPTCHA of type [{}]. Assuming wrong answer.", defaultCaptchaName, e);
+                this.logger.error("Failed to verify CAPTCHA of type [{}]. Assuming wrong answer.",
+                    defaultCaptchaName, e);
                 return false;
             }
         } else {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/DownloadRevAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/DownloadRevAction.java
@@ -24,8 +24,9 @@ import java.io.IOException;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import jakarta.inject.Inject;
+
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.EntityReference;
@@ -44,7 +45,8 @@ import com.xpn.xwiki.plugin.XWikiPluginManager;
 @Singleton
 public class DownloadRevAction extends DownloadAction
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DownloadRevAction.class);
+    @Inject
+    private Logger logger;
 
     @Override
     public String render(XWikiContext context) throws XWikiException
@@ -105,7 +107,7 @@ public class DownloadRevAction extends DownloadAction
                     context.getResponse().sendRedirect(url);
                     return null;
                 } catch (IOException ioe) {
-                    LOGGER.error("Failed to redirect to [{}]", url, ioe);
+                    this.logger.error("Failed to redirect to [{}]", url, ioe);
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/EditAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/EditAction.java
@@ -27,7 +27,6 @@ import javax.script.ScriptContext;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.csrf.CSRFToken;
 import org.xwiki.model.reference.DocumentReference;
@@ -53,7 +52,8 @@ public class EditAction extends XWikiAction
     /**
      * The object used for logging.
      */
-    private static final Logger LOGGER = LoggerFactory.getLogger(EditAction.class);
+    @Inject
+    private Logger logger;
 
     @Inject
     @Named("document")
@@ -325,7 +325,7 @@ public class EditAction extends XWikiAction
             }
         } catch (Exception e) {
             // Lock should never make XWiki fail, but we should log any related information.
-            LOGGER.error("Exception while setting up lock", e);
+            this.logger.error("Exception while setting up lock", e);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/LogoutAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/LogoutAction.java
@@ -27,7 +27,6 @@ import javax.servlet.http.HttpSession;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.csrf.CSRFToken;
 import org.xwiki.model.EntityType;
@@ -52,7 +51,8 @@ import com.xpn.xwiki.XWikiException;
 @Singleton
 public class LogoutAction extends XWikiAction
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(LogoutAction.class);
+    @Inject
+    private Logger logger;
 
     @Inject
     private CSRFToken csrf;
@@ -105,7 +105,7 @@ public class LogoutAction extends XWikiAction
 
             sendRedirect(response, redirect);
         } else {
-            LOGGER.debug("Skipping the redirect because the response has already been committed"
+            this.logger.debug("Skipping the redirect because the response has already been committed"
                 + " (e.g. by a custom authenticator)");
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/RegisterAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/RegisterAction.java
@@ -29,7 +29,6 @@ import javax.script.ScriptContext;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.xwiki.captcha.Captcha;
 import org.xwiki.captcha.CaptchaConfiguration;
 import org.xwiki.component.annotation.Component;
@@ -60,7 +59,8 @@ public class RegisterAction extends XWikiAction
     private static final String REG_CONSTANT = "reg";
 
     /** Logger. */
-    private static final Logger LOGGER = LoggerFactory.getLogger(RegisterAction.class);
+    @Inject
+    private Logger logger;
 
     /** Space where the registration config and class are stored. */
     private static final String WIKI_SPACE = "XWiki";
@@ -153,11 +153,11 @@ public class RegisterAction extends XWikiAction
                 Captcha captcha = Utils.getComponent(org.xwiki.captcha.Captcha.class, defaultCaptchaName);
 
                 if (!captcha.isValid()) {
-                    LOGGER.warn("Incorrect CAPTCHA answer");
+                    this.logger.warn("Incorrect CAPTCHA answer");
                     return false;
                 }
             } catch (Exception e) {
-                LOGGER.warn("Cannot verify answer for CAPTCHA of type [{}]: [{}]", defaultCaptchaName,
+                this.logger.warn("Cannot verify answer for CAPTCHA of type [{}]: [{}]", defaultCaptchaName,
                     ExceptionUtils.getRootCauseMessage(e));
                 return false;
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SaveAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SaveAction.java
@@ -40,7 +40,6 @@ import javax.script.ScriptContext;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.core5.http.HttpStatus;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.suigeneris.jrcs.diff.DifferentiationFailedException;
 import org.suigeneris.jrcs.diff.delta.Delta;
 import org.suigeneris.jrcs.rcs.Version;
@@ -90,7 +89,8 @@ public class SaveAction extends EditAction
     protected static final String ASYNC_PARAM = "async";
 
     /** Logger. */
-    private static final Logger LOGGER = LoggerFactory.getLogger(SaveAction.class);
+    @Inject
+    private Logger logger;
 
     /**
      * The key used to store the JSON answer for the save action on the XWiki context.
@@ -393,7 +393,7 @@ public class SaveAction extends EditAction
                 try {
                     customValue = URLDecoder.decode(customValue, request.getCharacterEncoding());
                 } catch (UnsupportedEncodingException e) {
-                    LOGGER.error("Error while decoding a custom value decision.", e);
+                    this.logger.error("Error while decoding a custom value decision.", e);
                 }
                 customChoicesMap.put(conflictReference, customValue);
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SaveAndContinueAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SaveAndContinueAction.java
@@ -30,7 +30,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.core5.http.HttpStatus;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.xwiki.component.annotation.Component;
 
 import com.xpn.xwiki.XWikiContext;
@@ -52,7 +51,8 @@ public class SaveAndContinueAction extends XWikiAction
     private static final String WRAPPED_ACTION_CONTEXT_KEY = "SaveAndContinueAction.wrappedAction";
 
     /** Logger. */
-    private static final Logger LOGGER = LoggerFactory.getLogger(SaveAndContinueAction.class);
+    @Inject
+    private Logger logger;
 
     @Inject
     @Named("save")
@@ -113,7 +113,7 @@ public class SaveAndContinueAction extends XWikiAction
                         localizePlainOrKey("core.editors.saveandcontinue.theDocumentWasNotSaved");
                     // This should not happen. SaveAction.save(context) should normally throw an
                     // exception when failing during save and continue.
-                    LOGGER.error("SaveAction.save(context) returned true while using save & continue");
+                    this.logger.error("SaveAction.save(context) returned true while using save & continue");
                     writeAjaxErrorResponse(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, errorMessage, context);
                 } else if (context.getResponse().getStatus() != HttpStatus.SC_CONFLICT) {
                     context.put(WRAPPED_ACTION_CONTEXT_KEY, sa);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/UploadAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/UploadAction.java
@@ -32,10 +32,11 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.servlet.http.HttpServletResponse;
 
+import jakarta.inject.Inject;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.xwiki.attachment.validation.AttachmentValidationException;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.localization.LocaleUtils;
@@ -67,7 +68,8 @@ public class UploadAction extends XWikiAction
     public static final String FILE_FIELD_NAME = "filepath";
 
     /** Logging helper object. */
-    private static final Logger LOGGER = LoggerFactory.getLogger(UploadAction.class);
+    @Inject
+    private Logger logger;
 
     /** The prefix of the corresponding filename input field name. */
     private static final String FILENAME_FIELD_NAME = "filename";
@@ -137,20 +139,20 @@ public class UploadAction extends XWikiAction
             try {
                 uploadAttachment(file.getValue(), file.getKey(), fileupload, doc, context);
             } catch (Exception ex) {
-                LOGGER.warn("Failed to save uploaded file [{}]. Root cause is [{}]", file.getKey(),
+                this.logger.warn("Failed to save uploaded file [{}]. Root cause is [{}]", file.getKey(),
                     ExceptionUtils.getRootCauseMessage(ex));
                 failedFiles.put(file.getKey(), ExceptionUtils.getRootCauseMessage(ex));
             }
         }
 
-        LOGGER.debug("Found files to upload: {}", fileNames);
-        LOGGER.debug("Failed attachments: {}", failedFiles);
-        LOGGER.debug("Wrong attachment names: {}", wrongFileNames);
+        this.logger.debug("Found files to upload: {}", fileNames);
+        this.logger.debug("Failed attachments: {}", failedFiles);
+        this.logger.debug("Wrong attachment names: {}", wrongFileNames);
         if (ajax) {
             try {
                 response.getOutputStream().println("ok");
             } catch (IOException ex) {
-                LOGGER.error("Unhandled exception writing output:", ex);
+                this.logger.error("Unhandled exception writing output:", ex);
             }
             return false;
         }
@@ -304,7 +306,7 @@ public class UploadAction extends XWikiAction
                 context.getResponse().getOutputStream()
                     .println("error: " + localizePlainOrKey((String) context.get(MESSAGE)));
             } catch (IOException ex) {
-                LOGGER.error("Unhandled exception writing output:", ex);
+                this.logger.error("Unhandled exception writing output:", ex);
             }
             return null;
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiURLFactoryServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiURLFactoryServiceImpl.java
@@ -31,7 +31,7 @@ import com.xpn.xwiki.pdf.impl.PdfURLFactory;
 
 public class XWikiURLFactoryServiceImpl implements XWikiURLFactoryService
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(XWikiURLFactoryService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(XWikiURLFactoryServiceImpl.class);
 
     private Map<Integer, Class<? extends XWikiURLFactory>> factoryMap;
 

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/cache/internal/DefaultSecurityCache.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/cache/internal/DefaultSecurityCache.java
@@ -495,9 +495,7 @@ public class DefaultSecurityCache implements SecurityCache, Initializable
             if (children != null) {
                 for (SecurityCacheEntry child : children) {
                     if (!child.disposed) {
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("Cascaded removal of entry [{}] from cache.", child.getKey());
-                        }
+                        logger.debug("Cascaded removal of entry [{}] from cache.", child.getKey());
                         child.dispose();
                     }
                 }
@@ -530,9 +528,7 @@ public class DefaultSecurityCache implements SecurityCache, Initializable
         {
             if (this.children != null) {
                 this.children.remove(entry);
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Remove child [{}] from [{}].", entry.getKey(), getKey());
-                }
+                logger.debug("Remove child [{}] from [{}].", entry.getKey(), getKey());
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/JsxAction.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/JsxAction.java
@@ -27,10 +27,11 @@ import java.util.Map;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import jakarta.inject.Inject;
+
 import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.xwiki.component.annotation.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -62,7 +63,8 @@ public class JsxAction extends AbstractSxAction
     public static final JsExtension JSX = new JsExtension();
 
     /** Logging helper. */
-    private static final Logger LOGGER = LoggerFactory.getLogger(JsxAction.class);
+    @Inject
+    private Logger logger;
 
     private static final String SOURCE_MAPS_SESSION_ATTRIBUTE = JsxAction.class.getName() + ".sourceMaps";
 
@@ -80,7 +82,7 @@ public class JsxAction extends AbstractSxAction
     @Override
     protected Logger getLogger()
     {
-        return LOGGER;
+        return this.logger;
     }
 
     @Override
@@ -212,8 +214,8 @@ public class JsxAction extends AbstractSxAction
             }
             return objectMapper.writeValueAsString(sourceMap);
         } catch (Exception e) {
-            LOGGER.warn("Failed to fix the source path in the generated JavaScript source mapping. Root cause is [{}].",
-                ExceptionUtils.getRootCauseMessage(e));
+            this.logger.warn("Failed to fix the source path in the generated JavaScript source mapping. "
+                + "Root cause is [{}].", ExceptionUtils.getRootCauseMessage(e));
             return sourceMapJSON;
         }
     }
@@ -226,7 +228,7 @@ public class JsxAction extends AbstractSxAction
             // Try to return a relative source URL because this is going to be saved in the source map.
             return urlFactory.getURL(new URL(sourceURL), context);
         } catch (MalformedURLException e) {
-            LOGGER.warn("Failed to convert absolute source URL to relative URL. Root cause is [{}].",
+            this.logger.warn("Failed to convert absolute source URL to relative URL. Root cause is [{}].",
                 ExceptionUtils.getRootCauseMessage(e));
             return sourceURL;
         }

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/SsxAction.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/SsxAction.java
@@ -22,8 +22,9 @@ package com.xpn.xwiki.web;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import jakarta.inject.Inject;
+
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.xwiki.component.annotation.Component;
 
 import com.xpn.xwiki.web.sx.AbstractSxAction;
@@ -47,7 +48,8 @@ public class SsxAction extends AbstractSxAction
     public static final CssExtension CSSX = new CssExtension();
 
     /** Logging helper. */
-    private static final Logger LOGGER = LoggerFactory.getLogger(SsxAction.class);
+    @Inject
+    private Logger logger;
 
     @Override
     public Extension getExtensionType()
@@ -58,6 +60,6 @@ public class SsxAction extends AbstractSxAction
     @Override
     protected Logger getLogger()
     {
-        return LOGGER;
+        return this.logger;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
@@ -36,7 +36,6 @@ import java.util.stream.Stream;
 import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xwiki.test.ui.po.BasePage;
 
 import com.deque.html.axecore.results.Results;
 import com.deque.html.axecore.results.Rule;
@@ -151,7 +150,7 @@ public class WCAGContext
      */
     private static final List<String> DISABLED_RULES = List.of();
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(BasePage.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(WCAGContext.class);
 
     /**
      * Stores the result of an axe-core validity scan.

--- a/xwiki-platform-core/xwiki-platform-zipexplorer/src/main/java/com/xpn/xwiki/plugin/zipexplorer/ZipExplorerPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-zipexplorer/src/main/java/com/xpn/xwiki/plugin/zipexplorer/ZipExplorerPlugin.java
@@ -56,7 +56,7 @@ public class ZipExplorerPlugin extends XWikiDefaultPlugin
     /**
      * Log object to log messages in this class.
      */
-    private static final Logger LOG = LoggerFactory.getLogger(ZipExplorerPlugin.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZipExplorerPlugin.class);
 
     /**
      * Path separators for URL.
@@ -156,7 +156,8 @@ public class ZipExplorerPlugin extends XWikiDefaultPlugin
                 }
             }
         } catch (XWikiException | IOException e) {
-            e.printStackTrace();
+            LOGGER.error("Failed to extract file [{}] from the ZIP attachment [{}]", filename,
+                attachment.getReference(), e);
         }
         return newAttachment;
     }
@@ -186,7 +187,8 @@ public class ZipExplorerPlugin extends XWikiDefaultPlugin
                 }
             }
         } catch (XWikiException | IOException e) {
-            e.printStackTrace();
+            LOGGER.error("Failed to list the entries of the ZIP attachment [{}] of document [{}]", attachmentName,
+                document.getPrefixedFullName(), e);
         }
         return zipList;
     }
@@ -284,7 +286,7 @@ public class ZipExplorerPlugin extends XWikiDefaultPlugin
             // In case of error we log the error and continue with the undecoded URL.
             // TODO: Ideally this should rather fail fast but we have no exception handling
             // framework for scripting code. Change this when we have one.
-            LOG.error("Failed to decode URL path [{}]", path, e);
+            LOGGER.error("Failed to decode URL path [{}]", path, e);
         }
 
         return path;
@@ -309,7 +311,7 @@ public class ZipExplorerPlugin extends XWikiDefaultPlugin
             try {
                 filecontent.reset();
             } catch (IOException e) {
-                e.printStackTrace();
+                LOGGER.error("Failed to reset the file content stream after checking for a ZIP header", e);
             }
         }
         return false;


### PR DESCRIPTION
Fourth pass of the [logging best practices](https://dev.xwiki.org/xwiki/bin/view/Community/CodeStyle/JavaCodeStyle/#HLoggingBestPractices) audit, continuing #6055 … #6068. 50 sites across 11 modules.

The first three passes all keyed off the **log call**. None of them ever looked at the **`Logger` field itself** — how it is acquired, which class it names, or its modifiers — even though that is the first bullet of the rules page. That is the gap this PR closes. It also re-runs the redundant-guard detector with a wider net (40 candidates rather than the 9 the third pass saw) and re-runs `printStackTrace` detection over files that pass skipped.

### Defects fixed, not just style

* **Four loggers named the wrong class.** `XWikiGroupServiceImpl` logged as `XWikiDocument`, `LegacySessionImplementor` as `XWiki`, `WCAGContext` as `BasePage`, and `XWikiURLFactoryServiceImpl` as its own interface. Besides the misattribution, this silently breaks per-class log configuration: raising `XWikiGroupServiceImpl` to DEBUG did nothing, while raising `XWikiDocument` turned on lines from a class the admin never asked about.
* **Two guards tested the wrong level, suppressing the message.** `XWiki` line ~6100 hid a `warn()` behind `isDebugEnabled()`, so "Using custom Right Service" never appeared in a normal install; `VisitStatsStoreItem` hid an `error()` behind `isWarnEnabled()`.
* **Four `printStackTrace()` calls left in main code**, each in a `catch` that then swallowed the failure — so the trace missed the log file, the level, the timestamp and the logger name, and is not captured at all under the functional-test harness.

### Breakdown

| Category | Fixed | Notes |
|---|---:|---|
| Redundant `isXxxEnabled()` guard | 23 | of 40 candidates |
| `@Component` not using `@Inject Logger` | 12 | of 18 |
| Logger names another class | 4 | |
| `printStackTrace()` in main code | 4 | missed by the third pass |
| `Logger` field not `static final` | 4 | |
| Field named `LOG` instead of `LOGGER` | 3 | |

### What was deliberately left alone

* **17 guards whose arguments do real work** — argument evaluation is not deferred, so removing the guard pays that cost on every call. Kept for `getEntryKey(...)` in `DefaultSecurityCache` (builds a key via `StringBuilder` + reference serialization), `getDBVersion()` in `AbstractDataMigrationManager` (takes a lock, may query the DB), `String.format`-based `getId()`, `String.join`/`StringUtils.join` arguments, and the DBCP pool accessors.
* **Six `@Component` classes that cannot take an injected logger yet** — `DateXarObjectPropertySerializer` reads it from a `static` method, and `XWikiCacheStore`, `SkinAction`, `UndeleteAction` and `TempResourceAction` are constructed directly with `new` in their unit tests, where an injected field would be `null`. Converting them means first moving those tests onto `@InjectMockComponents`.
* **`protected`/`public` logger fields** (27 sites) — the rule says `private`, but these are inherited across modules, so tightening them is an API break for no logging benefit.
* **`SHUTDOWN_LOGGER`** — deliberately a named logger (`org.xwiki.shutdown`), not a class logger.

### Verification

`mvn -B -ntp test` and `mvn -B -ntp checkstyle:check -Plegacy,quality` run from each of the 11 bundled module directories. Checkstyle passes everywhere; tests pass everywhere except one pre-existing `oldcore` failure — `XWikiDocumentTest.testRenderedTitleWhenVelocityError`, which reproduces identically on a clean `master` (it resolves a stale locally-installed `xwiki-platform-display` SNAPSHOT that predates #6063's message change).

No test needed updating: no changed message alters its rendered text (the two reflowed strings concatenate to the same value), and no test asserts on the log output of a converted class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
