### PR TITLE
[Misc] Fix misspellings in Javadoc, comments and messages in oldcore and 5 more platform modules

### DIFF
--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-distribution/src/main/java/org/xwiki/extension/distribution/internal/DefaultDistributionManager.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-distribution/src/main/java/org/xwiki/extension/distribution/internal/DefaultDistributionManager.java
@@ -176,7 +176,7 @@ public class DefaultDistributionManager implements DistributionManager, Initiali
                     new ExtensionId(this.mainUIExtensionId.getId(), this.distributionExtension.getId().getVersion());
             }
 
-            // Subwikis defualt UI
+            // Subwikis default UI
             if (this.wikiUIExtensionId == null) {
                 String wikiUIId = this.distributionExtension.getProperty("xwiki.extension.distribution.wikiui");
 

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-distribution/src/main/java/org/xwiki/extension/distribution/internal/DistributionAction.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-distribution/src/main/java/org/xwiki/extension/distribution/internal/DistributionAction.java
@@ -61,7 +61,7 @@ public class DistributionAction extends XWikiAction
         // Disallow template override with xpage parameter.
         if (!DISTRIBUTION_ACTION.equals(Utils.getPage(context.getRequest(), DISTRIBUTION_ACTION))) {
             throw new XWikiException(XWikiException.MODULE_XWIKI, XWikiException.ERROR_XWIKI_ACCESS_DENIED,
-                String.format("Template may not be overriden with 'xpage' in [%s] action.", DISTRIBUTION_ACTION));
+                String.format("Template may not be overridden with 'xpage' in [%s] action.", DISTRIBUTION_ACTION));
         }
 
         // Make sure the user has the right to access the distribution action

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-distribution/src/main/java/org/xwiki/extension/distribution/internal/job/AbstractDistributionJob.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-distribution/src/main/java/org/xwiki/extension/distribution/internal/job/AbstractDistributionJob.java
@@ -266,7 +266,8 @@ public abstract class AbstractDistributionJob<R extends DistributionRequest>
                 distributionJobThread.setName("Wikis non-interfactive distribution jobs");
                 distributionJobThread.start();
             } catch (WikiManagerException e) {
-                this.logger.error("Failed to get the list of wikis. Sub-wikis ditribution jobs won't be triggered.", e);
+                this.logger.error("Failed to get the list of wikis. Sub-wikis distribution jobs won't be triggered.",
+                    e);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-distribution/src/main/java/org/xwiki/extension/distribution/internal/job/DistributionJobStatus.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-distribution/src/main/java/org/xwiki/extension/distribution/internal/job/DistributionJobStatus.java
@@ -126,7 +126,7 @@ public class DistributionJobStatus extends DefaultJobStatus<DistributionRequest>
         this.currentStateIndex = currentStateIndex;
     }
 
-    // Distribution informations
+    // Distribution information
 
     public ExtensionId getPreviousDistributionExtension()
     {

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/handler/XarHandlerUtils.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/handler/XarHandlerUtils.java
@@ -31,7 +31,7 @@ public final class XarHandlerUtils
 
     private XarHandlerUtils()
     {
-        // Utlity class
+        // Utility class
     }
     
     /**

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/script/SafeConflictQuestion.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/script/SafeConflictQuestion.java
@@ -43,7 +43,7 @@ public class SafeConflictQuestion extends AbstractSafeObject<ConflictQuestion>
         super(question, safeProvider);
     }
 
-    // Datas
+    // Data
 
     public Document getCurrentDocument()
     {

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/question/ConflictQuestion.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/question/ConflictQuestion.java
@@ -145,7 +145,7 @@ public class ConflictQuestion
         ASK
     }
 
-    // Question datas
+    // Question data
 
     private final ConflictType type;
 
@@ -159,7 +159,7 @@ public class ConflictQuestion
 
     private List<Conflict<?>> documentConflicts;
 
-    // Answer datas
+    // Answer data
 
     private GlobalAction globalAction;
 
@@ -245,7 +245,7 @@ public class ConflictQuestion
 
     /**
      * @since 11.8RC1
-     * @return the conflicts occured during the merge of documents.
+     * @return the conflicts occurred during the merge of documents.
      */
     public List<Conflict<?>> getDocumentConflicts()
     {

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/ExtensionIndexSolrCoreInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/ExtensionIndexSolrCoreInitializer.java
@@ -271,7 +271,7 @@ public class ExtensionIndexSolrCoreInitializer extends AbstractSolrCoreInitializ
         String cannonicalType = DefaultExtensionComponent.toCanonicalComponentType(componentType);
 
         // It's a pity but I cannot find any way to escape < > and , in a Solr query so replacing them
-        // Conflict is theorically possible but highly unlikely, especially since it's only about component roles
+        // Conflict is theoretically possible but highly unlikely, especially since it's only about component roles
         cannonicalType = COMPONENT_SPECIAL_CHARS.matcher(cannonicalType).replaceAll("_");
 
         return Extension.FIELD_COMPONENTS + "__" + cannonicalType;

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/ExtensionIndexStore.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/ExtensionIndexStore.java
@@ -313,7 +313,7 @@ public class ExtensionIndexStore implements Initializable, Disposable
     }
 
     /**
-     * Update variable informations (support plans, ratings, etc.).
+     * Update variable information (support plans, ratings, etc.).
      *
      * @param extensionId the identifier of the extension to update
      * @param remoteExtension the remote extension from which to extract variable information
@@ -401,7 +401,7 @@ public class ExtensionIndexStore implements Initializable, Disposable
     }
 
     /**
-     * Update variable informations (support plans, ratings, etc.) by copying it from another version.
+     * Update variable information (support plans, ratings, etc.) by copying it from another version.
      *
      * @param extensionId the identifier of the extension to update
      * @param copyVersion the version of the extension to copy

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/AbstractExtensionScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/AbstractExtensionScriptService.java
@@ -176,7 +176,7 @@ public abstract class AbstractExtensionScriptService implements ScriptService
      */
     public void contextualize(AbstractRequest request)
     {
-        // Provide informations on what started the job
+        // Provide information on what started the job
         request.setProperty(PROPERTY_CONTEXT_WIKI, this.xcontextProvider.get().getWikiId());
         request.setProperty(PROPERTY_CONTEXT_ACTION, this.xcontextProvider.get().getAction());
     }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/ExtensionManagerScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/ExtensionManagerScriptService.java
@@ -461,7 +461,7 @@ public class ExtensionManagerScriptService extends AbstractExtensionScriptServic
         // Indicate if it's allowed to do modification on root namespace
         installRequest.setRootModificationsAllowed(namespace == null || xcontext.isMainWiki(toWikiId(namespace)));
 
-        // Allow overwritting a few things in extensions descriptors
+        // Allow overwriting a few things in extensions descriptors
         installRequest.setRewriter(new ScriptExtensionRewriter());
 
         contextualize(installRequest);

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-instance/xwiki-platform-filter-instance-api/src/main/java/org/xwiki/filter/instance/input/AbstractInstanceInputEventGenerator.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-instance/xwiki-platform-filter-instance-api/src/main/java/org/xwiki/filter/instance/input/AbstractInstanceInputEventGenerator.java
@@ -96,25 +96,25 @@ public abstract class AbstractInstanceInputEventGenerator<F> implements Instance
     @Override
     public void setWikiFarmParameters(FilterEventParameters parameters) throws FilterException
     {
-        // To ovewrite
+        // To overwrite
     }
 
     @Override
     public void setWikiParameters(String name, FilterEventParameters parameters) throws FilterException
     {
-        // To ovewrite
+        // To overwrite
     }
 
     @Override
     public void setWikiSpaceParameters(String name, FilterEventParameters parameters) throws FilterException
     {
-        // To ovewrite
+        // To overwrite
     }
 
     @Override
     public void setWikiDocumentParameters(String name, FilterEventParameters parameters) throws FilterException
     {
-        // To ovewrite
+        // To overwrite
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-instance/xwiki-platform-filter-instance-api/src/main/java/org/xwiki/filter/instance/internal/input/InstanceInputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-instance/xwiki-platform-filter-instance-api/src/main/java/org/xwiki/filter/instance/internal/input/InstanceInputFilterStream.java
@@ -80,7 +80,7 @@ public class InstanceInputFilterStream extends AbstractBeanInputFilterStream<Ins
             this.eventGenerators = this.componentManager.get().getInstanceList(InstanceInputEventGenerator.class);
         } catch (ComponentLookupException e) {
             throw new FilterException(
-                "Failed to get regsitered instance of OutputInstanceFilterStreamFactory components", e);
+                "Failed to get registered instance of OutputInstanceFilterStreamFactory components", e);
         }
 
         for (InstanceInputEventGenerator eventGenerator : this.eventGenerators) {

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-instance/xwiki-platform-filter-instance-api/src/main/java/org/xwiki/filter/instance/internal/output/InstanceOutputFilterStreamFactory.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-instance/xwiki-platform-filter-instance-api/src/main/java/org/xwiki/filter/instance/internal/output/InstanceOutputFilterStreamFactory.java
@@ -102,7 +102,7 @@ public class InstanceOutputFilterStreamFactory extends
             factories = this.componentManagerProvider.get().getInstanceList(OutputInstanceFilterStreamFactory.class);
         } catch (ComponentLookupException e) {
             throw new FilterException(
-                "Failed to get regsitered instance of OutputInstanceFilterStreamFactory components", e);
+                "Failed to get registered instance of OutputInstanceFilterStreamFactory components", e);
         }
 
         Set<Class< ? >> filters = new HashSet<>();

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/output/XAROutputProperties.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/output/XAROutputProperties.java
@@ -82,17 +82,17 @@ public class XAROutputProperties extends XMLOutputProperties
     private String packageExtensionId;
 
     /**
-     * @return Indicate if all revisions related informations should be serialized
+     * @return Indicate if all revisions related information should be serialized
      */
-    @PropertyName("Preserve revisions informations")
-    @PropertyDescription("Indicate if all revisions related informations should be serialized")
+    @PropertyName("Preserve revisions information")
+    @PropertyDescription("Indicate if all revisions related information should be serialized")
     public boolean isPreserveVersion()
     {
         return this.preserveVersion;
     }
 
     /**
-     * @param preserveVersion Indicate if all revisions related informations should be serialized
+     * @param preserveVersion Indicate if all revisions related information should be serialized
      */
     public void setPreserveVersion(boolean preserveVersion)
     {
@@ -140,7 +140,7 @@ public class XAROutputProperties extends XMLOutputProperties
     // package.xml
 
     /**
-     * @return Indicate if all revisions related informations should be serialized
+     * @return Indicate if all revisions related information should be serialized
      */
     @PropertyName("Package Name")
     @PropertyDescription("The name to put in package.xml")
@@ -150,7 +150,7 @@ public class XAROutputProperties extends XMLOutputProperties
     }
 
     /**
-     * @param packageName Indicate if all revisions related informations should be serialized
+     * @param packageName Indicate if all revisions related information should be serialized
      */
     public void setPackageName(String packageName)
     {

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/internal/DefaultGroupingEventStrategy.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/internal/DefaultGroupingEventStrategy.java
@@ -140,7 +140,7 @@ public class DefaultGroupingEventStrategy implements GroupingEventStrategy
             for (Event existingEvent : existingCompositeEvent.getEvents()) {
                 int similarity = similarityCalculator.computeSimilarity(event, existingEvent);
                 if (similarity < existingCompositeEvent.getSimilarityBetweenEvents()) {
-                    // Penality
+                    // Penalty
                     similarity -= 5;
                 }
                 if (similarity > bestSimilarity.value) {

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/WikiNotificationFilterDisplayer.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/WikiNotificationFilterDisplayer.java
@@ -50,7 +50,7 @@ import com.xpn.xwiki.objects.BaseObjectReference;
 import com.xpn.xwiki.objects.BaseProperty;
 
 /**
- * This class is meant to be instanciated and then registered against the Component Manager by the
+ * This class is meant to be instantiated and then registered against the Component Manager by the
  * {@link WikiNotificationFilterDisplayerComponentBuilder}.
  *
  * @version $Id$

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersLiveDataEntryStore.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersLiveDataEntryStore.java
@@ -156,7 +156,7 @@ public class NotificationCustomFiltersLiveDataEntryStore extends AbstractNotific
             case PAGE ->
                 this.entityReferenceResolver.resolve(filterPreference.getPageOnly(), EntityType.DOCUMENT);
         };
-        // TODO: Create an improvment ticket for having a displayer
+        // TODO: Create an improvement ticket for having a displayer
         ScriptContext currentScriptContext = this.scriptContextManager.getCurrentScriptContext();
         currentScriptContext.setAttribute("location", location, ScriptContext.ENGINE_SCOPE);
         return this.templateManager.renderNoException(LOCATION_TEMPLATE);

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/system/NotificationSystemFiltersLiveDataEntryStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/system/NotificationSystemFiltersLiveDataEntryStoreTest.java
@@ -202,7 +202,7 @@ class NotificationSystemFiltersLiveDataEntryStoreTest
         when(filter6.getFormats()).thenReturn(List.of(NotificationFormat.EMAIL));
         when(filter7.getFormats()).thenReturn(List.of(NotificationFormat.EMAIL, NotificationFormat.ALERT));
 
-        // There's explicitely no activation data for filter2 and filter6
+        // There's explicitly no activation data for filter2 and filter6
         ToggleableNotificationFilterActivation activationFilter4 = mock(ToggleableNotificationFilterActivation.class,
             filter4Name);
         ToggleableNotificationFilterActivation activationFilter5 = mock(ToggleableNotificationFilterActivation.class,
@@ -380,7 +380,7 @@ class NotificationSystemFiltersLiveDataEntryStoreTest
         when(filter6.getFormats()).thenReturn(List.of(NotificationFormat.EMAIL));
         when(filter7.getFormats()).thenReturn(List.of(NotificationFormat.EMAIL, NotificationFormat.ALERT));
 
-        // There's explicitely no activation data for filter2 and filter6
+        // There's explicitly no activation data for filter2 and filter6
         ToggleableNotificationFilterActivation activationFilter4 = mock(ToggleableNotificationFilterActivation.class,
             filter4Name);
         ToggleableNotificationFilterActivation activationFilter5 = mock(ToggleableNotificationFilterActivation.class,

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/script/NotificationNotifiersScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/script/NotificationNotifiersScriptService.java
@@ -138,8 +138,8 @@ public class NotificationNotifiersScriptService implements ScriptService
     }
 
     /**
-     * Compute the HTML fragment for the async placehoder.
-     * @param response the async response containing ID informations for the placeholder
+     * Compute the HTML fragment for the async placeholder.
+     * @param response the async response containing ID information for the placeholder
      * @param inline if {@code true} returns a span else a div.
      * @return a string containing the HTML for the placeholder.
      */

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/WikiNotificationDisplayer.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/WikiNotificationDisplayer.java
@@ -35,7 +35,7 @@ import org.xwiki.template.Template;
 import com.xpn.xwiki.objects.BaseObject;
 
 /**
- * This class is meant to be instanciated and then registered to the Component Manager by the
+ * This class is meant to be instantiated and then registered to the Component Manager by the
  * {@link WikiNotificationDisplayerComponentBuilder} component every time a document containing a
  * NotificationDisplayerClass is added, updated or deleted.
  *

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/WikiEmailNotificationRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/WikiEmailNotificationRenderer.java
@@ -36,7 +36,7 @@ import org.xwiki.template.Template;
 import com.xpn.xwiki.objects.BaseObject;
 
 /**
- * This class is meant to be instanciated and then registered to the Component Manager by the
+ * This class is meant to be instantiated and then registered to the Component Manager by the
  * {@link WikiEmailNotificationRendererComponentBuilder} component every time a document containing a
  * NotificationEmailRendererClass is added, updated or deleted.
  *

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/main/java/org/xwiki/notifications/preferences/TargetableNotificationPreferenceBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/main/java/org/xwiki/notifications/preferences/TargetableNotificationPreferenceBuilder.java
@@ -36,7 +36,7 @@ import org.xwiki.notifications.NotificationFormat;
 public interface TargetableNotificationPreferenceBuilder
 {
     /**
-     * @return a freshly instanciated {@link TargetableNotificationPreference}
+     * @return a freshly instantiated {@link TargetableNotificationPreference}
      */
     TargetableNotificationPreference build();
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/DefaultParametrizedNotificationManager.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/DefaultParametrizedNotificationManager.java
@@ -217,7 +217,7 @@ public class DefaultParametrizedNotificationManager implements ParametrizedNotif
      * 
      * @param event the event that is tested
      * @param userReference the user reference given by the parameters
-     * @return {@code true} iff the user is explicitely target, or through a group.
+     * @return {@code true} iff the user is explicitly target, or through a group.
      */
     private boolean eventTargetUser(Event event, DocumentReference userReference)
     {
@@ -225,7 +225,7 @@ public class DefaultParametrizedNotificationManager implements ParametrizedNotif
         if (event.getTarget() != null && !event.getTarget().isEmpty() && userReference != null) {
             String serializedUserReference = this.serializer.serialize(userReference);
 
-            // if the target explicitely contains the user reference we're good
+            // if the target explicitly contains the user reference we're good
             if (event.getTarget().contains(serializedUserReference)) {
                 result = true;
                 // else we need to check that the targets does not contain any group the user belongs to

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/DefaultParametrizedNotificationManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/DefaultParametrizedNotificationManagerTest.java
@@ -399,7 +399,7 @@ class DefaultParametrizedNotificationManagerTest
         assertTrue(results.isEmpty());
         verify(this.groupManager).getGroups(this.userReference, null, true);
 
-        // the current user is targeted explicitely by the event: we get a result.
+        // the current user is targeted explicitly by the event: we get a result.
         // We also check that we don't perform any check in groups in that case
         when(event.getTarget()).thenReturn(Set.of("Foo.bar", "XWiki.UserA"));
         results = this.defaultParametrizedNotificationManager.getEvents(parameters);
@@ -417,7 +417,7 @@ class DefaultParametrizedNotificationManagerTest
         assertEquals(1, results.size());
         verify(this.groupManager, times(2)).getGroups(this.userReference, null, true);
 
-        // the current user is targeted explicitely by the event, but also through a group: we should still get a single
+        // the current user is targeted explicitly by the event, but also through a group: we should still get a single
         // result
         // We also check that we don't perform any supplementary check in groups in that case
         when(event.getTarget()).thenReturn(Set.of("Foo.bar", "XWiki.UserA"));

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-pageobjects/src/main/java/org/xwiki/platform/notifications/test/po/AbstractNotificationsSettingsPage.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-pageobjects/src/main/java/org/xwiki/platform/notifications/test/po/AbstractNotificationsSettingsPage.java
@@ -112,7 +112,7 @@ public abstract class AbstractNotificationsSettingsPage extends ViewPage
     }
 
     /**
-     * Initialize the page with applications informations.
+     * Initialize the page with applications information.
      */
     protected void initializeApplications()
     {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -1539,7 +1539,7 @@ public class XWiki implements EventListener
 
     /**
      * @param wikiId the id of the wiki
-     * @param force if the update of the databse should be forced
+     * @param force if the update of the database should be forced
      * @param initDocuments if mandatory document and plugin should be initialized for passed wiki
      * @param context see {@link XWikiContext}
      * @deprecated since 8.4RC1, use {@link #initializeWiki(String, boolean, XWikiContext)} instead
@@ -4035,7 +4035,7 @@ public class XWiki implements EventListener
     }
 
     /**
-     * Method allows to create an empty user with no password (he won't be able to login) This method is usefull for
+     * Method allows to create an empty user with no password (he won't be able to login) This method is useful for
      * authentication like LDAP or App Server trusted
      *
      * @param xwikiname
@@ -4145,7 +4145,7 @@ public class XWiki implements EventListener
      * Create a new user.
      *
      * @param userName the name of the user (without the space)
-     * @param map extra datas to add to user profile object
+     * @param map extra data to add to user profile object
      * @param context see {@link XWikiContext}
      * @return
      *         <ul>
@@ -4163,7 +4163,7 @@ public class XWiki implements EventListener
      * Create a new user.
      *
      * @param userName the name of the user (without the space)
-     * @param map extra datas to add to user profile object
+     * @param map extra data to add to user profile object
      * @param userRights the right of the user on his own profile page
      * @param context see {@link XWikiContext}
      * @return
@@ -4210,7 +4210,7 @@ public class XWiki implements EventListener
      * Create a new user.
      *
      * @param userName the name of the user (without the space)
-     * @param map extra datas to add to user profile object
+     * @param map extra data to add to user profile object
      * @param parentReference the parent of the user profile
      * @param content the content of the user profile
      * @param syntax the syntax of the provided content
@@ -4262,7 +4262,7 @@ public class XWiki implements EventListener
             // The information from the user profile needs to be indexed using the proper locale. If multilingual is
             // enabled then the user can choose the desired locale (from the list of supported locales) before
             // registering. An administrator registering users can do the same. Otherwise, if there is only one locale
-            // supported then that langage will be used.
+            // supported then that language will be used.
             doc.setDefaultLocale(context.getLocale());
 
             protectUserPage(doc.getFullName(), userRights, doc, context);
@@ -5678,7 +5678,7 @@ public class XWiki implements EventListener
         return getAttachmentURL(attachmentReference, queryString, context);
     }
 
-    // Usefull date functions
+    // Useful date functions
 
     public int getTimeDelta(long time)
     {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWikiConfig.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWikiConfig.java
@@ -75,7 +75,7 @@ public class XWikiConfig extends Properties
     }
 
     /**
-     * @return array of string splited from property.
+     * @return array of string split from property.
      * @param param - name of property
      */
     public String[] getPropertyAsList(String param)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWikiContext.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWikiContext.java
@@ -597,7 +597,7 @@ public class XWikiContext extends Hashtable<Object, Object>
             setUserReference(null);
         } else if (user.endsWith(XWikiRightService.GUEST_USER_FULLNAME) || user.equals(XWikiRightService.GUEST_USER)) {
             setUserReference(null);
-            // retro-compatibilty hack: some code does not give the same meaning to null XWikiUser and XWikiUser
+            // retro-compatibility hack: some code does not give the same meaning to null XWikiUser and XWikiUser
             // containing guest user
             put(USER_KEY, new XWikiUser(user, main));
         } else {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Context.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Context.java
@@ -565,7 +565,7 @@ public class Context extends Api
     }
 
     /**
-     * Returns the form field validation status, which contains the exceptions or errors that may have occured during
+     * Returns the form field validation status, which contains the exceptions or errors that may have occurred during
      * the validation process performed during a <i>save</i>.
      *
      * @return The validation status.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
@@ -774,7 +774,7 @@ public class Document extends Api
     }
 
     /**
-     * @return the tranlated Document if the wiki is multilingual, the locale is first checked in the URL, the cookie,
+     * @return the translated Document if the wiki is multilingual, the locale is first checked in the URL, the cookie,
      *         the user profile and finally the wiki configuration if not, the locale is the one on the wiki
      *         configuration.
      */

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
@@ -805,7 +805,7 @@ public class XWiki extends Api
     }
 
     /**
-     * API allowing to search for documents allowing to have mutliple entries per locale
+     * API allowing to search for documents allowing to have multiple entries per locale
      *
      * @param wheresql query to use similar to searchDocuments(wheresql)
      * @param distinctbylocale true to return multiple rows per locale
@@ -1846,7 +1846,7 @@ public class XWiki extends Api
     }
 
     /**
-     * API to execute a form in the context of an including topic, optionnaly surrounding the content with {pre}{/pre}
+     * API to execute a form in the context of an including topic, optionally surrounding the content with {pre}{/pre}
      * to avoid future wiki rendering The rendering is evaluated in the context of the including topic All velocity
      * variables are the one of the including topic This api is usually called using #includeForm in a page, which
      * modifies the behavior of "Edit this page" button to direct for Form mode (inline).
@@ -2166,7 +2166,7 @@ public class XWiki extends Api
 
     /**
      * API to retrieve a link to the User Name page displayed with a custom view. The link will link to the page on the
-     * wiki where the user is registered. The formating is done using the format parameter which can contain velocity
+     * wiki where the user is registered. The formatting is done using the format parameter which can contain velocity
      * scripting and access all properties of the User profile using variables ($first_name $last_name $email $city)
      *
      * @param user Fully qualified username as retrieved from $xcontext.user (XWiki.LudovicDubost)
@@ -2196,7 +2196,7 @@ public class XWiki extends Api
 
     /**
      * API to retrieve a link to the User Name page displayed with a custom view. The link will link to the page on the
-     * local wiki even if the user is registered on a different wiki. The formating is done using the format parameter
+     * local wiki even if the user is registered on a different wiki. The formatting is done using the format parameter
      * which can contain velocity scripting and access all properties of the User profile using variables ($first_name
      * $last_name $email $city)
      *
@@ -2230,7 +2230,7 @@ public class XWiki extends Api
     /**
      * API to retrieve a text representing the user with a custom view With the link param set to false it will not link
      * to the user page. With the link param set to true, the link will link to the page on the wiki where the user was
-     * registered. The formating is done using the format parameter which can contain velocity scripting and access all
+     * registered. The formatting is done using the format parameter which can contain velocity scripting and access all
      * properties of the User profile using variables ($first_name $last_name $email $city)
      *
      * @param user Fully qualified username as retrieved from $xcontext.user (XWiki.LudovicDubost)
@@ -2262,10 +2262,11 @@ public class XWiki extends Api
     }
 
     /**
-     * API to retrieve a text representing the user with a custom view. The formating is done using the format parameter
-     * which can contain velocity scripting and access all properties of the User profile using variables ($first_name
-     * $last_name $email $city). With the link param set to false it will not link to the user page. With the link param
-     * set to true, the link will link to the page on the local wiki even if the user is registered on a different wiki.
+     * API to retrieve a text representing the user with a custom view. The formatting is done using the format
+     * parameter which can contain velocity scripting and access all properties of the User profile using variables
+     * ($first_name $last_name $email $city). With the link param set to false it will not link to the user page. With
+     * the link param set to true, the link will link to the page on the local wiki even if the user is registered on
+     * a different wiki.
      *
      * @param user Fully qualified username as retrieved from $xcontext.user (XWiki.LudovicDubost)
      * @param format formatting to be used ("$first_name $last_name", "$first_name")
@@ -2308,7 +2309,7 @@ public class XWiki extends Api
      * 'dateformat' parameter of the XWiki Preferences
      *
      * @param date date object to format
-     * @return A string with the date formating from the default Wiki setting
+     * @return A string with the date formatting from the default Wiki setting
      */
     public String formatDate(Date date)
     {
@@ -2562,7 +2563,7 @@ public class XWiki extends Api
     }
 
     /**
-     * Priviledge API to regenerate the links/backlinks table Normally links and backlinks are stored when a page is
+     * Privilege API to regenerate the links/backlinks table Normally links and backlinks are stored when a page is
      * modified This function will regenerate all the backlinks This function can be long to run
      *
      * @throws XWikiException exception if the generation fails
@@ -2702,7 +2703,7 @@ public class XWiki extends Api
     }
 
     /**
-     * Privileged API to retrieve an object instanciated from groovy code in a String Groovy scripts compilation is
+     * Privileged API to retrieve an object instantiated from groovy code in a String Groovy scripts compilation is
      * cached
      *
      * @param fullname // script containing a Groovy class definition (public class MyClass { ... })
@@ -2891,7 +2892,7 @@ public class XWiki extends Api
     }
 
     /**
-     * Check authentication from request and set according persitent login information If it fails user is unlogged
+     * Check authentication from request and set according persistent login information If it fails user is unlogged
      *
      * @return null if failed, non null XWikiUser if sucess
      * @throws XWikiException
@@ -2902,8 +2903,8 @@ public class XWiki extends Api
     }
 
     /**
-     * Check authentication from username and password and set according persitent login information If it fails user is
-     * unlogged
+     * Check authentication from username and password and set according persistent login information If it fails user
+     * is unlogged
      *
      * @param username username to check
      * @param password password to check
@@ -3010,7 +3011,7 @@ public class XWiki extends Api
                         break;
                     }
                 } else {
-                    // TODO: improve version comparaison since it does not work when comparing 2.0 and 10.0 for example.
+                    // TODO: improve version comparison since it does not work when comparing 2.0 and 10.0 for example.
                     // We
                     // should have a Version which implements Comparable like we have SyntaxId in Syntax
                     if (factorySyntax.getType().getId().equalsIgnoreCase(syntaxType)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/criteria/impl/Range.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/criteria/impl/Range.java
@@ -123,7 +123,7 @@ public class Range
                 max = list.size();
             }
 
-            // with both start and size negative the maximum becomes the mininum & vice versa
+            // with both start and size negative the maximum becomes the minimum & vice versa
             if (min > max) {
                 int oldmax = max;
                 max = min;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/criteria/impl/RevisionCriteria.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/criteria/impl/RevisionCriteria.java
@@ -22,7 +22,7 @@ package com.xpn.xwiki.criteria.impl;
 import java.util.Date;
 
 /**
- * information about document versions used to retreive a set of document versions.
+ * information about document versions used to retrieve a set of document versions.
  *
  * @version $Id$
  * @see com.xpn.xwiki.doc.XWikiDocument#getRevisions(RevisionCriteria, com.xpn.xwiki.XWikiContext)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/LazyXWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/LazyXWikiDocument.java
@@ -42,7 +42,7 @@ import com.xpn.xwiki.web.Utils;
 /**
  * Read only lazy loading document.
  * <p>
- * The following informations are taken into account:
+ * The following information is taken into account:
  * <ul>
  * <li>document reference: the absolute reference of the document</li>
  * <li>document language: if provided the proper language version of the document is loaded. If not the default one is

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiAttachment.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiAttachment.java
@@ -655,7 +655,7 @@ public class XWikiAttachment implements Cloneable
      * @param out the output where to write the XML
      * @param bWithAttachmentContent if true, binary content of the attachment is included (base64 encoded)
      * @param bWithVersions if true, all archive version is also included
-     * @param format true if the XML should be formated
+     * @param format true if the XML should be formatted
      * @param context current XWikiContext
      * @throws IOException when an error occurs during streaming operation
      * @throws XWikiException when an error occurs during xwiki operation
@@ -673,7 +673,7 @@ public class XWikiAttachment implements Cloneable
      * @param out the output where to write the XML
      * @param bWithAttachmentContent if true, binary content of the attachment is included (base64 encoded)
      * @param bWithVersions if true, all archive version is also included
-     * @param format true if the XML should be formated
+     * @param format true if the XML should be formatted
      * @param encoding the encoding to use when serializing XML
      * @throws XWikiException when an error occurs during xwiki operation
      * @since 9.10RC1
@@ -1320,7 +1320,7 @@ public class XWikiAttachment implements Cloneable
     }
 
     /**
-     * Apply the provided attachment so that the current one contains the same informations and indicate if it was
+     * Apply the provided attachment so that the current one contains the same information and indicate if it was
      * necessary to modify it in any way.
      *
      * @param attachment the attachment to apply

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -4984,7 +4984,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
             return false;
         }
 
-        // Datas
+        // Data
 
         // We consider that 2 documents are still equal even when they have different original
         // documents (see getOriginalDocument() for more details as to what is an original
@@ -4994,14 +4994,14 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
     }
 
     /**
-     * Same as {@link #equals(Object)} but only for actual datas of the document.
+     * Same as {@link #equals(Object)} but only for actual data of the document.
      * <p>
      * The goal being to compare two versions of the same document this method skip every version/reference/author
      * related information. For example it allows to compare a document coming from a another wiki and easily check if
      * thoses actually are the same thing whatever the plumbing differences.
      *
      * @param otherDocument the document to compare
-     * @return true if bith documents have the same datas
+     * @return true if bith documents have the same data
      * @since 4.1.1
      */
     public boolean equalsData(XWikiDocument otherDocument)
@@ -5336,7 +5336,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
      * @param bWithRendering include the rendered content
      * @param bWithAttachmentContent include attachments content
      * @param bWithVersions include archived versions
-     * @param format true if the XML should be formated
+     * @param format true if the XML should be formatted
      * @param encoding the encoding to use to write the XML
      * @throws XWikiException when an errors occurs during wiki operations
      * @since 9.0RC1
@@ -9450,7 +9450,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
     /**
      * Apply modification coming from provided document.
      * <p>
-     * Thid method does not take into account versions and author related informations and the provided document should
+     * This method does not take into account versions and author related information and the provided document should
      * have the same reference. Like {@link #merge(XWikiDocument, XWikiDocument, MergeConfiguration, XWikiContext)},
      * this method is dealing with "real" data and should not change anything related to version management and document
      * identifier.
@@ -9470,7 +9470,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
     /**
      * Apply modification coming from provided document.
      * <p>
-     * Thid method does not take into account versions and author related informations and the provided document should
+     * This method does not take into account versions and author related information and the provided document should
      * have the same reference. Like {@link #merge(XWikiDocument, XWikiDocument, MergeConfiguration, XWikiContext)},
      * this method is dealing with "real" data and should not change everything related to version management and
      * document identifier.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocumentArchive.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocumentArchive.java
@@ -413,7 +413,7 @@ public class XWikiDocumentArchive
      * @param version The version to retrieve.
      * @param context The {@link com.xpn.xwiki.XWikiContext context}.
      * @return The XML corresponding to the version.
-     * @throws XWikiException If any exception occured.
+     * @throws XWikiException If any exception occurred.
      */
     public String getVersionXml(Version version, XWikiContext context) throws XWikiException
     {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/cache/rendering/RenderingCacheAware.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/cache/rendering/RenderingCacheAware.java
@@ -33,7 +33,7 @@ import com.xpn.xwiki.XWikiContext;
 public interface RenderingCacheAware
 {
     /**
-     * Obtain needed resources for this compoment to successfully restore it from cache.
+     * Obtain needed resources for this component to successfully restore it from cache.
      *
      * @param context current xwiki context
      * @return resources needed for restoring this component

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/context/XWikiContextContextStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/context/XWikiContextContextStore.java
@@ -105,7 +105,7 @@ public class XWikiContextContextStore extends AbstractContextStore
     public static final String PROP_ACTION = "action";
 
     /**
-     * The prefix of the entries containing request related informations.
+     * The prefix of the entries containing request related information.
      */
     public static final String PREFIX_PROP_REQUEST = "request.";
 
@@ -228,7 +228,7 @@ public class XWikiContextContextStore extends AbstractContextStore
     public static final String PROP_REQUEST_WIKI = PREFIX_PROP_REQUEST + SUFFIX_PROP_REQUEST_WIKI;
 
     /**
-     * The prefix of the entries containing context document related informations.
+     * The prefix of the entries containing context document related information.
      */
     public static final String PREFIX_PROP_DOCUMENT = "doc.";
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/doc/DatabaseDocumentRevisionProvider.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/doc/DatabaseDocumentRevisionProvider.java
@@ -94,7 +94,7 @@ public class DatabaseDocumentRevisionProvider implements DocumentRevisionProvide
 
             return xcontext.getWiki().getVersioningStore().loadXWikiDoc(document, revision, xcontext);
         } catch (XWikiException e) {
-            // If the errot is that the version does not exist return null
+            // If the error is that the version does not exist return null
             if (e.getCode() != XWikiException.ERROR_XWIKI_STORE_HIBERNATE_UNEXISTANT_VERSION) {
                 throw e;
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/EditModeClassDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/EditModeClassDocumentInitializer.java
@@ -29,7 +29,7 @@ import com.xpn.xwiki.doc.AbstractMandatoryClassInitializer;
 import com.xpn.xwiki.objects.classes.BaseClass;
 
 /**
- * Update XWiki.EditModeClass document with all required informations.
+ * Update XWiki.EditModeClass document with all required information.
  *
  * @version $Id$
  * @since 4.3M1

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/GlobalRedirectDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/GlobalRedirectDocumentInitializer.java
@@ -33,7 +33,7 @@ import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.classes.BaseClass;
 
 /**
- * Update XWiki.XWikiUsers document with all required informations.
+ * Update XWiki.XWikiUsers document with all required information.
  *
  * @version $Id$
  * @since 4.3M1

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/RedirectClassDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/RedirectClassDocumentInitializer.java
@@ -30,7 +30,7 @@ import com.xpn.xwiki.doc.AbstractMandatoryClassInitializer;
 import com.xpn.xwiki.objects.classes.BaseClass;
 
 /**
- * Update XWiki.Redirect document with all required informations.
+ * Update XWiki.Redirect document with all required information.
  *
  * @version $Id$
  * @since 8.1RC1

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/TagClassDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/TagClassDocumentInitializer.java
@@ -31,7 +31,7 @@ import com.xpn.xwiki.doc.AbstractMandatoryClassInitializer;
 import com.xpn.xwiki.objects.classes.BaseClass;
 
 /**
- * Update XWiki.TagClass document with all required informations.
+ * Update XWiki.TagClass document with all required information.
  *
  * @version $Id$
  * @since 4.3M1

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiCommentsDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiCommentsDocumentInitializer.java
@@ -32,7 +32,7 @@ import com.xpn.xwiki.objects.classes.BaseClass;
 import com.xpn.xwiki.objects.classes.TextAreaClass;
 
 /**
- * Update XWiki.XWikiComments document with all required informations.
+ * Update XWiki.XWikiComments document with all required information.
  *
  * @version $Id$
  * @since 4.3M1

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiGlobalRightsDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiGlobalRightsDocumentInitializer.java
@@ -28,7 +28,7 @@ import org.xwiki.model.reference.LocalDocumentReference;
 import com.xpn.xwiki.XWiki;
 
 /**
- * Update XWiki.XWikiGlobalRights document with all required informations.
+ * Update XWiki.XWikiGlobalRights document with all required information.
  *
  * @version $Id$
  * @since 4.3M1

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiGroupsDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiGroupsDocumentInitializer.java
@@ -34,7 +34,7 @@ import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.classes.BaseClass;
 
 /**
- * Update XWiki.XWikiGroups document with all required informations.
+ * Update XWiki.XWikiGroups document with all required information.
  *
  * @version $Id$
  * @since 4.3M1

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiPreferencesDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiPreferencesDocumentInitializer.java
@@ -39,7 +39,7 @@ import com.xpn.xwiki.objects.classes.TextAreaClass.ContentType;
 import com.xpn.xwiki.objects.meta.PasswordMetaClass;
 
 /**
- * Update XWiki.XWikiPreferences document with all required informations.
+ * Update XWiki.XWikiPreferences document with all required information.
  *
  * @version $Id$
  * @since 4.3M1

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiRightsDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiRightsDocumentInitializer.java
@@ -28,7 +28,7 @@ import org.xwiki.model.reference.LocalDocumentReference;
 import com.xpn.xwiki.XWiki;
 
 /**
- * Update XWiki.XWikiRights document with all required informations.
+ * Update XWiki.XWikiRights document with all required information.
  *
  * @version $Id$
  * @since 4.3M1

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiSkinsDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiSkinsDocumentInitializer.java
@@ -34,7 +34,7 @@ import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.classes.BaseClass;
 
 /**
- * Update XWiki.XWikiSkins document with all required informations.
+ * Update XWiki.XWikiSkins document with all required information.
  *
  * @version $Id$
  * @since 4.3M1

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiUsersDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiUsersDocumentInitializer.java
@@ -34,7 +34,7 @@ import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.classes.BaseClass;
 
 /**
- * Update XWiki.XWikiUsers document with all required informations.
+ * Update XWiki.XWikiUsers document with all required information.
  *
  * @version $Id$
  * @since 4.3M1

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/observation/remote/converter/AbstractXWikiEventConverter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/observation/remote/converter/AbstractXWikiEventConverter.java
@@ -68,7 +68,7 @@ public abstract class AbstractXWikiEventConverter extends AbstractEventConverter
     protected Logger logger;
 
     /**
-     * Used to set some proper context informations.
+     * Used to set some proper context information.
      */
     @Inject
     private Execution execution;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/security/authorization/DefaultAuthorExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/security/authorization/DefaultAuthorExecutor.java
@@ -54,7 +54,7 @@ public class DefaultAuthorExecutor implements AuthorExecutor
     private Logger logger;
 
     /**
-     * Contain the informations to restore.
+     * Contain the information to restore.
      *
      * @version $Id$
      */

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/HibernateConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/HibernateConfiguration.java
@@ -97,7 +97,7 @@ public class HibernateConfiguration
     }
 
     /**
-     * @return the databse/schema name for the main wiki
+     * @return the database/schema name for the main wiki
      */
     public String getDB()
     {
@@ -105,7 +105,7 @@ public class HibernateConfiguration
     }
 
     /**
-     * @return a prefix to apply to the database/shema name of each wiki
+     * @return a prefix to apply to the database/schema name of each wiki
      */
     public String getDBPrefix()
     {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/job/JobRequestContext.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/job/JobRequestContext.java
@@ -88,7 +88,7 @@ public class JobRequestContext implements Serializable
     }
 
     /**
-     * @param xcontext the XWiki context to extract informations from
+     * @param xcontext the XWiki context to extract information from
      */
     public JobRequestContext(XWikiContext xcontext)
     {
@@ -276,7 +276,7 @@ public class JobRequestContext implements Serializable
     }
 
     /**
-     * @return true if the request informations have been set
+     * @return true if the request information has been set
      * @since 8.4RC1
      */
     public boolean isRequestSet()

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseCollection.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseCollection.java
@@ -821,7 +821,7 @@ public abstract class BaseCollection<R extends EntityReference> extends BaseElem
     /**
      * Return a XML version of this collection.
      * <p>
-     * The XML is not formated. to get formatted XML you can use {@link #toXMLString(boolean)} instead.
+     * The XML is not formatted. to get formatted XML you can use {@link #toXMLString(boolean)} instead.
      * 
      * @return the XML as a String
      */

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseElement.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseElement.java
@@ -489,7 +489,7 @@ public abstract class BaseElement<R extends EntityReference> implements ElementI
         // Note that we're loosing conflicts information about prettyname, but it's probably ok, at least it's not a
         // regression since we were not getting that info in the past.
         // Now it might not be a good idea to mix those info with the conflicts related to the value of the element
-        // we might need improvment in the design here...
+        // we might need improvement in the design here...
         mergeManagerResult.setLog(mergePrettyNameResult.getLog());
         if (mergePrettyNameResult.isModified()) {
             mergeManagerResult.setModified(true);
@@ -607,7 +607,7 @@ public abstract class BaseElement<R extends EntityReference> implements ElementI
     }
 
     /**
-     * @param format true if the XML should be formated
+     * @param format true if the XML should be formatted
      * @return the XML as a String
      * @since 9.0RC1
      */

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseProperty.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseProperty.java
@@ -267,7 +267,7 @@ public class BaseProperty<R extends EntityReference> extends BaseElement<R> impl
     /**
      * Return a XML version of this collection.
      * <p>
-     * The XML is not formated. to get formatted XML you can use {@link #toXMLString(boolean)} instead.
+     * The XML is not formatted. to get formatted XML you can use {@link #toXMLString(boolean)} instead.
      * 
      * @return the XML as a String
      */

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/ElementInterface.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/ElementInterface.java
@@ -94,11 +94,11 @@ public interface ElementInterface
         MergeConfiguration configuration, XWikiContext context);
 
     /**
-     * Apply the provided element so that the current one contains the same informations and indicate if it was
+     * Apply the provided element so that the current one contains the same information and indicate if it was
      * necessary to modify it in any way.
      *
      * @param newElement the element to apply
-     * @param clean true if informations that are not in the new element should be removed (for example class properties
+     * @param clean true if information that are not in the new element should be removed (for example class properties
      *            not in the new class)
      * @return true if the element has been modified
      * @since 4.3M1

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/TextAreaClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/TextAreaClass.java
@@ -108,7 +108,7 @@ public class TextAreaClass extends StringClass
         }
 
         /**
-         * Retreive the {@link EditorType} based on its value.
+         * Retrieve the {@link EditorType} based on its value.
          * <p>
          * The search is case insensitive.
          *
@@ -170,7 +170,7 @@ public class TextAreaClass extends StringClass
         }
 
         /**
-         * Retreive the {@link ContentType} based on its value.
+         * Retrieve the {@link ContentType} based on its value.
          * <p>
          * The search is case insensitive.
          *

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
@@ -836,7 +836,7 @@ public class Package
                     previousdoc = previousdoc.getTranslatedDocument(doc.getLanguage(), context);
                 }
                 // we should only delete the previous document
-                // if we are overridding the versions and/or if this is a backup pack
+                // if we are overriding the versions and/or if this is a backup pack
                 if (!this.preserveVersion || this.withVersions) {
                     try {
                         // This is not a real document delete, it's a upgrade. To be sure to not

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/stats/impl/XWikiStats.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/stats/impl/XWikiStats.java
@@ -238,7 +238,7 @@ public class XWikiStats extends BaseCollection
     /**
      * Initialize statistics object from XML schema.
      *
-     * @param oel the XML root node containing statistics datas.
+     * @param oel the XML root node containing statistics data.
      * @throws XWikiException error when parsing XML schema.
      */
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
@@ -599,7 +599,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
                     Session session = getSession(context);
                     session.setHibernateFlushMode(FlushMode.COMMIT);
 
-                    // These informations will allow to not look for attachments and objects on loading
+                    // This information will allow to not look for attachments and objects on loading
                     doc.setElement(XWikiDocument.HAS_ATTACHMENTS, !doc.getAttachmentList().isEmpty());
                     doc.setElement(XWikiDocument.HAS_OBJECTS, !doc.getXObjects().isEmpty());
 
@@ -1026,7 +1026,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
                 executeWrite(context, session -> {
                     saveXWikiDoc(newDocument, context, false);
 
-                    // Since the save documment is called without a commit, the information are not flushed
+                    // Since the save document is called without a commit, the information is not flushed
                     // in the session either. However we need the new information in the session for the delete
                     // in particular to know the possible changes made in the spaces.
                     session.flush();
@@ -3275,7 +3275,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
      * is to simply replace all instances of \ with \\ which makes the first backslash escape the second.
      *
      * @param sql the uncleaned sql.
-     * @return same as sql except it is guarenteed not to contain groups of odd numbers of backslashes.
+     * @return same as sql except it is guaranteed not to contain groups of odd numbers of backslashes.
      * @since 2.4M1
      */
     private String filterSQL(String sql)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/AbstractDropNotNullDataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/AbstractDropNotNullDataMigration.java
@@ -30,7 +30,7 @@ import com.xpn.xwiki.store.XWikiHibernateBaseStore;
 import com.xpn.xwiki.store.migration.DataMigrationException;
 
 /**
- * Remove a non-null constraint from a colomn.
+ * Remove a non-null constraint from a column.
  *
  * @version $Id$
  * @since 9.11RC1

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R140600000XWIKI19869DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R140600000XWIKI19869DataMigration.java
@@ -289,7 +289,7 @@ public class R140600000XWIKI19869DataMigration extends AbstractHibernateDataMigr
                     }
                 } catch (XWikiException e) {
                     // Note: this should never happen since it's a standard string field.
-                    this.logger.error("Error while reseting password field for user [{}]", userDoc, e);
+                    this.logger.error("Error while resetting password field for user [{}]", userDoc, e);
                 }
                 result = true;
             } else if (isMain) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyPersistentLoginManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyPersistentLoginManager.java
@@ -349,7 +349,7 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
                 String encryptedEncodedText = new String(Base64.encodeBase64(encryptedText));
                 // Since the cookie spec does not allow = in the cookie value, it must be replaced
                 // with something else. Bas64 does not use _, and it is allowed in cookies, so
-                // we're using that instead of =. In decryptText the reverse operation is perfomed.
+                // we're using that instead of =. In decryptText the reverse operation is performed.
                 // See XWIKI-2211
                 return encryptedEncodedText.replace("=", "_");
             }
@@ -544,7 +544,7 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
         try {
             // Since the cookie spec does not allow = in the cookie value, it must be replaced
             // with something else. Bas64 does not use _, and it is allowed in cookies, so
-            // we're using that instead of =. In encryptText the reverse operation was perfomed,
+            // we're using that instead of =. In encryptText the reverse operation was performed,
             // so here we must re-introduce the = sign needed by Base64.
             // See XWIKI-2211
             byte[] decodedEncryptedText =

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiGroupServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiGroupServiceImpl.java
@@ -453,7 +453,7 @@ public class XWikiGroupServiceImpl implements XWikiGroupService, EventListener
      *            <li>asc : a Boolean, if true the order is ascendent</li>
      *            </ul>
      * @param parameterValues the list of values to fill for use with HQL named request.
-     * @return the formated HQL named request.
+     * @return the formatted HQL named request.
      */
     protected String createMatchUserOrGroupWhereClause(boolean user, Object[][] matchFields, Object[][] order,
         List<Object> parameterValues)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/util/XWikiStubContextProvider.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/util/XWikiStubContextProvider.java
@@ -27,7 +27,7 @@ import com.xpn.xwiki.XWikiContext;
  * Tool to make easier to generate stub XWikiContext. It's supposed to be initialized once with the first request and it
  * can be called to get a stub context generated from this initial XWikiContext.
  * <p>
- * The reason to initialize it based on first request is to get some informations we could not know otherwise like a
+ * The reason to initialize it based on first request is to get some information we could not know otherwise like a
  * default scheme/host/port.
  *
  * @version $Id$

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/EditForm.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/EditForm.java
@@ -509,7 +509,7 @@ public class EditForm extends XWikiForm
                 try {
                     classNumber = Integer.parseInt(classNumberAsString);
                 } catch (NumberFormatException e) {
-                    // If the numner isn't valid, skip the property update
+                    // If the number isn't valid, skip the property update
                     LOGGER.warn("Invalid xobject number [{}], ignoring property update [{}].", classNumberAsString,
                         parameter.getKey());
                     continue;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ExportAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ExportAction.java
@@ -123,7 +123,7 @@ public class ExportAction extends XWikiAction
         // down or even block the PDF export
         //
         // Ideally we should ask for a CSRF token, but this would break backwards compatibility. We can't rely on the
-        // Accept HTTP header either becuse it includes */* most of the time, even when the request originates from a
+        // Accept HTTP header either because it includes */* most of the time, even when the request originates from a
         // script or image HTML tag. The best option seems to be to rely on the Sec-Fetch-Dest header which is set by
         // modern browsers to indicate the context in which the request is made.
         // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Dest

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ImportAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ImportAction.java
@@ -168,7 +168,7 @@ public class ImportAction extends XWikiAction
         @SuppressWarnings("resource")
         InputSource source = new XWikiAttachmentContentInputSource(packFile.getAttachmentContent(context));
 
-        // Get the history handling stategy
+        // Get the history handling strategy
         String historyStrategy = request.getParameter("historyStrategy");
 
         // Get the backup switch value

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/LoginAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/LoginAction.java
@@ -53,7 +53,7 @@ public class LoginAction extends XWikiAction
         // Disallow template override with xpage parameter.
         if (!LOGIN.equals(Utils.getPage(context.getRequest(), LOGIN))) {
             throw new XWikiException(XWikiException.MODULE_XWIKI, XWikiException.ERROR_XWIKI_ACCESS_DENIED,
-                String.format("Template may not be overriden with 'xpage' in [%s] action.", LOGIN));
+                String.format("Template may not be overridden with 'xpage' in [%s] action.", LOGIN));
         }
 
         return super.action(context);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/LoginErrorAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/LoginErrorAction.java
@@ -45,7 +45,7 @@ public class LoginErrorAction extends XWikiAction
         // Disallow template override with xpage parameter.
         if (!LOGIN.equals(Utils.getPage(context.getRequest(), LOGIN))) {
             throw new XWikiException(XWikiException.MODULE_XWIKI, XWikiException.ERROR_XWIKI_ACCESS_DENIED,
-                String.format("Template may not be overriden with 'xpage' in [%s] action.", LOGIN));
+                String.format("Template may not be overridden with 'xpage' in [%s] action.", LOGIN));
         }
 
         return super.action(context);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/LoginSubmitAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/LoginSubmitAction.java
@@ -50,7 +50,7 @@ public class LoginSubmitAction extends XWikiAction
         // Disallow template override with xpage parameter.
         if (!LOGIN.equals(Utils.getPage(context.getRequest(), LOGIN))) {
             throw new XWikiException(XWikiException.MODULE_XWIKI, XWikiException.ERROR_XWIKI_ACCESS_DENIED,
-                String.format("Template may not be overriden with 'xpage' in [%s] action.", LOGIN));
+                String.format("Template may not be overridden with 'xpage' in [%s] action.", LOGIN));
         }
 
         return super.action(context);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SaveAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SaveAction.java
@@ -138,7 +138,7 @@ public class SaveAction extends EditAction
      * @param context The current request {@link XWikiContext context}.
      * @return <code>true</code> if there was an error and the response needs to render an error page,
      *         <code>false</code> if the document was correctly saved.
-     * @throws XWikiException If an error occured: cannot communicate with the storage module, or cannot update the
+     * @throws XWikiException If an error occurred: cannot communicate with the storage module, or cannot update the
      *             document because the request contains invalid parameters.
      */
     public boolean save(XWikiContext context) throws XWikiException

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SkinAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SkinAction.java
@@ -100,7 +100,7 @@ public class SkinAction extends XWikiAction
         // Disallow template override with xpage parameter.
         if (!DOCDOESNOTEXIST.equals(Utils.getPage(context.getRequest(), DOCDOESNOTEXIST))) {
             throw new XWikiException(XWikiException.MODULE_XWIKI, XWikiException.ERROR_XWIKI_ACCESS_DENIED,
-                "Template may not be overriden with 'xpage' in [skin] action.");
+                "Template may not be overridden with 'xpage' in [skin] action.");
         }
 
         return super.action(context);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/Utils.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/Utils.java
@@ -523,7 +523,7 @@ public class Utils
     }
 
     /**
-     * Convert a byte character value to the corresponding hexidecimal digit value.
+     * Convert a byte character value to the corresponding hexadecimal digit value.
      * <p>
      * Code borrowed from Apache Tomcat 5.0
      * </p>

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
@@ -128,7 +128,7 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
         // Set the configured home URL for the main wiki
         setDefaultURL(null, homepageConfigration);
 
-        // Check if the request is a deamon thread request
+        // Check if the request is a daemon thread request
         XWikiRequest request = context.getRequest();
         this.daemon = request.getHttpServletRequest() instanceof XWikiServletRequestStub stub
             && stub.isDaemon();

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/IDVersionHibernateAdapterFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/IDVersionHibernateAdapterFactory.java
@@ -116,7 +116,7 @@ public class IDVersionHibernateAdapterFactory implements HibernateAdapterFactory
                 try {
                     adapter = this.componentManager.getInstance(HibernateAdapter.class, roleHint);
                 } catch (ComponentLookupException e) {
-                    throw new HibernateException("Failed to initialize the adapater", e);
+                    throw new HibernateException("Failed to initialize the adapter", e);
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/observation/remote/converter/DocumentEventConverterTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/observation/remote/converter/DocumentEventConverterTest.java
@@ -70,7 +70,7 @@ class DocumentEventConverterTest
     {
         DocumentReference documentReference = new DocumentReference("wiki", "space", "page");
 
-        // Setup of document which just been created and recived by a document event listener
+        // Setup of document which just been created and received by a document event listener
         XWikiDocument document =
             this.oldcore.getSpyXWiki().getDocument(documentReference, this.oldcore.getXWikiContext());
         this.oldcore.getSpyXWiki().saveDocument(document, this.oldcore.getXWikiContext());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/NumberClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/NumberClassTest.java
@@ -55,7 +55,7 @@ class NumberClassTest
         bc.setName("Some.Class");
         nc.setObject(bc);
 
-        // A String value containing non-numeric caracters can not be respresented as a numeric value, so this sould
+        // A String value containing non-numeric characters can not be represented as a numeric value, so this sould
         // throw an exception
         XWikiException xWikiException = assertThrows(XWikiException.class, () -> nc.fromString("asd"));
         assertEquals("Error number 0 in 0: Error when parsing [asd] to type [long]",  xWikiException.getMessage());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/AbstractPackageTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/AbstractPackageTest.java
@@ -174,7 +174,7 @@ public abstract class AbstractPackageTest
         sb.append("<author>XWiki.Admin</author>\n");
         sb.append("<backupPack>true</backupPack>\n");
 
-        // Add extension related informations
+        // Add extension related information
         if (extension != null) {
             sb.append("<extensionId>");
             sb.append(extension.getId());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
@@ -521,7 +521,7 @@ class CreateActionTest
         when(document.getContent()).thenReturn("Some non-empty content");
 
         // Submit from the UI spaceReference=X&name=Y&tocreate=terminal
-        // No diference if it was a non-terminal document, just easier to mock since we already have Main.WebHome set
+        // No difference if it was a non-terminal document, just easier to mock since we already have Main.WebHome set
         // up.
         when(mockRequest.getParameter("spaceReference")).thenReturn("Main");
         when(mockRequest.getParameter("name")).thenReturn("WebHome");
@@ -1614,7 +1614,7 @@ class CreateActionTest
         // Verify null is returned (this means the response has been returned)
         assertNull(result);
 
-        // Note: We are creating X.Y as terminal, since it is overriden from the UI, regardless of any backwards
+        // Note: We are creating X.Y as terminal, since it is overridden from the UI, regardless of any backwards
         // compatibility resolutions. Also using the template extracted from the template provider.
         verify(mockURLFactory).createURL("X", "Y", "edit",
             "template=XWiki.MyTemplate&parent=Main.WebHome&title=Y&form_token=" + CSRF_TOKEN_VALUE,

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/XWikiServletURLFactoryTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/XWikiServletURLFactoryTest.java
@@ -465,7 +465,7 @@ class XWikiServletURLFactoryTest
     {
         this.oldcore.getMockXWikiCfg().setProperty("xwiki.virtual.usepath", "0");
 
-        // Set a deamon request
+        // Set a daemon request
         initDaemonRequest("request", 42);
 
         this.oldcore.getXWikiContext().setWikiId("wiki1");

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/java/org/xwiki/rendering/internal/parser/pygments/PygmentsParser.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/java/org/xwiki/rendering/internal/parser/pygments/PygmentsParser.java
@@ -104,7 +104,7 @@ public class PygmentsParser extends AbstractHighlightParser implements Initializ
     private Parser plainTextParser;
 
     /**
-     * Pygments highligh parser configuration.
+     * Pygments highlight parser configuration.
      */
     @Inject
     private PygmentsParserConfiguration configuration;

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/internal/macro/wikibridge/DefaultWikiMacroManager.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/internal/macro/wikibridge/DefaultWikiMacroManager.java
@@ -163,7 +163,7 @@ public class DefaultWikiMacroManager implements WikiMacroManager
             componentDescriptor.setRoleType(Macro.class);
             componentDescriptor.setRoleHint(wikiMacro.getDescriptor().getId().getId());
 
-            // Save current context informations
+            // Save current context information
             String currentUser = this.bridge.getCurrentUser();
             EntityReference currentEntityReference = this.modelContext.getCurrentEntityReference();
             try {
@@ -181,7 +181,7 @@ public class DefaultWikiMacroManager implements WikiMacroManager
                 throw new WikiMacroException(String.format("Failed to register macro [%s] in [%s] for visibility [%s]",
                     wikiMacro.getDescriptor().getId().getId(), documentReference, visibility), e);
             } finally {
-                // Restore previous context informations
+                // Restore previous context information
                 this.bridge.setCurrentUser(currentUser);
                 this.modelContext.setCurrentEntityReference(currentEntityReference);
             }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/macro/wikibridge/InsufficientPrivilegesException.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/macro/wikibridge/InsufficientPrivilegesException.java
@@ -36,7 +36,7 @@ public class InsufficientPrivilegesException extends Exception
     /**
      * Builds a new {@link InsufficientPrivilegesException} with the given error message.
      * 
-     * @param message error messge.
+     * @param message error message.
      */
     public InsufficientPrivilegesException(String message)
     {

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/macro/wikibridge/WikiMacroException.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/macro/wikibridge/WikiMacroException.java
@@ -35,7 +35,7 @@ public class WikiMacroException extends Exception
     /**
      * Builds a new {@link WikiMacroException} with the given error message.
      * 
-     * @param message error messge.
+     * @param message error message.
      */
     public WikiMacroException(String message)
     {

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroClassDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroClassDocumentInitializer.java
@@ -34,7 +34,7 @@ import com.xpn.xwiki.objects.classes.NumberClass;
 import com.xpn.xwiki.objects.classes.TextAreaClass;
 
 /**
- * Update XWiki.WikiMacroClass document with all required informations.
+ * Update XWiki.WikiMacroClass document with all required information.
  * 
  * @version $Id$
  * @since 4.3M1

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroConstants.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroConstants.java
@@ -99,7 +99,7 @@ public interface WikiMacroConstants
     String MACRO_CONTENT_TYPE_WIKI = "Wiki";
 
     /**
-     * Constant for the "Unkown" choice for Macro Content Type.
+     * Constant for the "Unknown" choice for Macro Content Type.
      */
     String MACRO_CONTENT_TYPE_UNKNOWN = "Unknown";
 
@@ -202,7 +202,7 @@ public interface WikiMacroConstants
     String PARAMETER_TYPE_WIKI = MACRO_CONTENT_TYPE_WIKI;
 
     /**
-     * Constant for the "Unkown" choice for Macro Content Type.
+     * Constant for the "Unknown" choice for Macro Content Type.
      *
      * @since 15.3RC1
      */

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroParameterClassDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroParameterClassDocumentInitializer.java
@@ -33,7 +33,7 @@ import com.xpn.xwiki.objects.classes.ListClass;
 import com.xpn.xwiki.objects.classes.NumberClass;
 
 /**
- * Update XWiki.WikiMacroParameterClass document with all required informations.
+ * Update XWiki.WikiMacroParameterClass document with all required information.
  * 
  * @version $Id$
  * @since 4.3M1

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/StoreFileUtils.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/StoreFileUtils.java
@@ -50,7 +50,7 @@ public final class StoreFileUtils
     }
 
     /**
-     * Get the stored (optionally versionned) name of a file name assuming it's in an associated unique folder.
+     * Get the stored (optionally versioned) name of a file name assuming it's in an associated unique folder.
      *
      * @param filename the name of the file to save. This will be URL encoded.
      * @param versionName the name of the version of the file. This will also be URL encoded.

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentStore.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentStore.java
@@ -488,7 +488,7 @@ public class FilesystemAttachmentStore implements XWikiAttachmentStoreInterface
         protected void onRun() throws Exception
         {
             // TODO: When the rest of storage is rewritten using TransactionRunnable,
-            // this method should be disolved.
+            // this method should be dissolved.
 
             final Session session = this.context.getWiki().getHibernateStore().getSession(this.context);
 

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentVersioningStore.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentVersioningStore.java
@@ -68,7 +68,7 @@ public class FilesystemAttachmentVersioningStore implements AttachmentVersioning
     private FilesystemStoreTools fileTools;
 
     /**
-     * A serializer for the list of attachment metdata.
+     * A serializer for the list of attachment metadata.
      */
     @Inject
     @Named("attachment-list-meta/1.0")

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/serialization/xml/internal/AttachmentListMetadataSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/serialization/xml/internal/AttachmentListMetadataSerializer.java
@@ -61,7 +61,7 @@ public class AttachmentListMetadataSerializer
     private static final String ROOT_ELEMENT_NAME = "attachment-list";
 
     /**
-     * Root node paramter which must be present in order to attempt parsing.
+     * Root node parameter which must be present in order to attempt parsing.
      */
     private static final String SERIALIZER_PARAM = "serializer";
 
@@ -87,7 +87,7 @@ public class AttachmentListMetadataSerializer
 
     /**
      * Testing Constructor.
-     * Dependencied specified.
+     * Dependencies specified.
      *
      * @param attachSerializer the serializer used to serialize/parse the individual attachments.
      */

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/serialization/xml/internal/AttachmentMetadataSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/serialization/xml/internal/AttachmentMetadataSerializer.java
@@ -48,7 +48,7 @@ public class AttachmentMetadataSerializer extends AbstractXMLSerializer<XWikiAtt
     private static final String ROOT_ELEMENT_NAME = "attachment";
 
     /**
-     * Root node paramter which must be present in order to attempt parsing.
+     * Root node parameter which must be present in order to attempt parsing.
      */
     private static final String SERIALIZER_PARAM = "serializer";
 

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/serialization/xml/internal/DeletedAttachmentMetadataSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/serialization/xml/internal/DeletedAttachmentMetadataSerializer.java
@@ -49,7 +49,7 @@ public class DeletedAttachmentMetadataSerializer extends AbstractXMLSerializer<X
     private static final String ROOT_ELEMENT_NAME = "deletedattachment";
 
     /**
-     * Root node paramter which must be present in order to attempt parsing.
+     * Root node parameter which must be present in order to attempt parsing.
      */
     private static final String SERIALIZER_PARAM = "serializer";
 

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-locks/src/main/java/org/xwiki/store/locks/dummy/internal/DummyLock.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-locks/src/main/java/org/xwiki/store/locks/dummy/internal/DummyLock.java
@@ -25,7 +25,7 @@ import java.util.concurrent.locks.Condition;
 
 /**
  * A fake lock.
- * Used for cases when a lock is demanded by the code but the perticular operation does not require one.
+ * Used for cases when a lock is demanded by the code but the particular operation does not require one.
  * Also useful for disabling locking.
  *
  * @version $Id$

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-api/src/main/java/org/xwiki/store/merge/MergeManagerResult.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-api/src/main/java/org/xwiki/store/merge/MergeManagerResult.java
@@ -149,7 +149,7 @@ public class MergeManagerResult<R, C>
     }
 
     /**
-     * @return {@code true} if at least one conflict occured during the merge operation.
+     * @return {@code true} if at least one conflict occurred during the merge operation.
      */
     public boolean hasConflicts()
     {

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-default/src/main/java/org/xwiki/store/merge/internal/DefaultMergeManager.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-default/src/main/java/org/xwiki/store/merge/internal/DefaultMergeManager.java
@@ -489,7 +489,7 @@ public class DefaultMergeManager implements MergeManager
                                 }
                             }
                         } else {
-                            // Object explicitely removed from the DB, it's a conflict
+                            // Object explicitly removed from the DB, it's a conflict
                             objectMergeResult.getLog().error(ERROR_COLLISION_OBJECT, previousObject.getReference());
 
                             // We put the new object only if the fallback is to take new version.

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-serialization/src/main/java/org/xwiki/store/serialization/xml/internal/AbstractXMLSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-serialization/src/main/java/org/xwiki/store/serialization/xml/internal/AbstractXMLSerializer.java
@@ -52,7 +52,7 @@ public abstract class AbstractXMLSerializer<R, P extends R> implements XMLSerial
     public InputStream serialize(final R object) throws IOException
     {
         // This puts everything on the heap for now.
-        // if size becomes a major problem, the alternitive is to fork over another thread
+        // if size becomes a major problem, the alternative is to fork over another thread
         // and use a PipedInputStream.
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-serialization/src/main/java/org/xwiki/store/serialization/xml/internal/XMLWriter.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-serialization/src/main/java/org/xwiki/store/serialization/xml/internal/XMLWriter.java
@@ -62,7 +62,7 @@ public class XMLWriter extends org.dom4j.io.XMLWriter
     private static final int BASE64_WIDTH = 80;
 
     /**
-     * Platform dependent line seperator.
+     * Platform dependent line separator.
      */
     private static final byte[] NEWLINE;
 

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/main/java/org/xwiki/store/ProvidingTransactionRunnable.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/main/java/org/xwiki/store/ProvidingTransactionRunnable.java
@@ -20,7 +20,7 @@
 package org.xwiki.store;
 
 /**
- * A special type of TransactionRunnable which guarentees to provide state to the TransactionRunnables
+ * A special type of TransactionRunnable which guarantees to provide state to the TransactionRunnables
  * which are run inside of it. It can also provide them with data.
  * Suppose you have a unit of work which loads data and that data must be saved in a later
  * TransactionRunnable in the same transaction.

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/main/java/org/xwiki/store/TransactionRunnable.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/main/java/org/xwiki/store/TransactionRunnable.java
@@ -145,7 +145,7 @@ public class TransactionRunnable<T>
                 // Casting the provided context to T is safe because T be what it provides and to add it
                 // as a ProvidingTR, what it provides (P) must extend T, and adding it as a plain
                 // TransactionRunnable, what it requires must extend T and what it provides must extend
-                // what it requires so this.parent.getProvidedContext() is guarenteed to extend T.
+                // what it requires so this.parent.getProvidedContext() is guaranteed to extend T.
                 return (T) ((ProvidingTransactionRunnable) this.parent).getProvidedContext();
             }
             return this.parent.getContext();


### PR DESCRIPTION
Continuation of the logging best-practices audit series (#6055 … #6071), but this batch is deliberately **not** a logging fix.

## Why this is a spelling batch

A **sixth audit pass** removed the one structural blind spot every earlier pass shared: passes 1–5 only ever matched a receiver literally *named* `logger` / `LOGGER` / `log` / `LOG`. The new parser resolves **every `Logger`-typed identifier declared in a file** (field, local or parameter) and scans calls on each, over `src/test/java` as well as `src/main/java`.

Result over `xwiki-platform-core`, `xwiki-platform-distribution` and `xwiki-platform-tools`: **1476 log calls, nothing new.** Zero `CONCAT`, zero `FORMAT`, zero `warn()`-with-Throwable; the remaining `GETMSG` / `MSGLESS` / `LOGGERID` / `SYSOUT` hits are all non-violations already documented in the audit notes. So this batch takes the item the fifth pass explicitly parked: the misspellings **outside** log messages.

They were found with the **codespell dictionary** (65 000 known misspelling → correction pairs), not the thin hand-written list the fifth pass used — which is why pass 5 found 11 typos and this finds 213 across 42 top-level modules. This PR takes the six modules with ≥10 sites.

## What changed

**160 occurrences of 63 distinct misspellings** — 148 in comments/Javadoc, 12 in string literals:

| Module | Fixes |
|---|---:|
| `oldcore` | 96 |
| `notifications` | 15 |
| `extension` | 14 |
| `store` | 14 |
| `filter` | 12 |
| `rendering` | 9 |

Most frequent: `informations` → `information` (42), `datas` → `data` (10), `formated` → `formatted` (7), `explicitely` → `explicitly` (7), `overriden` → `overridden` (6), `occured` → `occurred` (5), `instanciated` → `instantiated` (5).

Two of the string fixes are **log messages** the fifth pass's dictionary missed — `ditribution` in `AbstractDistributionJob` and `reseting` in `R140600000XWIKI19869DataMigration`. The other ten are exception messages (five of them the same "Template may not be overriden with 'xpage'…") and the two `XAROutputProperties` filter-property labels shown in the export UI. **No test in the repository asserts on any of the 12** (checked before changing them).

## Safety

- **Prose only, never an identifier.** The applier classifies every character as comment / string / code and rewrites only the first two. `adapater`, `datas`, `deamon`, `overriden` and `shema` all exist as code too — renaming `HibernateAdapter.getInformationShemaInnoDBTables()` or `XWikiHibernateBaseStore.getHibernateAdapater()` would be a Revapi break — so all 19 code occurrences are left as they are.
- **`@param` / `@throws` tag names are untouched**, verified by diffing the set of tag names before and after.
- Where dropping the French plural left a subject-verb disagreement, the verb was fixed too ("the following information **is** taken into account").
- Deliberately **not** fixed: `advices` in `ExtensionSecurityAdvice` (project vocabulary — the class *is* `Advice`, and "Advice are computed" would be ungrammatical), and the two `TOOD` comments (turning them into real `TODO` tags would create new SonarQube `java:S1135` findings).

## Verification

`mvn -B -ntp checkstyle:check -Plegacy,quality` and `mvn -B -ntp test` run from each of the six module directories.

- checkstyle: **BUILD SUCCESS ×6**
- tests: **BUILD SUCCESS** for `filter`, `store`, `notifications`, `rendering`, `oldcore` (oldcore: 1140 tests, 0 failures)
- `extension`: the only failures are in `xwiki-platform-extension-security-index` (`AffectObjectTest`, `VulnObjectTest`), which this PR does not touch at all — they are pre-existing untracked work-in-progress files in the local tree. Both extension submodules this PR does change (Handler - XAR, Distribution) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
