### PR TITLE
[Misc] Fix misspellings in Javadoc, comments and messages in store and 8 more platform modules

### DIFF
--- a/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/source/AxisConfigurator.java
+++ b/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/source/AxisConfigurator.java
@@ -148,7 +148,7 @@ public class AxisConfigurator extends AbstractConfigurator
     }
 
     /**
-     * Claime limit parameters.
+     * Claim limit parameters.
      *
      * @param key the parameter name.
      * @param value the parameter value.

--- a/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/source/Configurator.java
+++ b/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/source/Configurator.java
@@ -24,7 +24,7 @@ import org.xwiki.rendering.macro.MacroExecutionException;
 /**
  * Configurator interface.
  *
- * Currently, the parameter handling in the Chart macro is a mess, whith most things thrown into the generic "param"
+ * Currently, the parameter handling in the Chart macro is a mess, with most things thrown into the generic "param"
  * parameter.  The configurator interface is used by classes that use the macro parameters for configuration.
  *
  * All parameters will be set by calling setParameter in all configurators before the validation is performed.

--- a/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/source/table/TableCategoryDatasetBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/source/table/TableCategoryDatasetBuilder.java
@@ -57,12 +57,12 @@ public class TableCategoryDatasetBuilder implements TableDatasetBuilder
     private boolean transpose;
 
     /**
-     * Row key set used for validating the absense of duplicate row keys.
+     * Row key set used for validating the absence of duplicate row keys.
      */
     private final Set<String> rowKeySet = new HashSet<>();
 
     /**
-     * Column key set used for validating the absense of duplicate column keys.
+     * Column key set used for validating the absence of duplicate column keys.
      */
     private final Set<String> columnKeySet = new HashSet<>();
 

--- a/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/source/table/TableDatasetBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/source/table/TableDatasetBuilder.java
@@ -82,7 +82,7 @@ public interface TableDatasetBuilder
     /**
      * Set wether the table should be transposed.
      *
-     * @param transpose Indicates that the table shoudl be transposed.
+     * @param transpose Indicates that the table should be transposed.
      */
     void setTranspose(boolean transpose);
 

--- a/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/source/table/TablePieDatasetBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/source/table/TablePieDatasetBuilder.java
@@ -25,7 +25,7 @@ import org.jfree.data.general.Dataset;
 import org.jfree.util.TableOrder;
 
 /**
- * A buider of pie dataset ({@see org.jfree.data.pie.PieDataset}) from a table data source.
+ * A builder of pie dataset ({@see org.jfree.data.pie.PieDataset}) from a table data source.
  *
  * @version $Id$
  * @since 4.2M1

--- a/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-renderer/src/main/java/org/xwiki/chart/internal/VisibilityChartCustomizer.java
+++ b/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-renderer/src/main/java/org/xwiki/chart/internal/VisibilityChartCustomizer.java
@@ -29,7 +29,7 @@ import org.xwiki.chart.ChartCustomizer;
 import org.xwiki.component.annotation.Component;
 
 /**
- * Customize visiblity of items on the chart.
+ * Customize visibility of items on the chart.
  *
  * @version $Id$
  * @since 7.4.3

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/handler/XarExtensionHandlerTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/handler/XarExtensionHandlerTest.java
@@ -376,9 +376,9 @@ class XarExtensionHandlerTest
             this.oldcore.getDocuments().get(new DocumentReference(translatedReference, new Locale("tr")));
 
         assertNotNull(translated,
-            "Document wiki:translated.translated in langauge tr has not been saved in the database");
+            "Document wiki:translated.translated in language tr has not been saved in the database");
         assertFalse(translated.isNew(),
-            "Document wiki:translated.translated in langauge tr has not been saved in the database");
+            "Document wiki:translated.translated in language tr has not been saved in the database");
 
         assertEquals("tr content", translated.getContent(), "Wrong content");
         assertEquals(this.contextUser, translated.getCreatorReference(), "Wrong creator");
@@ -396,7 +396,7 @@ class XarExtensionHandlerTest
         assertNotNull(translated2,
             "Document wiki:translated.translated in language fr has not been saved in the database");
         assertFalse(translated2.isNew(),
-            "Document wiki:translated.translated in langauge fr has not been saved in the database");
+            "Document wiki:translated.translated in language fr has not been saved in the database");
 
         assertEquals("fr content", translated2.getContent(), "Wrong content");
         assertEquals(this.contextUser, translated2.getCreatorReference(), "Wrong creator");
@@ -542,9 +542,9 @@ class XarExtensionHandlerTest
             this.oldcore.getDocuments().get(new DocumentReference(translatedReference, new Locale("tr")));
 
         assertNotNull(translated,
-            "Document wiki:translated.translated in langauge tr has not been saved in the database");
+            "Document wiki:translated.translated in language tr has not been saved in the database");
         assertFalse(translated.isNew(),
-            "Document wiki:translated.translated in langauge tr has not been saved in the database");
+            "Document wiki:translated.translated in language tr has not been saved in the database");
 
         assertEquals("tr content", translated.getContent(), "Wrong content");
         assertEquals(xarCreatorReference, translated.getCreatorReference(), "Wrong creator");
@@ -559,7 +559,7 @@ class XarExtensionHandlerTest
         assertNotNull(translated2,
             "Document wiki:translated.translated in language fr has not been saved in the database");
         assertFalse(translated2.isNew(),
-            "Document wiki:translated.translated in langauge fr has not been saved in the database");
+            "Document wiki:translated.translated in language fr has not been saved in the database");
 
         assertEquals("fr content", translated2.getContent(), "Wrong content");
         assertEquals(xarCreatorReference, translated2.getCreatorReference(), "Wrong creator");

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/ExtensionIndexSolrCoreInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/ExtensionIndexSolrCoreInitializer.java
@@ -123,7 +123,7 @@ public class ExtensionIndexSolrCoreInitializer extends AbstractSolrCoreInitializ
     /**
      * The values of the individual CVEs known for an extension.
      *
-     * @see #SECURITY_MAX_CVSS stores the maxium value of this collection
+     * @see #SECURITY_MAX_CVSS stores the maximum value of this collection
      */
     public static final String SECURITY_CVE_CVSS = "security_cveCVSS";
 

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/AbstractExtensionScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/AbstractExtensionScriptService.java
@@ -227,7 +227,7 @@ public abstract class AbstractExtensionScriptService implements ScriptService
 
     /**
      * Call the passed callable but try/catch and return null in case of exception (and update the last error). A safe
-     * verison of the result is returned.
+     * version of the result is returned.
      * 
      * @param <R> the result type of method {@code call}
      * @param callable a task that returns a result and may throw an exception

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/ExtensionManagerScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/ExtensionManagerScriptService.java
@@ -178,7 +178,7 @@ public class ExtensionManagerScriptService extends AbstractExtensionScriptServic
      * @param nb the maximum number of search results to return. -1 indicate no limit. 0 indicate that no result will be
      *            returned but it can be used to get the total hits.
      * @return the found extensions descriptors, empty list if nothing could be found and null if an expected error has
-     *         been catched
+     *         been caught
      * @see org.xwiki.extension.repository.search.Searchable
      */
     public IterableResult<Extension> search(String pattern, int offset, int nb)
@@ -203,7 +203,7 @@ public class ExtensionManagerScriptService extends AbstractExtensionScriptServic
      * 
      * @param query the search query
      * @return the found extensions descriptors, empty list if nothing could be found and null if an expected error has
-     *         been catched
+     *         been caught
      * @see org.xwiki.extension.repository.search.Searchable
      * @since 7.1RC1
      */

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-api/src/main/java/org/xwiki/mentions/notifications/MentionNotificationParameters.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-api/src/main/java/org/xwiki/mentions/notifications/MentionNotificationParameters.java
@@ -135,9 +135,9 @@ public class MentionNotificationParameters implements Serializable
     }
 
     /**
-     * Returns an unmodifable map of the new mentions. The type of the mentioned actors are used as keys, and the values
-     * are {@link MentionNotificationParameter}, identifying a unique mention in a page by its actor reference and its
-     * anchor.
+     * Returns an unmodifiable map of the new mentions. The type of the mentioned actors are used as keys, and the
+     * values are {@link MentionNotificationParameter}, identifying a unique mention in a page by its actor reference
+     * and its anchor.
      *
      * @return the map of new mentions
      */

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzerTest.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzerTest.java
@@ -307,7 +307,7 @@ class UpdatedDocumentMentionsAnalyzerTest
             buildMentionMacro(USER_U1, "anchor2", FIRST_NAME));
         when(this.xdomService.listMentionMacros(newXDOM)).thenReturn(newMentions);
 
-        // anchor0 is removed and anchor1 and anchor2 are added, all mentionning U1.
+        // anchor0 is removed and anchor1 and anchor2 are added, all mentioning U1.
         Map<MentionedActorReference, List<String>> oldCounts = new HashMap<>();
         oldCounts.put(new MentionedActorReference(USER_U1, "user"), List.of("anchor0"));
         when(this.xdomService.groupAnchorsByUserReference(oldMentions)).thenReturn(oldCounts);
@@ -366,7 +366,7 @@ class UpdatedDocumentMentionsAnalyzerTest
         );
         when(this.xdomService.listMentionMacros(newXDOM)).thenReturn(newMentions);
 
-        // anchor0 is removed and anchor1 and anchor2 are added, all mentionning U1.
+        // anchor0 is removed and anchor1 and anchor2 are added, all mentioning U1.
         Map<MentionedActorReference, List<String>> oldCounts = new HashMap<>();
         oldCounts.put(new MentionedActorReference(USER_U1, "user"), List.of("anchor0"));
         when(this.xdomService.groupAnchorsByUserReference(oldMentions)).thenReturn(oldCounts);
@@ -427,7 +427,7 @@ class UpdatedDocumentMentionsAnalyzerTest
             buildMentionMacro(USER_U1, "anchor2", FIRST_NAME));
         when(this.xdomService.listMentionMacros(newXDOM)).thenReturn(newMentions);
 
-        // anchor0 is removed and anchor1 and anchor2 are added, all mentionning U1.
+        // anchor0 is removed and anchor1 and anchor2 are added, all mentioning U1.
         Map<MentionedActorReference, List<String>> oldCounts = new HashMap<>();
         oldCounts.put(new MentionedActorReference(USER_U1, "user"), asList("anchor0"));
         when(this.xdomService.groupAnchorsByUserReference(oldMentions)).thenReturn(oldCounts);
@@ -492,7 +492,7 @@ class UpdatedDocumentMentionsAnalyzerTest
         );
         when(this.xdomService.listMentionMacros(newXDOM)).thenReturn(newMentions);
 
-        // anchor0 is removed and anchor1 and anchor2 are added, all mentionning U1.
+        // anchor0 is removed and anchor1 and anchor2 are added, all mentioning U1.
         Map<MentionedActorReference, List<String>> oldCounts = new HashMap<>();
         oldCounts.put(new MentionedActorReference(USER_U1, "user"), List.of("anchor0"));
         when(this.xdomService.groupAnchorsByUserReference(oldMentions)).thenReturn(oldCounts);

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/RatingsConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/RatingsConfiguration.java
@@ -34,7 +34,7 @@ import org.xwiki.model.reference.EntityReference;
 public interface RatingsConfiguration
 {
     /**
-     * @return {@code false} if a rating set to 0 shoud lead to the deletion of a previously made vote.
+     * @return {@code false} if a rating set to 0 should lead to the deletion of a previously made vote.
      *         {@code true} means that all ratings noted to 0 are stored. Note that this option will impact the
      *         average rating.
      */

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/events/CreatedRatingEvent.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/events/CreatedRatingEvent.java
@@ -24,7 +24,7 @@ import org.xwiki.ratings.RatingsManager;
 
 /**
  * Event sent whenever a new {@link Rating} is recorded.
- * The event is sent with the following informations:
+ * The event is sent with the following information:
  *   - source: the identifier of the {@link RatingsManager}
  *   - data: the {@link Rating} created.
  *

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/events/DeletedRatingEvent.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/events/DeletedRatingEvent.java
@@ -24,7 +24,7 @@ import org.xwiki.ratings.RatingsManager;
 
 /**
  * Event sent whenever a {@link Rating} is deleted.
- * The event is sent with the following informations:
+ * The event is sent with the following information:
  *   - source: the identifier of the {@link RatingsManager}
  *   - data: the {@link Rating} deleted.
  *

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/events/UpdatedRatingEvent.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/events/UpdatedRatingEvent.java
@@ -28,7 +28,7 @@ import org.xwiki.text.XWikiToStringBuilder;
 
 /**
  * Event sent whenever a {@link Rating} is updated.
- * The event is sent with the following informations:
+ * The event is sent with the following information:
  *   - source: the identifier of the {@link RatingsManager}
  *   - data: the {@link Rating} updated.
  *

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/DefaultRatingsManagerFactory.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/DefaultRatingsManagerFactory.java
@@ -50,7 +50,7 @@ import org.xwiki.ratings.RatingsManagerFactory;
  *   4. it set in the newly instance of {@link RatingsManager} some information such as its identifiers
  *      and configuration
  *   5. it creates a new {@link ComponentDescriptor} by copying the descriptor of the retrieved
- *      {@link RatingsManager}, modifies it to specify the asked hint and by changing the instatiation strategy
+ *      {@link RatingsManager}, modifies it to specify the asked hint and by changing the instantiation strategy
  *      so that it's only instantiated once
  *   6. finally it registers the new component descriptor it in the current component manager so that in next request of
  *      a {@link RatingsManager} with the same hint, the retrieved instance will be returned.

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/RatingSolrCoreInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/RatingSolrCoreInitializer.java
@@ -101,7 +101,7 @@ public class RatingSolrCoreInitializer extends AbstractSolrCoreInitializer
         this.logger.info("Ratings Solr Core schema migrated. Starting migration of already existing ratings.");
         // Step 2: Loop on old ratings and migrate them
 
-        // We explicitely don't retrieve scale from config here since the previous ratings
+        // We explicitly don't retrieve scale from config here since the previous ratings
         // were done with a scale of 5.
         int scaleUpperBound = 5;
         this.solrDocumentMigration120900000

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/SolrRatingsManager.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/SolrRatingsManager.java
@@ -340,7 +340,7 @@ public class SolrRatingsManager implements RatingsManager
                 // Send the appropriate notification
                 this.observationManager.notify(event, this.getIdentifier(), result);
 
-                // If we store the average, we also compute the new informations for it.
+                // If we store the average, we also compute the new information for it.
                 if (storeAverage) {
                     if (oldRating == null) {
                         this.getAverageRatingManager().addVote(reference, vote);

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/migration/R120901000XWIKI17761DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/migration/R120901000XWIKI17761DataMigration.java
@@ -62,7 +62,7 @@ import com.xpn.xwiki.store.migration.hibernate.AbstractHibernateDataMigration;
  * Migration of old Ratings XObjects to Solr store.
  *
  * This migration performs the following operations:
- *   1. it queries in database all the references of document containings a Rating xobjects
+ *   1. it queries in database all the references of document containing a Rating xobjects
  *   2. it iterates over all those documents and all the rating xobjects in them, check if the voted document matches
  *      the configuration (i.e. if the Rating App was configured to use separate documents, then the xobjects to
  *      consider should not be located in the same page as the voted page), and migrate them if its the case and store
@@ -393,7 +393,7 @@ public class R120901000XWIKI17761DataMigration extends AbstractHibernateDataMigr
                 .setReference(ratedPage)
                 .setCreatedAt(date)
                 .setUpdatedAt(date)
-                // We explicitely don't retrieve scale from config here since the previous ratings
+                // We explicitly don't retrieve scale from config here since the previous ratings
                 // were done with a scale of 5.
                 .setScaleUpperBound(5)
                 .setVote(vote);

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
@@ -1074,7 +1074,7 @@ public class ModelFactory
      * {@link ComputedFieldClass}, the serialized value is the computed property value.
      *
      * @param property an XObject property
-     * @param propertyClass the PropertyClass of that XObject proprety
+     * @param propertyClass the PropertyClass of that XObject property
      * @param context the XWikiContext
      * @return the String representation of the property value
      */
@@ -1083,7 +1083,7 @@ public class ModelFactory
     {
         String result;
         if (propertyClass instanceof ComputedFieldClass computedFieldClass) {
-            // TODO: the XWikiDocument needs to be explicitely set in the context, otherwise method
+            // TODO: the XWikiDocument needs to be explicitly set in the context, otherwise method
             // PropertyClass.renderInContext fires a null pointer exception: bug?
             XWikiDocument document = context.getDoc();
             try {

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractClassPropertyValuesProvider.java
@@ -144,7 +144,7 @@ public abstract class AbstractClassPropertyValuesProvider<T> implements ClassPro
      * @param filter the text filter
      * @param propertyDefinition the property definition
      * @return value of {@see getValueFromQueryResult} with the first query result or null if no results.
-     * @throws QueryException if an error occured during the query execution
+     * @throws QueryException if an error occurred during the query execution
      */
     protected PropertyValue getValue(Query query, String filter, T propertyDefinition) throws QueryException
     {

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/url/resources/DocumentRestURLGenerator.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/url/resources/DocumentRestURLGenerator.java
@@ -62,7 +62,7 @@ public class DocumentRestURLGenerator extends AbstractEntityRestURLGenerator<Doc
         } catch (MalformedURLException e) {
             // Note: The method getBaseURI() always return a valid URL (because it uses XWikiURLFactory#getServerURL()
             // which is a URL). Thus calling Utils.createURI().toURL() should always return a valid URL normally.
-            // Thus getBaseURI() should probably be named getBaseURL() and Utils.createURI() should probaby be named
+            // Thus getBaseURI() should probably be named getBaseURL() and Utils.createURI() should probably be named
             // Utils.createURL()...
             throw new XWikiRestException(
                 String.format("Failed to generate a REST URL for the document [%s].", reference), e);

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-docker/src/test/it/org/xwiki/rest/test/WikisResourceIT.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-docker/src/test/it/org/xwiki/rest/test/WikisResourceIT.java
@@ -435,7 +435,8 @@ class WikisResourceIT extends AbstractHttpIT
         }
 
         // Verify we can search for all attachments in a given space (sandbox)
-        // Also verify that a space can be looked up independtly of its case ("sandbox" will match the "Sandbox" space)
+        // Also verify that a space can be looked up independently of its case ("sandbox" will match the "Sandbox"
+        // space)
         getMethod = executeGet(
             String.format("%s?space=" + getTestClassName(), buildURI(WikiAttachmentsResource.class, getWiki())));
         assertEquals(HttpStatus.SC_OK, getMethod.getStatusCode(), getHttpMethodInfo(getMethod));

--- a/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/SchedulerPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/SchedulerPlugin.java
@@ -550,10 +550,10 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
             saveStatus(PAUSED, object, context);
         } catch (SchedulerException e) {
             throw new SchedulerPluginException(SchedulerPluginException.ERROR_SCHEDULERPLUGIN_PAUSE_JOB,
-                "Error occured while trying to pause job " + object.getStringValue(JOB_NAME), e);
+                "Error occurred while trying to pause job " + object.getStringValue(JOB_NAME), e);
         } catch (XWikiException e) {
             throw new SchedulerPluginException(SchedulerPluginException.ERROR_SCHEDULERPLUGIN_PAUSE_JOB,
-                "Error occured while trying to save status of job " + object.getStringValue(JOB_NAME), e);
+                "Error occurred while trying to save status of job " + object.getStringValue(JOB_NAME), e);
         }
     }
 
@@ -573,10 +573,10 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
             saveStatus(NORMAL, object, context);
         } catch (SchedulerException e) {
             throw new SchedulerPluginException(SchedulerPluginException.ERROR_SCHEDULERPLUGIN_RESUME_JOB,
-                "Error occured while trying to resume job " + object.getStringValue(JOB_NAME), e);
+                "Error occurred while trying to resume job " + object.getStringValue(JOB_NAME), e);
         } catch (XWikiException e) {
             throw new SchedulerPluginException(SchedulerPluginException.ERROR_SCHEDULERPLUGIN_RESUME_JOB,
-                "Error occured while trying to save status of job " + object.getStringValue(JOB_NAME), e);
+                "Error occurred while trying to save status of job " + object.getStringValue(JOB_NAME), e);
         }
     }
 
@@ -595,7 +595,7 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
             getScheduler().triggerJob(new JobKey(job));
         } catch (SchedulerException e) {
             throw new SchedulerPluginException(SchedulerPluginException.ERROR_SCHEDULERPLUGIN_TRIGGER_JOB,
-                "Error occured while trying to trigger job " + object.getStringValue(JOB_NAME), e);
+                "Error occurred while trying to trigger job " + object.getStringValue(JOB_NAME), e);
         }
     }
 
@@ -625,14 +625,14 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
             getScheduler().deleteJob(new JobKey(job));
         } catch (SchedulerException e) {
             throw new SchedulerPluginException(SchedulerPluginException.ERROR_SCHEDULERPLUGIN_PAUSE_JOB,
-                "Error occured while trying to pause job " + object.getStringValue(JOB_NAME), e);
+                "Error occurred while trying to pause job " + object.getStringValue(JOB_NAME), e);
         }
         this.schedulersClassLoaderManager.removeScheduler(object.getReference());
     }
 
 
     /**
-     * Re-create the job and put it back in the same state as now. Usefull when something change in the database or the
+     * Re-create the job and put it back in the same state as now. Useful when something change in the database or the
      * indicated class.
      * 
      * @param jobObject the xobject holder the job metadata
@@ -665,7 +665,7 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
                 getScheduler().addJob(job, true);
             } catch (SchedulerException e) {
                 throw new SchedulerPluginException(SchedulerPluginException.ERROR_SCHEDULERPLUGIN_PAUSE_JOB,
-                    "Error occured while trying to unregistere the job [" + jobObject.getReference() + "]", e);
+                    "Error occurred while trying to unregister the job [" + jobObject.getReference() + "]", e);
             }
 
             // Put back the scheduler in the same state as before
@@ -686,7 +686,7 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
                 }
             } catch (SchedulerException e) {
                 throw new SchedulerPluginException(SchedulerPluginException.ERROR_SCHEDULERPLUGIN_SCHEDULE_JOB,
-                    "Error occured while trying to put the job [" + jobObject.getReference()
+                    "Error occurred while trying to put the job [" + jobObject.getReference()
                         + "] in the same state as before",
                     e);
             }

--- a/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/internal/SchedulerJobClassDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/internal/SchedulerJobClassDocumentInitializer.java
@@ -101,7 +101,7 @@ public class SchedulerJobClassDocumentInitializer extends AbstractMandatoryClass
         xclass.addTextField(FIELD_STATUS, "Status", 30);
         xclass.addTextField(FIELD_CRON, "Cron Expression", 30);
 
-        // This field contains groovy script and is thus of tpye PureText.
+        // This field contains groovy script and is thus of type PureText.
         // TODO: In the future, add the ability to provide wiki markup so that all script languages can be supported
         // and not only Groovy. When this is done, convert this field to "Text".
         xclass.addTextAreaField(FIELD_SCRIPT, "Job Script", 60, 10, TextAreaClass.ContentType.PURE_TEXT);

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/AttachmentArchiveDeleteRunnable.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/AttachmentArchiveDeleteRunnable.java
@@ -44,7 +44,7 @@ public class AttachmentArchiveDeleteRunnable extends StartableTransactionRunnabl
     /**
      * @param archive the attachment archive to delete.
      * @param fileTools tools for getting the metadata and versions of the attachment and locks.
-     * @param provider the file provider for gettign the files to delete.
+     * @param provider the file provider for getting the files to delete.
      */
     public AttachmentArchiveDeleteRunnable(final XWikiAttachmentArchive archive, final FilesystemStoreTools fileTools,
         final AttachmentBlobProvider provider) throws BlobStoreException

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/AttachmentArchiveSaveRunnable.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/AttachmentArchiveSaveRunnable.java
@@ -53,9 +53,9 @@ public class AttachmentArchiveSaveRunnable extends StartableTransactionRunnable
      * The Constructor.
      *
      * @param archive the attachment archive to save.
-     * @param fileTools a set of tools for getting the file corrisponding to each version of the
+     * @param fileTools a set of tools for getting the file corresponding to each version of the
      * attachment content and the file for the meta data, as well as temporary
-     * and backup files corrisponding to each. Also for getting locks.
+     * and backup files corresponding to each. Also for getting locks.
      * @param provider the means to get the blobs to store each version of the attachment.
      * @param serializer an attachment list metadata serializer for serializing the metadata of each
      * version of the attachment.

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/main/java/org/xwiki/store/FileSaveTransactionRunnable.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/main/java/org/xwiki/store/FileSaveTransactionRunnable.java
@@ -289,7 +289,7 @@ public class FileSaveTransactionRunnable extends StartableTransactionRunnable<Tr
         throw new IllegalStateException("Tried to rollback the saving of file " + this.toSave.getAbsolutePath()
             + " and encountered a backup, a temp file, and a main file. Since any existing "
             + "main file is renamed to a temp location and the content is saved in the backup location and then "
-            + "renamed to the main location, the existance of all 3 at once should never happen.");
+            + "renamed to the main location, the existence of all 3 at once should never happen.");
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-locks/src/main/java/org/xwiki/store/locks/LockProvider.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-locks/src/main/java/org/xwiki/store/locks/LockProvider.java
@@ -37,7 +37,7 @@ public interface LockProvider
      * If the object is equal to another object gotten through this function then
      * the lock will be identical. As long as the lock is referenced IE: not garbage collected,
      * the original object will be referenced as well so holding locks on large objects will
-     * cause memory leakage. Because of the guarantee of the same lock being used for equivilent
+     * cause memory leakage. Because of the guarantee of the same lock being used for equivalent
      * objects, you can get locks as needed and throw them out when you are done with them.
      *
      * @param toLockOn the object to get a lock for.

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-default/src/test/java/org/xwiki/store/merge/internal/DefaultMergeConflictDecisionManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-default/src/test/java/org/xwiki/store/merge/internal/DefaultMergeConflictDecisionManagerTest.java
@@ -113,7 +113,7 @@ class DefaultMergeConflictDecisionManagerTest
         assertEquals("Cannot find a conflict with reference [unexisting] for document identifier [null_null]",
             logCapture.getMessage(0));
         assertTrue(mergeConflictDecisionsManager.recordDecision(documentReference, userReference, "conflict2",
-            ConflictDecision.DecisionType.CUSTOM, Arrays.asList("Someting", "Custom")));
+            ConflictDecision.DecisionType.CUSTOM, Arrays.asList("Something", "Custom")));
 
         List<ConflictDecision> conflictDecisionList =
             mergeConflictDecisionsManager.getConflictDecisionList(documentReference, userReference);
@@ -128,7 +128,7 @@ class DefaultMergeConflictDecisionManagerTest
         assertEquals(Arrays.asList("some", "elements"), conflictDecisionList.get(0).getChunk().getElements());
 
         assertEquals(42, conflictDecisionList.get(1).getChunk().getIndex());
-        assertEquals(Arrays.asList("Someting", "Custom"), conflictDecisionList.get(1).getChunk().getElements());
+        assertEquals(Arrays.asList("Something", "Custom"), conflictDecisionList.get(1).getChunk().getElements());
 
         mergeConflictDecisionsManager.removeConflictDecisionList(documentReference, userReference);
         assertNull(mergeConflictDecisionsManager.getConflictDecisionList(documentReference, userReference));

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-serialization/src/main/java/org/xwiki/store/serialization/xml/internal/XMLWriter.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-serialization/src/main/java/org/xwiki/store/serialization/xml/internal/XMLWriter.java
@@ -177,7 +177,7 @@ public class XMLWriter extends org.dom4j.io.XMLWriter
      * </p>
      *
      * @param element <code>{@link Element}</code> to output.
-     * @param rd <code>{@link Reader}</code> that will be fully read and transfered
+     * @param rd <code>{@link Reader}</code> that will be fully read and transferred
      * into the element content.
      * @throws IOException a problem occurs during reading or writing.
      */
@@ -194,11 +194,11 @@ public class XMLWriter extends org.dom4j.io.XMLWriter
      * <code>{@link InputStream}</code> for its content.
      * <p>
      * Note that no decoding/encoding of the InputStream will be ensured during this operation.
-     * The byte content is transfered untouched.
+     * The byte content is transferred untouched.
      * </p>
      *
      * @param element <code>{@link Element}</code> to output.
-     * @param is <code>{@link InputStream}</code> that will be fully read and transfered into
+     * @param is <code>{@link InputStream}</code> that will be fully read and transferred into
      * the element content.
      * @throws IOException a problem occurs during reading or writing.
      */

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/main/java/org/xwiki/store/StartableTransactionRunnable.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/main/java/org/xwiki/store/StartableTransactionRunnable.java
@@ -39,7 +39,7 @@ public class StartableTransactionRunnable<T> extends ProvidingTransactionRunnabl
      * Start this TransactionRunnable and all that are chained to it.
      *
      * @throws TransactionException if something goes wrong while pre running, running, committing,
-     * rolling back or completeing this or any of the chained runnables.
+     * rolling back or completing this or any of the chained runnables.
      * @throws IllegalStateException if the same runnable is started more than once.
      */
     public void start() throws TransactionException

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/main/java/org/xwiki/store/TransactionRunnable.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/main/java/org/xwiki/store/TransactionRunnable.java
@@ -249,7 +249,7 @@ public class TransactionRunnable<T>
     /**
      * PreRun this and all of the chained runnables.
      * Run in the order as they were registered in a deep first tree walk.
-     * If an exception occures, call onComplete on each runnable in the reverse order preRun was called.
+     * If an exception occurs, call onComplete on each runnable in the reverse order preRun was called.
      *
      * @throws TransactionException if an exception is thrown by this or one of the chained runnables'
      * onPreRun() functions, also may contain exceptions thrown by one or more
@@ -308,7 +308,7 @@ public class TransactionRunnable<T>
      *
      * @throws TransactionException made by grouping together whatever is thrown by this or one of the
      * chained runnables' onRun() functions and whatever might be thrown by
-     * onRollback() or onComplete() which are called if somethign goes wrong.
+     * onRollback() or onComplete() which are called if something goes wrong.
      */
     protected final void run() throws TransactionException
     {
@@ -430,7 +430,7 @@ public class TransactionRunnable<T>
             });
         }
         doAllAndCollectThrowables(list, "Failure in onComplete() the storage engine should be "
-            + "consistant although it may contain uncollected garbage.",
+            + "consistent although it may contain uncollected garbage.",
             false);
     }
 

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/com/xpn/xwiki/plugin/tag/TagPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/com/xpn/xwiki/plugin/tag/TagPlugin.java
@@ -200,7 +200,7 @@ public class TagPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfac
      * Get cardinality map of tags within the wiki.
      * 
      * @param context XWiki context.
-     * @return map of tags (alphabetical order) with their occurences counts.
+     * @return map of tags (alphabetical order) with their occurrences counts.
      * @throws XWikiException if search query fails (possible failures: DB access problems, etc).
      */
     public Map<String, Integer> getTagCount(XWikiContext context) throws XWikiException
@@ -237,7 +237,7 @@ public class TagPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfac
      * 
      * @param spaces the list of space to get tags in, as a comma separated, quoted space references strings.
      * @param context XWiki context.
-     * @return map of tags with their occurences counts
+     * @return map of tags with their occurrences counts
      * @throws XWikiException if search query fails (possible failures: space list parse error, DB problems, etc).
      * @since 8.2M1
      */

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/com/xpn/xwiki/plugin/tag/TagPluginApi.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/com/xpn/xwiki/plugin/tag/TagPluginApi.java
@@ -72,7 +72,7 @@ public class TagPluginApi extends PluginApi<TagPlugin>
     /**
      * Get cardinality map of tags within the wiki.
      * 
-     * @return map of tags with their occurences counts.
+     * @return map of tags with their occurrences counts.
      * @throws XWikiException if search query fails (possible failures: DB access problems, etc).
      */
     public Map<String, Integer> getTagCount() throws XWikiException
@@ -84,7 +84,7 @@ public class TagPluginApi extends PluginApi<TagPlugin>
      * Get cardinality map of tags for a specific wiki space.
      * 
      * @param space the space to get tags in
-     * @return map of tags with their occurences counts
+     * @return map of tags with their occurrences counts
      * @throws XWikiException if search query fails (possible failures: DB access problems, etc).
      * @since 1.2
      */
@@ -97,7 +97,7 @@ public class TagPluginApi extends PluginApi<TagPlugin>
      * Get cardinality map of tags for list wiki spaces.
      * 
      * @param spaces the list of space to get tags in, as a comma separated, quoted string
-     * @return map of tags with their occurences counts
+     * @return map of tags with their occurrences counts
      * @throws XWikiException if search query fails (possible failures: DB access problems, etc).
      * @since 8.1
      */

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/ExtensionInstaller.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/ExtensionInstaller.java
@@ -186,7 +186,7 @@ public class ExtensionInstaller
         // System properties by the Maven Surefire or Failsafe plugins. If not defined, then read the dependencies from
         // the current POM and only take the ones not having a "test" scope and being of type "xar" or "jar".
         // Note that the use case for defining the system property is for the cases when you don't want to draw
-        // dependencies in your POM (can be useful when you want to test your extension on a vesion of XWiki for which
+        // dependencies in your POM (can be useful when you want to test your extension on a version of XWiki for which
         // it wasn't developed for).
         extensions.addAll(getProjectExtensionIds(distributionExtensionIds));
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/configuration/ConfigurationFilesGenerator.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/configuration/ConfigurationFilesGenerator.java
@@ -379,7 +379,7 @@ public class ConfigurationFilesGenerator
         // DB connections. compared  to in the past. When the tests succeed, xwiki starts in about 1mn20s. When they
         // fail xwiki takes over 5mn to start, showing how slow the machine is. When it succeeds the connection cool
         // is used up to 40 connections (out of 50) so already close to the max. When it fails, it goes quickly to 50.
-        // Basically the connections are not released fast enough becauase the SQL queries take longer to execute.
+        // Basically the connections are not released fast enough because the SQL queries take longer to execute.
         // Thus trying with 300 max connections to see if that's the problem.
         props.setProperty("xwikiDbDbcpMaxTotal", "300");
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/ExtensionOverride.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/ExtensionOverride.java
@@ -29,7 +29,7 @@ package org.xwiki.test.docker.junit5;
 public @interface ExtensionOverride
 {
     /**
-     * @return the idenfier of the extension
+     * @return the identifier of the extension
      */
     String extensionId();
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-rest/src/main/java/org/xwiki/test/extension/JobExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-rest/src/main/java/org/xwiki/test/extension/JobExecutor.java
@@ -50,7 +50,7 @@ public class JobExecutor
      * @param request the Job request to send
      * @param xwikiRESTURL the XWiki REST URL (e.g. {@code http://localhsot:8080/xwiki/rest})
      * @param credentials the xwiki user and password to use to connect for the REST endpoint
-     * @throws Exception if an error occured when connecting to the REST endpoint
+     * @throws Exception if an error occurred when connecting to the REST endpoint
      */
     public void execute(String jobType, JobRequest request, String xwikiRESTURL,
         UsernamePasswordCredentials credentials) throws Exception

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
@@ -3263,7 +3263,7 @@ public class TestUtils
             ResourceAPI resource = RESOURCES_MAP.get(reference.getType());
 
             if (resource == null) {
-                throw new Exception("Unsuported type [" + reference.getType() + "]");
+                throw new Exception("Unsupported type [" + reference.getType() + "]");
             }
 
             return getLocale(reference) != null ? resource.localeAPI : resource.api;

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
@@ -269,7 +269,7 @@ public class BasePage extends BaseElement
     }
 
     /**
-     * Performs a click on the "edit acces rights" entry of the content menu.
+     * Performs a click on the "edit access rights" entry of the content menu.
      */
     public RightsEditPage editRights()
     {

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CopyOverwritePromptPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CopyOverwritePromptPage.java
@@ -80,7 +80,7 @@ public class CopyOverwritePromptPage extends ViewPage
 
     /**
      * Click the cancel link.
-     * @return the view page of the originaly copied document.
+     * @return the view page of the originally copied document.
      */
     public ViewPage clickCancelButton()
     {

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/TableElement.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/TableElement.java
@@ -57,7 +57,7 @@ public class TableElement extends BaseElement
         }
     }
 
-    /** @return true if there are no colums or no rows in the table. True if the table only contains headings. */
+    /** @return true if there are no columns or no rows in the table. True if the table only contains headings. */
     public boolean isEmpty()
     {
         if (empty == -1) {


### PR DESCRIPTION
## Description

Continuation of the spelling sweep started in #6072, which took the six top-level modules with the
most sites. This one takes the **nine largest of the remaining modules**: `store`, `extension`,
`scheduler`, `ratings`, `test`, `chart`, `mentions`, `rest` and `tag` — **74 corrections in 44
files**.

| Module | Fixes | In string literals |
|---|---:|---:|
| `store` | 14 | 4 |
| `extension` | 10 | 6 |
| `scheduler` | 10 | 8 |
| `ratings` | 9 | — |
| `test` | 8 | 1 |
| `chart` | 7 | — |
| `mentions` | 5 | — |
| `rest` | 5 | — |
| `tag` | 5 | — |

The list comes from a codespell-dictionary run over every string literal, Javadoc block and `//`
comment in `xwiki-platform-core`, `xwiki-platform-distribution` and `xwiki-platform-tools`, keeping
only unambiguous single-suggestion corrections. Most frequent: `occured` → `occurred` (10),
`langauge` → `language` (6), `transfered` → `transferred` (3), `occurences` → `occurrences` (5),
`informations` → `information` (4), `mentionning` → `mentioning` (4).

### Policy

Same as #6072:

* **Prose only — never an identifier.** Every character of every file is classified as comment /
  string literal / code, and only the first two are rewritten. Words glued inside a larger token are
  skipped, and case is preserved.
* **`@param` / `@throws` names are left alone.** `xwiki-platform-extension-security-index`'s
  `QueryObject` and `AffectObject` both document a parameter genuinely named `packag` — `package`
  being a Java keyword, it cannot be named anything else — so both are skipped.
* Two lines crossed 120 characters after their correction (`MentionNotificationParameters`,
  `WikisResourceIT`) and were rewrapped by hand.

### The 19 string-literal changes

Eight `SchedulerPlugin` exception messages, six assertion messages in `XarExtensionHandlerTest`
("in langauge tr"), the `FileSaveTransactionRunnable` and `TransactionRunnable` exception messages,
`TestUtils`'s `"Unsuported type [...]"`, and two `"Someting"` chunk values in
`DefaultMergeConflictDecisionManagerTest`. Each was grepped repo-wide before being changed; every
one is confined to its own file, and no test asserts on any of them from elsewhere.

One correction is not from the dictionary: `SchedulerPlugin`'s message also read "trying to
**unregistere** the job", on a line this change was rewriting anyway.

## Verification

Per bundled module, `mvn -B -ntp test` then `mvn -B -ntp checkstyle:check -Plegacy,quality`, run
from that module's directory — all nine green. `xwiki-platform-rest-test-docker` is only built under
the `docker` profile, so its comment change was verified separately with
`mvn -B -ntp test-compile -Pdocker,integration-tests`.
