### PR TITLE
[Misc] Apply the logging best practices to oldcore and 16 more platform modules

### DIFF
--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/main/java/org/xwiki/attachment/internal/listener/MovedAttachmentListener.java
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/main/java/org/xwiki/attachment/internal/listener/MovedAttachmentListener.java
@@ -107,8 +107,8 @@ public class MovedAttachmentListener implements EventListener
             try {
                 updateBackLinks(attachmentMovedEvent, canEdit);
             } catch (RefactoringException e) {
-                this.logger.error("Failed to update backlinks targetting attachment [{}] for request [{}]",
-                    attachmentMovedEvent.getSourceReference(), moveAttachmentRequest.toString(), e);
+                this.logger.error("Failed to update backlinks targeting attachment [{}] for request [{}]",
+                    attachmentMovedEvent.getSourceReference(), moveAttachmentRequest, e);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-macro/src/main/java/org/xwiki/rendering/internal/macro/dashboard/DashboardMacro.java
+++ b/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-macro/src/main/java/org/xwiki/rendering/internal/macro/dashboard/DashboardMacro.java
@@ -195,7 +195,7 @@ public class DashboardMacro extends AbstractMacro<DashboardMacroParameters> impl
         if (renderer == null) {
             String message = "Could not find dashboard renderer " + parameters.getLayout();
             // log and throw further
-            this.logger.error(message);
+            this.logger.error("Could not find dashboard renderer [{}]", parameters.getLayout());
             throw new MacroExecutionException(message);
         }
 
@@ -208,7 +208,7 @@ public class DashboardMacro extends AbstractMacro<DashboardMacroParameters> impl
         } catch (Exception e) {
             String message = "Could not render the gadgets for layout " + parameters.getLayout();
             // log and throw further
-            this.logger.error(message, e);
+            this.logger.error("Could not render the gadgets for layout [{}]", parameters.getLayout(), e);
             throw new MacroExecutionException(message, e);
         }
 

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-instance/xwiki-platform-filter-instance-extension/src/main/java/org/xwiki/filter/instance/output/ExtensionInstanceOutputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-instance/xwiki-platform-filter-instance-extension/src/main/java/org/xwiki/filter/instance/output/ExtensionInstanceOutputFilterStream.java
@@ -185,7 +185,7 @@ public class ExtensionInstanceOutputFilterStream
             // Notify about the install
             this.observation.notify(new ExtensionInstalledEvent(localExtension.getId(), namespace), installedExtension);
         } catch (Exception e) {
-            this.logger.error("Failed to register extenion [{}] from the XAR", extensionId, e);
+            this.logger.error("Failed to register extension [{}] from the XAR", extensionId, e);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/java/org/xwiki/index/tree/internal/nestedpages/query/QueryRegistrationHandler.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/java/org/xwiki/index/tree/internal/nestedpages/query/QueryRegistrationHandler.java
@@ -102,7 +102,7 @@ public class QueryRegistrationHandler implements EventListener
             // created.
             this.sessionFactory.getConfiguration().addInputStream(replacedStream);
         } catch (IOException e) {
-            this.logger.error("Failed to close the resoure stream", e);
+            this.logger.error("Failed to close the resource stream", e);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/web/TempResourceAction.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/web/TempResourceAction.java
@@ -34,13 +34,14 @@ import java.util.regex.Pattern;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import jakarta.inject.Inject;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.tika.mime.MimeTypes;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.environment.Environment;
 import org.xwiki.tika.internal.TikaUtils;
@@ -91,7 +92,8 @@ public class TempResourceAction extends XWikiAction
     /**
      * Logging support.
      */
-    private static final Logger LOGGER = LoggerFactory.getLogger(TempResourceAction.class);
+    @Inject
+    private Logger logger;
 
     /**
      * Used to find the temporary dir.
@@ -118,7 +120,7 @@ public class TempResourceAction extends XWikiAction
         try {
             contentType = TikaUtils.detect(tempFile);
         } catch (IOException ex) {
-            LOGGER.warn("Unable to determine mime type for temporary resource [{}]. Root cause is [{}]",
+            this.logger.warn("Unable to determine mime type for temporary resource [{}]. Root cause is [{}]",
                 tempFile.getAbsolutePath(), ExceptionUtils.getRootCauseMessage(ex));
         }
         response.setContentType(contentType);

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/web/TempResourceActionTest.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/web/TempResourceActionTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.xwiki.environment.Environment;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
 
 import com.xpn.xwiki.XWikiContext;
@@ -72,12 +73,12 @@ class TempResourceActionTest
     /**
      * The action being tested.
      */
+    @InjectMockComponents
     private TempResourceAction action;
 
     @BeforeEach
     void beforeEach() throws Exception
     {
-        this.action = new TempResourceAction();
         when(this.environment.getTemporaryDirectory()).thenReturn(this.temporaryDirectory);
     }
 

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/thread/MailSenderInitializerListener.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/thread/MailSenderInitializerListener.java
@@ -141,7 +141,7 @@ public class MailSenderInitializerListener implements EventListener, Disposable
         try {
             stopMailThreads();
         } catch (InterruptedException e) {
-            SHUTDOWN_LOGGER.debug("Mail threads shutdown has been interruped", e);
+            SHUTDOWN_LOGGER.debug("Mail threads shutdown has been interrupted", e);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/main/java/org/xwiki/mail/internal/DatabaseMailStatusStore.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/main/java/org/xwiki/mail/internal/DatabaseMailStatusStore.java
@@ -311,7 +311,7 @@ public class DatabaseMailStatusStore implements MailStatusStore
                     builder.append(',').append((' '));
                 }
             }
-            this.logger.debug("Find mail statuses for query [{}] and parameters [{}]", queryString, builder.toString());
+            this.logger.debug("Find mail statuses for query [{}] and parameters [{}]", queryString, builder);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/main/java/org/xwiki/observation/remote/internal/jgroups/JGroupsNetworkAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/main/java/org/xwiki/observation/remote/internal/jgroups/JGroupsNetworkAdapter.java
@@ -63,7 +63,7 @@ public class JGroupsNetworkAdapter implements NetworkAdapter, Disposable
     @Override
     public void send(RemoteEventData remoteEvent)
     {
-        this.logger.debug("Send JGroups remote event [{}]", remoteEvent.toString());
+        this.logger.debug("Send JGroups remote event [{}]", remoteEvent);
 
         // Send the message to the whole group
         // Using BytesMessage and not ObjectMessage (which would have been much better for the memory) here because it's
@@ -75,8 +75,7 @@ public class JGroupsNetworkAdapter implements NetworkAdapter, Disposable
             try {
                 entry.getValue().send(message);
             } catch (Exception e) {
-                this.logger.error("Failed to send message [{}] to the channel [{}]", remoteEvent.toString(),
-                    entry.getKey(), e);
+                this.logger.error("Failed to send message [{}] to the channel [{}]", remoteEvent, entry.getKey(), e);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/HibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/HibernateStore.java
@@ -306,7 +306,7 @@ public class HibernateStore implements Disposable, Initializable
                 return StringUtils.replace(newURL, PROPERTY_TIMEZONE_VARIABLE,
                     URLEncoder.encode(TimeZone.getDefault().getID(), "UTF-8"));
             } catch (UnsupportedEncodingException e) {
-                this.logger.error("Failedd to encode the current timezone id", e);
+                this.logger.error("Failed to encode the current timezone id", e);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactory.java
@@ -202,7 +202,7 @@ public class FileSystemURLFactory extends XWikiServletURLFactory
                 }
 
                 File file = getTemporaryFile(key, context);
-                LOGGER.debug("Temporary PDF export file [{}]", file.toString());
+                LOGGER.debug("Temporary PDF export file [{}]", file);
 
                 if (StringUtils.isNotEmpty(revision)) {
                     attachment = attachment.getAttachmentRevision(revision, context);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
@@ -777,7 +777,7 @@ public class Package
                 Utils.getComponent(ObservationManager.class)
                     .notify(new ExtensionInstalledEvent(installedExtension.getId(), namespace), installedExtension);
             } catch (Exception e) {
-                LOGGER.error("Failed to register extenion [{}] from the XAR", extensionId, e);
+                LOGGER.error("Failed to register extension [{}] from the XAR", extensionId, e);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/stats/impl/XWikiStatsServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/stats/impl/XWikiStatsServiceImpl.java
@@ -172,7 +172,7 @@ public class XWikiStatsServiceImpl implements XWikiStatsService, EventListener
                 this.statsRegister.addStats(document, action, context);
             }
         } catch (Exception e) {
-            LOGGER.error("Faild to get filter users list", e);
+            LOGGER.error("Failed to get filter users list", e);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/stats/impl/xwiki/XWikiStatsReader.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/stats/impl/xwiki/XWikiStatsReader.java
@@ -434,7 +434,7 @@ public class XWikiStatsReader
                 userListWhere.append("?" + paramList.size());
             }
         } catch (Exception e) {
-            LOGGER.error("Faild to get filter users list", e);
+            LOGGER.error("Failed to get filter users list", e);
         }
 
         if (!userListWhere.isEmpty()) {
@@ -497,7 +497,7 @@ public class XWikiStatsReader
                 Collections.reverse(visiStatList);
             }
         } catch (XWikiException e) {
-            LOGGER.error("Faild to search for vist statistics", e);
+            LOGGER.error("Failed to search for visit statistics", e);
 
             visiStatList = Collections.emptyList();
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiCacheStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiCacheStore.java
@@ -74,7 +74,8 @@ import com.xpn.xwiki.web.Utils;
 public class XWikiCacheStore extends AbstractXWikiStore
     implements XWikiCacheStoreInterface, EventListener, Initializable, CacheEntryListener<XWikiDocument>
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(XWikiCacheStore.class);
+    @Inject
+    private Logger logger;
 
     /**
      * Used to know if a received event is a local or remote one.
@@ -127,6 +128,7 @@ public class XWikiCacheStore extends AbstractXWikiStore
     {
         setStore(store);
 
+        this.logger = LoggerFactory.getLogger(XWikiCacheStore.class);
         this.remoteObservationManagerContext = Utils.getComponent(RemoteObservationManagerContext.class);
         this.observationManager = Utils.getComponent(ObservationManager.class);
         this.uidStringEntityReferenceSerializer = Utils.getComponent(EntityReferenceSerializer.TYPE_STRING, "uid");
@@ -393,13 +395,13 @@ public class XWikiCacheStore extends AbstractXWikiStore
             // Calculate the cache key
             String key = getKey(doc, context);
 
-            LOGGER.debug("Starting checking for Document [{}] in cache", key);
+            this.logger.debug("Starting checking for Document [{}] in cache", key);
 
             XWikiDocument cachedoc;
             try {
                 cachedoc = getCache().get(key);
             } catch (Exception e) {
-                LOGGER.error("Failed to get document [{}] from cache", key, e);
+                this.logger.error("Failed to get document [{}] from cache", key, e);
 
                 cachedoc = null;
             }
@@ -410,12 +412,12 @@ public class XWikiCacheStore extends AbstractXWikiStore
             if (cachedoc != null && !cachedoc.isMetaDataDirty()) {
                 cachedoc.setFromCache(true);
 
-                LOGGER.debug("Document [{}] was retrieved from cache", key);
+                this.logger.debug("Document [{}] was retrieved from cache", key);
             } else {
                 Boolean result = getPageExistCache().get(key);
 
                 if (result == Boolean.FALSE) {
-                    LOGGER.debug("Document [{}] doesn't exist in cache, returning an empty one", key);
+                    this.logger.debug("Document [{}] doesn't exist in cache, returning an empty one", key);
 
                     cachedoc = doc;
                     cachedoc.setNew(true);
@@ -429,11 +431,11 @@ public class XWikiCacheStore extends AbstractXWikiStore
                 } else {
                     cachedoc = this.cacheLoader.loadAndStoreInCache(key,
                         k -> {
-                            LOGGER.debug("Trying to get Document [{}] from persistent storage", key);
+                            this.logger.debug("Trying to get Document [{}] from persistent storage", key);
 
                             XWikiDocument databaseDocument = this.store.loadXWikiDoc(doc, context);
 
-                            LOGGER.debug("Document [{}] was retrieved from persistent storage", key);
+                            this.logger.debug("Document [{}] was retrieved from persistent storage", key);
                             return databaseDocument;
                         },
                         this::storeInCache
@@ -442,7 +444,7 @@ public class XWikiCacheStore extends AbstractXWikiStore
             }
 
             cachedoc.setStore(this);
-            LOGGER.debug("Ending checking for Document [{}] in cache", key);
+            this.logger.debug("Ending checking for Document [{}] in cache", key);
 
             return cachedoc;
         } catch (ExecutionException e) {
@@ -469,7 +471,7 @@ public class XWikiCacheStore extends AbstractXWikiStore
             }
         }
 
-        LOGGER.debug("Document [{}] was put in cache", key);
+        this.logger.debug("Document [{}] was put in cache", key);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/AbstractDataMigrationManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/AbstractDataMigrationManager.java
@@ -598,7 +598,8 @@ public abstract class AbstractDataMigrationManager implements DataMigrationManag
             String message =
                 String.format("The empty database %s seems to be not writable, please check your configuration!",
                     getXWikiContext().getWikiId());
-            this.logger.error(message, e);
+            this.logger.error("The empty database [{}] seems to be not writable, please check your configuration!",
+                getXWikiContext().getWikiId(), e);
             throw new DataMigrationException(message, e);
         }
     }
@@ -611,7 +612,8 @@ public abstract class AbstractDataMigrationManager implements DataMigrationManag
         } catch (DataMigrationException e) {
             String message = String.format("Database %s seems to be inaccessible, please check your configuration!",
                 getXWikiContext().getWikiId());
-            this.logger.error(message, e);
+            this.logger.error("Database [{}] seems to be inaccessible, please check your configuration!",
+                getXWikiContext().getWikiId(), e);
             throw new DataMigrationException(message, e);
         }
         return status;
@@ -718,7 +720,7 @@ public abstract class AbstractDataMigrationManager implements DataMigrationManag
 
             if (errorCount > 0) {
                 String message = String.format("%s wiki database migration(s) failed.", errorCount);
-                this.logger.error(message);
+                this.logger.error("[{}] wiki database migration(s) failed.", errorCount);
                 throw new DataMigrationException(message);
             }
         } finally {
@@ -785,8 +787,7 @@ public abstract class AbstractDataMigrationManager implements DataMigrationManag
             } catch (DataMigrationException e1) {
                 // Should not happen and could be safely ignored.
             }
-            String message = String.format("Failed to migrate database [%s]...", database);
-            this.logger.error(message, e);
+            this.logger.error("Failed to migrate database [{}]...", database, e);
             return false;
         } finally {
             context.setWikiId(currentDatabase);
@@ -874,10 +875,8 @@ public abstract class AbstractDataMigrationManager implements DataMigrationManag
             for (XWikiMigration migration : migrations) {
                 this.progress.startStep(this);
 
-                if (this.logger.isInfoEnabled()) {
-                    this.logger.info("Starting data migration [{}] with version [{}] on database [{}]",
-                        migration.dataMigration.getName(), migration.dataMigration.getVersion(), database);
-                }
+                this.logger.info("Starting data migration [{}] with version [{}] on database [{}]",
+                    migration.dataMigration.getName(), migration.dataMigration.getVersion(), database);
 
                 migration.dataMigration.migrate();
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/HibernateDataMigrationManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/HibernateDataMigrationManager.java
@@ -207,10 +207,8 @@ public class HibernateDataMigrationManager extends AbstractDataMigrationManager
      */
     private void hibernateShemaUpdate() throws DataMigrationException
     {
-        if (this.logger.isInfoEnabled()) {
-            this.logger.info("Checking Hibernate mapping and updating schema if needed for wiki [{}]",
-                getXWikiContext().getWikiId());
-        }
+        this.logger.info("Checking Hibernate mapping and updating schema if needed for wiki [{}]",
+            getXWikiContext().getWikiId());
         getBaseStore().updateSchema(getXWikiContext(), true);
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R140600000XWIKI19869DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R140600000XWIKI19869DataMigration.java
@@ -254,7 +254,7 @@ public class R140600000XWIKI19869DataMigration extends AbstractHibernateDataMigr
             } catch (Exception e) {
                 this.logger.warn(
                     "Failed to handle revision [{}] for user page [{}]: [{}]. It's recommended to delete this version.",
-                    node.getVersion().toString(), userDoc.getDocumentReference(),
+                    node.getVersion(), userDoc.getDocumentReference(),
                     ExceptionUtils.getRootCauseMessage(e));
             }
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SkinAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SkinAction.java
@@ -35,7 +35,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.environment.Environment;
 import org.xwiki.internal.attachment.XWikiAttachmentSecurityManager;
@@ -74,9 +73,6 @@ import com.xpn.xwiki.util.Util;
 public class SkinAction extends XWikiAction
 {
 
-    /** Logging helper. */
-    private static final Logger LOGGER = LoggerFactory.getLogger(SkinAction.class);
-
     /** Path delimiter. */
     private static final String DELIMITER = "/";
 
@@ -87,6 +83,10 @@ public class SkinAction extends XWikiAction
     private static final String RESOURCES_DIRECTORY = "resources";
 
     private static final String DOCDOESNOTEXIST = "docdoesnotexist";
+
+    /** Logging helper. */
+    @Inject
+    private Logger logger;
 
     @Inject
     private Environment environment;
@@ -146,7 +146,7 @@ public class SkinAction extends XWikiAction
         // The default base skin is always a filesystem directory.
         String defaultbaseskin = xwiki.getDefaultBaseSkin(context);
 
-        LOGGER.debug("document: [{}] ; baseskin: [{}] ; defaultbaseskin: [{}]",
+        this.logger.debug("document: [{}] ; baseskin: [{}] ; defaultbaseskin: [{}]",
             doc.getDocumentReference(), baseskin, defaultbaseskin);
 
         // Since we don't know exactly what does the URL point at, meaning that we don't know where the skin identifier
@@ -156,7 +156,7 @@ public class SkinAction extends XWikiAction
         while (idx > 0) {
             try {
                 String filename = Util.decodeURI(path.substring(idx + 1), context);
-                LOGGER.debug("Trying [{}]", filename);
+                this.logger.debug("Trying [{}]", filename);
 
                 // Try on the current skin document.
                 if (renderSkin(filename, doc, context)) {
@@ -192,7 +192,7 @@ public class SkinAction extends XWikiAction
                     // successfully found. Signal this further, and stop trying to render.
                     throw ex;
                 }
-                LOGGER.debug(String.valueOf(idx), ex);
+                this.logger.debug(String.valueOf(idx), ex);
             }
             idx = path.lastIndexOf(DELIMITER, idx - 1);
         }
@@ -218,7 +218,7 @@ public class SkinAction extends XWikiAction
         String path = URI.create(getSkinPath(skin) + filename).normalize().toString();
         // Test to prevent someone from using "../" in the filename!
         if (!path.startsWith(DELIMITER + SKINS_DIRECTORY)) {
-            LOGGER.warn("Illegal access, tried to use file [{}] as a skin. Possible break-in attempt!", path);
+            this.logger.warn("Illegal access, tried to use file [{}] as a skin. Possible break-in attempt!", path);
             throw new IOException("Invalid filename: '" + filename + "' for skin '" + skin + "'");
         }
         return path;
@@ -248,7 +248,7 @@ public class SkinAction extends XWikiAction
         String path = URI.create(getResourcePath() + filename).normalize().toString();
         // Test to prevent someone from using "../" in the filename!
         if (!path.startsWith(DELIMITER + RESOURCES_DIRECTORY)) {
-            LOGGER.warn("Illegal access, tried to use file [{}] as a resource. Possible break-in attempt!", path);
+            this.logger.warn("Illegal access, tried to use file [{}] as a resource. Possible break-in attempt!", path);
             throw new IOException("Invalid filename: '" + filename + "'");
         }
         return path;
@@ -274,10 +274,10 @@ public class SkinAction extends XWikiAction
     private boolean renderSkin(String filename, XWikiDocument doc, XWikiContext context)
         throws XWikiException, IOException
     {
-        LOGGER.debug("Rendering file [{}] within the [{}] document", filename, doc.getDocumentReference());
+        this.logger.debug("Rendering file [{}] within the [{}] document", filename, doc.getDocumentReference());
         try {
             if (doc.isNew()) {
-                LOGGER.debug("[{}] is not a document", doc.getDocumentReference().getName());
+                this.logger.debug("[{}] is not a document", doc.getDocumentReference().getName());
             } else {
                 return renderFileFromObjectField(filename, doc, context)
                     || renderFileFromAttachment(filename, doc, context) || (SKINS_DIRECTORY.equals(doc.getSpace())
@@ -302,11 +302,11 @@ public class SkinAction extends XWikiAction
      */
     private boolean renderSkinFileFromResource(String skinName, String path, XWikiContext context) throws XWikiException
     {
-        LOGGER.debug("Rendering filesystem file from path [{}] in skin [{}]", path, skinName);
+        this.logger.debug("Rendering filesystem file from path [{}] in skin [{}]", path, skinName);
 
         // Make sure the skin exist
         if (this.environment.getResource(SKINS_DIRECTORY, skinName + "/") == null) {
-            LOGGER.debug("No filesystem skin with name [{}] can be found in resources", skinName);
+            this.logger.debug("No filesystem skin with name [{}] can be found in resources", skinName);
 
             return false;
         }
@@ -377,7 +377,7 @@ public class SkinAction extends XWikiAction
                 }
             }
         } catch (IOException ex) {
-            LOGGER.info("Skin file [{}] does not exist or cannot be accessed. Root cause is [{}]", path,
+            this.logger.info("Skin file [{}] does not exist or cannot be accessed. Root cause is [{}]", path,
                 ExceptionUtils.getRootCauseMessage(ex));
         }
 
@@ -397,7 +397,7 @@ public class SkinAction extends XWikiAction
     public boolean renderFileFromObjectField(String filename, XWikiDocument doc, final XWikiContext context)
         throws IOException
     {
-        LOGGER.debug("... as object property");
+        this.logger.debug("... as object property");
 
         BaseObject object = doc.getObject("XWiki.XWikiSkins");
         String content = null;
@@ -432,7 +432,7 @@ public class SkinAction extends XWikiAction
 
             return true;
         } else {
-            LOGGER.debug("Object field not found or empty");
+            this.logger.debug("Object field not found or empty");
         }
 
         return false;
@@ -457,7 +457,7 @@ public class SkinAction extends XWikiAction
                 .call(() -> context.getWiki().evaluateVelocity(content, namespace), author, sourceDocument);
         } catch (Exception e) {
             // Should not happen since there is nothing in the call() method throwing an exception.
-            LOGGER.error("Failed to evaluate velocity content for namespace [{}] with the rights of the user [{}]",
+            this.logger.error("Failed to evaluate velocity content for namespace [{}] with the rights of the user [{}]",
                 namespace, author, e);
         }
 
@@ -477,7 +477,7 @@ public class SkinAction extends XWikiAction
     public boolean renderFileFromAttachment(String filename, XWikiDocument doc, XWikiContext context)
         throws IOException, XWikiException
     {
-        LOGGER.debug("... as attachment");
+        this.logger.debug("... as attachment");
 
         XWikiAttachment attachment = doc.getAttachment(filename);
         if (attachment != null) {
@@ -518,7 +518,7 @@ public class SkinAction extends XWikiAction
 
             return true;
         } else {
-            LOGGER.debug("Attachment not found");
+            this.logger.debug("Attachment not found");
         }
 
         return false;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/UndeleteAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/UndeleteAction.java
@@ -26,9 +26,10 @@ import java.util.Locale;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import jakarta.inject.Inject;
+
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.job.Job;
 import org.xwiki.job.JobException;
@@ -70,7 +71,8 @@ public class UndeleteAction extends XWikiAction
 
     private static final String VIEW_ACTION = "view";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(UndeleteAction.class);
+    @Inject
+    private Logger logger;
 
     @Override
     public boolean action(XWikiContext context) throws XWikiException
@@ -138,7 +140,7 @@ public class UndeleteAction extends XWikiAction
 
             result = xwiki.getDeletedDocument(index, context);
         } catch (Exception e) {
-            LOGGER.error("Failed to get deleted document with ID [{}]", sindex, e);
+            this.logger.error("Failed to get deleted document with ID [{}]", sindex, e);
         }
 
         return result;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/SkinActionTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/SkinActionTest.java
@@ -21,11 +21,12 @@ package com.xpn.xwiki.web;
 
 import java.io.IOException;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.xwiki.test.LogLevel;
 import org.xwiki.test.junit5.LogCaptureExtension;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -34,21 +35,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for the {@link com.xpn.xwiki.web.SkinAction} class.
- * 
+ *
  * @version $Id$
  */
+@ComponentTest
 class SkinActionTest
 {
+    @InjectMockComponents
     private SkinAction action;
 
     @RegisterExtension
     private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.WARN);
-
-    @BeforeEach
-    void setUp()
-    {
-        this.action = new SkinAction();
-    }
 
     @Test
     void isTextJavascriptJavaScriptMimetype()

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/UndeleteActionTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/UndeleteActionTest.java
@@ -36,6 +36,7 @@ import org.xwiki.refactoring.script.RefactoringScriptService;
 import org.xwiki.refactoring.script.RequestFactory;
 import org.xwiki.script.service.ScriptService;
 import org.xwiki.test.junit5.mockito.InjectComponentManager;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
 import org.xwiki.test.mockito.MockitoComponentManager;
 
@@ -110,7 +111,8 @@ class UndeleteActionTest
     /**
      * The object being tested.
      */
-    private UndeleteAction undeleteAction = new UndeleteAction();
+    @InjectMockComponents
+    private UndeleteAction undeleteAction;
 
     @BeforeEach
     void beforeEach() throws Exception

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/DefaultQuery.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/DefaultQuery.java
@@ -294,7 +294,7 @@ public class DefaultQuery implements SecureQuery
         if (!this.filters.contains(filter)) {
             this.filters.add(filter);
         } else {
-            LOGGER.warn("QueryFilter [{}] already added to the query [{}]", filter.toString(), this.getStatement());
+            LOGGER.warn("QueryFilter [{}] already added to the query [{}]", filter, this.getStatement());
         }
 
         return this;

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/java/org/xwiki/rendering/internal/macro/code/CodeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/java/org/xwiki/rendering/internal/macro/code/CodeMacro.java
@@ -222,7 +222,7 @@ public class CodeMacro extends AbstractBoxMacro<CodeMacroParameters>
                 parser = componentManager.getInstance(HighlightParser.class, language);
                 return parser.highlight(language, new StringReader(source.getContent()));
             } catch (ComponentLookupException e) {
-                this.logger.error("Faild to load highlighting parser for language [{}]", language, e);
+                this.logger.error("Failed to load highlighting parser for language [{}]", language, e);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrIndexer.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrIndexer.java
@@ -759,7 +759,7 @@ public class DefaultSolrIndexer implements SolrIndexer, Initializable, Disposabl
         try {
             result = this.componentManager.getInstance(SolrMetadataExtractor.class, entityType.name().toLowerCase());
         } catch (ComponentLookupException e) {
-            this.logger.warn("Unsupported entity type: [{}]. Root cause is [{}]", entityType.toString(),
+            this.logger.warn("Unsupported entity type: [{}]. Root cause is [{}]", entityType,
                 ExceptionUtils.getRootCauseMessage(e));
         }
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrIndexAvailableLocalesListener.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrIndexAvailableLocalesListener.java
@@ -183,7 +183,7 @@ public class SolrIndexAvailableLocalesListener implements EventListener
                 }
             }
         } catch (Exception e) {
-            this.logger.error("Failed to handle event [{}] with source [{}]", event, source.toString(), e);
+            this.logger.error("Failed to handle event [{}] with source [{}]", event, source, e);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrIndexEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrIndexEventListener.java
@@ -176,7 +176,7 @@ public class SolrIndexEventListener implements EventListener
                 }
             }
         } catch (Exception e) {
-            this.logger.error("Failed to handle event [{}] with source [{}]", event, source.toString(), e);
+            this.logger.error("Failed to handle event [{}] with source [{}]", event, source, e);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/AbstractDocumentSkinExtensionPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/AbstractDocumentSkinExtensionPlugin.java
@@ -30,7 +30,6 @@ import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.bridge.event.DocumentCreatedEvent;
@@ -316,9 +315,7 @@ public abstract class AbstractDocumentSkinExtensionPlugin extends AbstractSkinEx
             return getAuthorizationManager().hasAccess(Right.SCRIPT, EntityType.DOCUMENT, authorReference,
                 documentReference);
         } catch (XWikiException e) {
-            LOGGER.error("Error while loading [{}] for checking script right: [{}]", documentReference,
-                ExceptionUtils.getRootCauseMessage(e));
-            LOGGER.debug("Original error stack trace:", e);
+            LOGGER.error("Error while loading [{}] for checking script right", documentReference, e);
             return false;
         }
     }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/main/java/org/xwiki/test/integration/XWikiExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/main/java/org/xwiki/test/integration/XWikiExecutor.java
@@ -515,7 +515,8 @@ public class XWikiExecutor
         if (response.timedOut) {
             String message = String.format("Failed to start XWiki in [%s] seconds, last error code [%s], message [%s]",
                 timeout, response.responseCode, response.responseBody);
-            LOGGER.info(message);
+            LOGGER.info("Failed to start XWiki in [{}] seconds, last error code [{}], message [{}]", timeout,
+                response.responseCode, response.responseBody);
             stop();
             throw new RuntimeException(message);
         } else {

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/main/java/org/xwiki/url/internal/DefaultURLSecurityManager.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/main/java/org/xwiki/url/internal/DefaultURLSecurityManager.java
@@ -223,14 +223,10 @@ public class DefaultURLSecurityManager implements URLSecurityManager
                     result = false;
                 }
             } catch (MalformedURLException e) {
-                logger.error("Error while transforming URI [{}] to URL: [{}]", uri,
-                    ExceptionUtils.getRootCauseMessage(e));
-                this.logger.debug("Full error stack trace of the URL resolution:", e);
+                this.logger.error("Error while transforming URI [{}] to URL", uri, e);
                 result = false;
             } catch (URISyntaxException e) {
-                logger.error("Error while transforming URI [{}] to absolute URI with http scheme: [{}]", uri,
-                    ExceptionUtils.getRootCauseMessage(e));
-                this.logger.debug("Full error stack trace of the URI resolution:", e);
+                this.logger.error("Error while transforming URI [{}] to absolute URI with http scheme", uri, e);
             }
         }
         return result;

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/test/java/org/xwiki/url/internal/DefaultURLSecurityManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/test/java/org/xwiki/url/internal/DefaultURLSecurityManagerTest.java
@@ -278,8 +278,8 @@ class DefaultURLSecurityManagerTest
         uri = new URI("market://launch?id=somePackageName");
         assertFalse(this.urlSecurityManager.isURITrusted(uri));
         assertEquals(1, this.logCapture.size());
-        assertEquals("Error while transforming URI [market://launch?id=somePackageName] to URL: "
-            + "[MalformedURLException: unknown protocol: market]", this.logCapture.getMessage(0));
+        assertEquals("Error while transforming URI [market://launch?id=somePackageName] to URL",
+            this.logCapture.getMessage(0));
 
         // invalidate cache so that we can call inject other trustedDomains
         this.urlSecurityManager.invalidateCache();
@@ -323,8 +323,8 @@ class DefaultURLSecurityManagerTest
         assertFalse(this.urlSecurityManager.isURITrusted(uri));
 
         assertEquals(2, this.logCapture.size());
-        assertEquals("Error while transforming URI [sftp://xwiki.org/something] to URL: "
-            + "[MalformedURLException: unknown protocol: sftp]", this.logCapture.getMessage(1));
+        assertEquals("Error while transforming URI [sftp://xwiki.org/something] to URL",
+            this.logCapture.getMessage(1));
     }
 
     private void assertParseToSafeThrowSecurity(String location, String expectedExceptionLocation)
@@ -388,8 +388,8 @@ class DefaultURLSecurityManagerTest
         location = "market://launch?id=somePackageName";
         assertParseToSafeThrowSecurity(location, location);
         assertEquals(1, this.logCapture.size());
-        assertEquals("Error while transforming URI [market://launch?id=somePackageName] to URL: "
-            + "[MalformedURLException: unknown protocol: market]", this.logCapture.getMessage(0));
+        assertEquals("Error while transforming URI [market://launch?id=somePackageName] to URL",
+            this.logCapture.getMessage(0));
 
         // invalidate cache so that we can call inject other trustedDomains
         this.urlSecurityManager.invalidateCache();
@@ -439,8 +439,8 @@ class DefaultURLSecurityManagerTest
         assertParseToSafeThrowSecurity(location, location);
 
         assertEquals(2, this.logCapture.size());
-        assertEquals("Error while transforming URI [sftp://xwiki.org/xwiki/something/] to URL: "
-            + "[MalformedURLException: unknown protocol: sftp]", this.logCapture.getMessage(1));
+        assertEquals("Error while transforming URI [sftp://xwiki.org/xwiki/something/] to URL",
+            this.logCapture.getMessage(1));
 
         // Check behaviour with |
         location = "http://extensions.xwiki.org/xwiki/bin/view/Main/WebHome#|t=recommendedextensions&p=1&l=15&s=doc"

--- a/xwiki-platform-core/xwiki-platform-velocity/xwiki-platform-velocity-webapp/src/main/java/org/xwiki/velocity/XWikiWebappResourceLoader.java
+++ b/xwiki-platform-core/xwiki-platform-velocity/xwiki-platform-velocity-webapp/src/main/java/org/xwiki/velocity/XWikiWebappResourceLoader.java
@@ -163,9 +163,7 @@ public class XWikiWebappResourceLoader extends ResourceLoader
             } catch (Exception e) {
                 // Remember the first exception
                 if (exception == null) {
-                    if (this.log.isDebugEnabled()) {
-                        this.log.debug("Could not load [{}]", path, e);
-                    }
+                    this.log.debug("Could not load [{}]", path, e);
 
                     exception = e;
                 }

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/descriptor/document/XWikiServerXwikiDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/descriptor/document/XWikiServerXwikiDocumentInitializer.java
@@ -125,7 +125,7 @@ public class XWikiServerXwikiDocumentInitializer extends AbstractMandatoryDocume
 
                 needsUpdate = true;
             } catch (XWikiException e) {
-                this.logger.error("Faied to initialize main wiki descriptor", e);
+                this.logger.error("Failed to initialize main wiki descriptor", e);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-workspaces-migrator/src/main/java/org/xwiki/wiki/workspacesmigrator/internal/WorkspacesMigration.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-workspaces-migrator/src/main/java/org/xwiki/wiki/workspacesmigrator/internal/WorkspacesMigration.java
@@ -210,7 +210,7 @@ public class WorkspacesMigration extends AbstractHibernateDataMigration
             }
             logger.warn("Failed to restore some documents: [{}]. You should import manually "
                     + "(1) xwiki-platform-administration-ui.xar and then (2) xwiki-platform-wiki-ui-wiki.xar into your"
-                    + " wiki, to restore these documents.", documentsToRestoreAsString.toString());
+                    + " wiki, to restore these documents.", documentsToRestoreAsString);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-workspaces-migrator/src/test/java/org/xwiki/wiki/workspacesmigrator/internal/WorkspaceMigrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-workspaces-migrator/src/test/java/org/xwiki/wiki/workspacesmigrator/internal/WorkspaceMigrationTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
 import org.slf4j.Logger;
 import org.xwiki.context.Execution;
 import org.xwiki.context.ExecutionContext;
@@ -40,6 +41,7 @@ import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.store.migration.hibernate.HibernateDataMigration;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -118,9 +120,7 @@ class WorkspaceMigrationTest
             eq(new DocumentReference("workspace", "XWiki", "RegistrationConfig")), any(XWikiContext.class));
 
         // Verify that the log contains a warning about the documents that the migration failed to restore
-        verify(this.logger).warn("Failed to restore some documents: [{}]. You should import manually "
-            + "(1) xwiki-platform-administration-ui.xar and then (2) xwiki-platform-wiki-ui-wiki.xar into your"
-            + " wiki, to restore these documents.", "workspace:XWiki.AdminRegistrationSheet, "
+        verifyDocumentsToRestoreLogged("workspace:XWiki.AdminRegistrationSheet, "
             + "workspace:XWiki.RegistrationHelp, workspace:XWiki.AdminUsersSheet");
     }
 
@@ -143,9 +143,7 @@ class WorkspaceMigrationTest
         this.workspacesMigration.hibernateMigrate();
 
         // Verify that the log contains a warning about the documents that the migration failed to restore
-        verify(this.logger).warn("Failed to restore some documents: [{}]. You should import manually "
-            + "(1) xwiki-platform-administration-ui.xar and then (2) xwiki-platform-wiki-ui-wiki.xar into your"
-            + " wiki, to restore these documents.", "workspacetemplate:XWiki.AdminRegistrationSheet, "
+        verifyDocumentsToRestoreLogged("workspacetemplate:XWiki.AdminRegistrationSheet, "
             + "workspacetemplate:XWiki.RegistrationConfig, workspacetemplate:XWiki.RegistrationHelp, "
             + "workspacetemplate:XWiki.AdminUsersSheet");
     }
@@ -191,5 +189,17 @@ class WorkspaceMigrationTest
         // Verify
         verify(this.logger).error(eq("Error while restoring documents from the Workspace XAR"),
             any(XWikiException.class));
+    }
+
+    /**
+     * The list of documents is passed as the {@link StringBuilder} it is built into, so it is matched on its rendered
+     * value rather than by equality.
+     */
+    private void verifyDocumentsToRestoreLogged(String expectedDocuments)
+    {
+        verify(this.logger).warn(eq("Failed to restore some documents: [{}]. You should import manually "
+            + "(1) xwiki-platform-administration-ui.xar and then (2) xwiki-platform-wiki-ui-wiki.xar into your"
+            + " wiki, to restore these documents."), argThat(
+                (ArgumentMatcher<Object>) documents -> expectedDocuments.equals(documents.toString())));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/internal/converter/DefaultHTMLConverter.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/internal/converter/DefaultHTMLConverter.java
@@ -146,7 +146,7 @@ public class DefaultHTMLConverter implements HTMLConverter
 
             return printer.toString();
         } catch (Exception e) {
-            this.logger.error(e.getLocalizedMessage(), e);
+            this.logger.error("Failed to convert HTML to the [{}] syntax", syntaxId, e);
             throw new RuntimeException("Exception while parsing HTML", e);
         } finally {
             if (renderingContextPushed) {
@@ -183,7 +183,8 @@ public class DefaultHTMLConverter implements HTMLConverter
 
             return printer.toString();
         } catch (Exception e) {
-            this.logger.error(e.getLocalizedMessage(), e);
+            this.logger.error("Failed to convert content in the [{}] syntax with source reference [{}] to HTML",
+                syntax, sourceReference, e);
             throw new RuntimeException("Exception while rendering HTML", e);
         }
     }
@@ -232,7 +233,8 @@ public class DefaultHTMLConverter implements HTMLConverter
 
             return printer.toString();
         } catch (Exception e) {
-            this.logger.error(e.getLocalizedMessage(), e);
+            this.logger.error("Failed to parse and render HTML in the [{}] syntax with source reference [{}]", syntax,
+                sourceReference, e);
             throw new RuntimeException("Exception while refreshing HTML", e);
         } finally {
             if (renderingContextPushed) {


### PR DESCRIPTION
Ninth batch of the SLF4J [logging best practices](https://dev.xwiki.org/xwiki/bin/view/Community/CodeStyle/JavaCodeStyle/#HLoggingBestPractices) sweep, after #6055, #6056, #6057, #6058, #6059, #6060, #6061, #6062, #6063, #6064, #6065, #6066, #6068 and #6070. **41 sites** across 17 top-level modules. Branches from `master`; it does not stack on #6070 and touches none of its files.

### Where these came from

The four earlier audit passes all resolved a call's message from a **literal at the call site**, and pass 4 additionally looked at the `Logger` field. This batch comes from a fifth pass that closes two gaps neither shape could see:

- a message **assembled into a local variable** one line above the call — a plain `String.format()` / concatenation violation that is invisible to a call-site parser (batch 7 hit this once by hand in `OfficeImporterScriptService`, but never generalised it);
- the **words inside the message**. Pass 1 spell-checked against a small hand-written list, so it only found words someone had thought to add. Re-checking all 1559 resolvable message literals against a real dictionary plus an XWiki-domain allow-list surfaced 11 genuine typos.

| Category | Sites |
|---|---:|
| Misspelled word in the message (`faild`, `extenion`, `resoure`, `interruped`, `faied`, `failedd`, `vist`, `targetting`) | 11 |
| Redundant `.toString()` on a `{}` argument | 11 |
| Message built with `String.format()` / `+` into a local, then logged | 7 |
| `@Component` still building a static logger — the 4 classes batch 8 had to defer | 4 |
| `error(e.getLocalizedMessage(), e)` — the variant pass 3's parser did not match | 3 |
| `error()` whose only exception info is a root-cause *string*, trace hidden behind a later `debug()` | 3 |
| Redundant `isXxxEnabled()` guard the pass-4 detector missed | 3 |
| **Total** (one site is both a typo and a `.toString()`) | **41** |

### Notes on the less obvious ones

- **`.toString()`** is not just noise: SLF4J calls it itself, so doing it by hand is *eager* (paid even when the level is disabled) and **throws an NPE** on a null value where SLF4J would have rendered `null`. I checked each argument's static type first — dropping `.toString()` from an array would have spread it as varargs; none of the 11 was an array.
- **The 4 deferred `@Component` classes** (`XWikiCacheStore`, `SkinAction`, `UndeleteAction`, `TempResourceAction`) were left out of #6070 because their unit tests construct them with `new`, which leaves an injected field null. `XWikiCacheStore` needed no test change at all — its deprecated 2-argument constructor already hand-wires every `@Inject` field through `Utils.getComponent`, so the logger just joins them. The three actions moved onto `@InjectMockComponents`; an injected logger is still a real SLF4J logger under `@ComponentTest`, so `SkinActionTest`'s seven `LogCaptureExtension` message assertions are untouched.
- **`DefaultURLSecurityManager` / `AbstractDocumentSkinExtensionPlugin`** logged `error("… : [{}]", …, getRootCauseMessage(e))` and put the trace behind a *second*, `debug()` call — so the trace was missing exactly when someone reads the error. Merged into one `error(…, e)`.
- **Deliberately not touched:** the 23 log-and-throw sites (a real anti-pattern, but not on the rules page, and several are deliberate — `SkinAction`'s break-in warnings log the attempt and throw a deliberately vaguer `IOException`); the 8 `printStackTrace(writer)` calls that serialize into a `StringWriter` rather than the console; and the ~10 same-family misspellings that live in *exception* messages and Javadoc rather than log messages.

### Tests

The tests that had to follow a change did so for the reason the change was worth making:

- `DefaultURLSecurityManagerTest` — 4 `LogCaptureExtension` assertions on the rendered message.
- `WorkspaceMigrationTest` — it `verify()`s the *arguments* handed to a mock `Logger`, and the argument is now the `StringBuilder` itself, which has no `equals()`; it matches on the rendered value through an `ArgumentMatcher`.
- `SkinActionTest`, `UndeleteActionTest`, `TempResourceActionTest` — `new` → `@InjectMockComponents`; the assertions themselves are unchanged.

`mvn -B -ntp test` and `mvn -B -ntp checkstyle:check -Plegacy,quality` pass from each of the 19 changed modules' directories (oldcore: 1140 tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
