### PR TITLE
[Misc] Fix misspellings in Javadoc, comments and messages in rendering and 24 more platform modules

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/io/IOService.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/io/IOService.java
@@ -27,7 +27,7 @@ import org.xwiki.component.annotation.Role;
 /**
  * This component provides services related to annotations storage and retrieval. It operates with string serialized
  * references for the targets of annotations. This interface does not restrict the implementation of the annotation
- * targets, they can be anything referencable through a string.
+ * targets, they can be anything referenceable through a string.
  *
  * @version $Id$
  * @since 2.3M1

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/io/IOTargetService.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/io/IOTargetService.java
@@ -25,7 +25,7 @@ import org.xwiki.rendering.block.XDOM;
 /**
  * This service provides functions to operate with annotations targets. It operates with string serialized references to
  * such targets. This interface does not restrict the implementation of the annotation targets, they can be anything
- * referencable through a string.
+ * referenceable through a string.
  *
  * @version $Id$
  * @since 2.3M1

--- a/xwiki-platform-core/xwiki-platform-bridge/src/main/java/org/xwiki/bridge/DocumentAccessBridge.java
+++ b/xwiki-platform-core/xwiki-platform-bridge/src/main/java/org/xwiki/bridge/DocumentAccessBridge.java
@@ -322,7 +322,7 @@ public interface DocumentAccessBridge
     /**
      * Retrieves the textual content of the document, in the given language.
      * 
-     * @param documentReference the referenc of the document to access
+     * @param documentReference the reference of the document to access
      * @param language The desired translation of the document.
      * @return The document's content.
      * @throws Exception If the document cannot be accessed.
@@ -333,7 +333,7 @@ public interface DocumentAccessBridge
     /**
      * Retrieves the textual content of the document, in the given language.
      * 
-     * @param documentReference the referenc of the document to access
+     * @param documentReference the reference of the document to access
      * @param language The desired translation of the document.
      * @return The document's content.
      * @throws Exception If the document cannot be accessed.

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/FilterIT.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/FilterIT.java
@@ -118,7 +118,7 @@ class FilterIT extends AbstractCKEditorIT
         }
 
         this.textArea.sendKeys(" end");
-        // Verify that the origial style content is preserved.
+        // Verify that the original style content is preserved.
         assertSourceContains(source.toString() + " end");
     }
 

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/LinkPickerModal.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/LinkPickerModal.java
@@ -24,7 +24,7 @@ import org.openqa.selenium.By;
 import org.xwiki.index.tree.test.po.DocumentPickerModal;
 
 /**
- * Represents the tree modal opened when chosing a link.
+ * Represents the tree modal opened when choosing a link.
  *
  * @version $Id$
  * @since 16.8.0RC1

--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/WikiObjectComponentBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/WikiObjectComponentBuilder.java
@@ -50,7 +50,7 @@ public interface WikiObjectComponentBuilder
      * @param reference the reference of the object that should be used to create the component.
      * @return the new component
      * @throws WikiComponentException if the given {@link ObjectReference} is incompatible with the current builder or
-     * if the {@link WikiComponentBuilder} has not been able to instanciate the component.
+     * if the {@link WikiComponentBuilder} has not been able to instantiate the component.
      */
     List<WikiComponent> buildComponents(ObjectReference reference) throws WikiComponentException;
 }

--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/DefaultWikiComponentManagerEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/DefaultWikiComponentManagerEventListener.java
@@ -103,7 +103,7 @@ public class DefaultWikiComponentManagerEventListener extends AbstractEventListe
                 // Unregister components from the deleted document, if any
                 this.wikiComponentManagerEventListenerHelper.unregisterComponents(documentReference);
             }
-        /* If we are at application startup time, we have to instanciate every document or object that we can find
+        /* If we are at application startup time, we have to instantiate every document or object that we can find
          * in the wiki */
         } else if (event instanceof ApplicationReadyEvent || event instanceof WikiReadyEvent) {
             // These 2 events are created when the database is ready. We register all wiki components.

--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/bridge/WikiBaseObjectComponentBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/bridge/WikiBaseObjectComponentBuilder.java
@@ -45,7 +45,7 @@ public interface WikiBaseObjectComponentBuilder extends WikiObjectComponentBuild
      * @param baseObject the XObject that should be used to create the component.
      * @return the new components
      * @throws WikiComponentException if the given {@link EntityReference} is incompatible with the current builder or
-     * if the {@link WikiComponentBuilder} has not been able to instanciate the component.
+     * if the {@link WikiComponentBuilder} has not been able to instantiate the component.
      */
     List<WikiComponent> buildComponents(BaseObject baseObject) throws WikiComponentException;
 

--- a/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-script/src/main/java/org/xwiki/crypto/script/RSACryptoScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-crypto/xwiki-platform-crypto-script/src/main/java/org/xwiki/crypto/script/RSACryptoScriptService.java
@@ -418,7 +418,8 @@ public class RSACryptoScriptService implements ScriptService
      *
      * @param signature the CMS signature to verify.
      * @param certificateProvider Optionally, a certificate provider for obtaining the chain of certificate for
-     *                            verifying the signatures. If null, certificat should all be embedded in the signature.
+     *                            verifying the signatures. If null, certificates should all be embedded in the
+     *                            signature.
      * @return a the result of the verification.
      * @throws GeneralSecurityException on error.
      */
@@ -434,7 +435,8 @@ public class RSACryptoScriptService implements ScriptService
      * @param signature the CMS signature to verify.
      * @param data the content to verify the signature against, or null of the content is embedded in the signature.
      * @param certificateProvider Optionally, a certificate provider for obtaining the chain of certificate for
-     *                            verifying the signatures. If null, certificat should all be embedded in the signature.
+     *                            verifying the signatures. If null, certificates should all be embedded in the
+     *                            signature.
      * @return a the result of the verification.
      * @throws GeneralSecurityException on error.
      */

--- a/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-api/src/main/java/org/xwiki/export/pdf/internal/job/PrintPreviewURLBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-api/src/main/java/org/xwiki/export/pdf/internal/job/PrintPreviewURLBuilder.java
@@ -77,7 +77,7 @@ public class PrintPreviewURLBuilder
         String hash = Objects.toString(request.getBaseURL().getRef(), "");
 
         // Note that URL#getRef() returns the raw value, similar to URI#getRawFragment(), so we need to decode it
-        // (because the fragment identifer can contain special characters that were URL encoded when the base URL was
+        // (because the fragment identifier can contain special characters that were URL encoded when the base URL was
         // created). Otherwise the fragment identifier will be double encoded in the print preview URL.
         hash = URLDecoder.decode(hash, StandardCharsets.UTF_8);
 

--- a/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-default/src/main/java/org/xwiki/export/pdf/internal/chrome/ChromeManagerManager.java
+++ b/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-default/src/main/java/org/xwiki/export/pdf/internal/chrome/ChromeManagerManager.java
@@ -289,7 +289,7 @@ public class ChromeManagerManager implements Disposable
         containerManager.execInContainer(this.containerId,
             bashCommand(waitForChromeReady.formatted(localDebuggingPort)));
 
-        // Start the socat proxy and leave it runnning in the background.
+        // Start the socat proxy and leave it running in the background.
         this.logger.debug("Starting socat proxy: [0.0.0.0:{}] -> [127.0.0.1:{}]", remoteDebuggingPort,
             localDebuggingPort);
         String startSocat = "nohup socat TCP-LISTEN:%s,fork,reuseaddr TCP:127.0.0.1:%s > /dev/null 2>&1 &";

--- a/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-test/xwiki-platform-export-pdf-test-docker/src/test/it/org/xwiki/export/pdf/test/ui/PDFExportIT.java
+++ b/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-test/xwiki-platform-export-pdf-test-docker/src/test/it/org/xwiki/export/pdf/test/ui/PDFExportIT.java
@@ -408,7 +408,7 @@ class PDFExportIT
             assertTrue(pageText.startsWith("""
                 Parent
                 Chapter 1
-                """), "Unexpeced parent document content: " + pageText);
+                """), "Unexpected parent document content: " + pageText);
             assertEquals("""
                 Hidden
                 Hidden content

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/EditTranslationIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/EditTranslationIT.java
@@ -179,7 +179,7 @@ class EditTranslationIT
         // Switch to en by switching language in the Drawer to test the feature
         viewPage.clickLocale(Locale.ENGLISH);
 
-        // Verify edit mode informations in edit page
+        // Verify edit mode information in edit page
         setup.gotoPage(referenceDEFAULT, "edit", "language=");
         editPage = new WikiEditPage();
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-pageobjects/src/main/java/org/xwiki/flamingo/test/po/PreviewBox.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-pageobjects/src/main/java/org/xwiki/flamingo/test/po/PreviewBox.java
@@ -28,7 +28,7 @@ import org.xwiki.test.ui.po.ViewPage;
 /**
  * Represents the preview iframe of when customizing a theme.
  * Be careful when using it: the context is switched to be inside the iframe when the box is created. You need to call
- * explicitely {@link #switchToDefaultContent()} to come back on the main frame.
+ * explicitly {@link #switchToDefaultContent()} to come back on the main frame.
  *
  * @version $Id$
  */

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-events-hibernate/xwiki-platform-legacy-events-hibernate-api/src/main/java/org/xwiki/eventstream/store/internal/LegacyEvent.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-events-hibernate/xwiki-platform-legacy-events-hibernate-api/src/main/java/org/xwiki/eventstream/store/internal/LegacyEvent.java
@@ -73,7 +73,7 @@ public class LegacyEvent
     protected String user;
 
     /**
-     * Wiki in which the event occured, example: "xwiki".
+     * Wiki in which the event occurred, example: "xwiki".
      */
     protected String wiki;
 

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/internal/template/SUExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/internal/template/SUExecutor.java
@@ -45,7 +45,7 @@ import org.xwiki.security.authorization.AuthorExecutor;
 public class SUExecutor
 {
     /**
-     * Contain the informations to restore.
+     * Contain the information to restore.
      *
      * @version $Id$
      */

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/plugin/query/XWikiQuery.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/plugin/query/XWikiQuery.java
@@ -68,7 +68,7 @@ public class XWikiQuery extends XWikiCriteria
                     bclass.get(propname), this, map);
             } catch (Exception e) {
                 throw new XWikiException(XWikiException.MODULE_XWIKI, XWikiException.ERROR_XWIKI_UNKNOWN,
-                    "Failed to excute PropertyClass#fromSearchMap", e);
+                    "Failed to execute PropertyClass#fromSearchMap", e);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-api/src/main/java/org/xwiki/localization/LocalizationContext.java
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-api/src/main/java/org/xwiki/localization/LocalizationContext.java
@@ -24,7 +24,7 @@ import java.util.Locale;
 import org.xwiki.component.annotation.Role;
 
 /**
- * Provide various localization related contextual informations (current Locale, etc.).
+ * Provide various localization related contextual information (current Locale, etc.).
  * 
  * @version $Id$
  * @since 4.3M2

--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-api/src/main/java/org/xwiki/localization/internal/message/ParameterTranslationMessageElement.java
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-api/src/main/java/org/xwiki/localization/internal/message/ParameterTranslationMessageElement.java
@@ -57,7 +57,7 @@ public class ParameterTranslationMessageElement implements TranslationMessageEle
     private Parser plainParser;
 
     /**
-     * @param index the index of the paramater to return
+     * @param index the index of the parameter to return
      * @param plainParser used to parse the String content
      */
     public ParameterTranslationMessageElement(int index, Parser plainParser)

--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-api/src/main/java/org/xwiki/localization/message/TranslationMessage.java
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-api/src/main/java/org/xwiki/localization/message/TranslationMessage.java
@@ -27,7 +27,7 @@ import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.CompositeBlock;
 
 /**
- * Generate the final translation based or variables informations (parameters, etc.).
+ * Generate the final translation based or variables information (parameters, etc.).
  * 
  * @version $Id$
  * @since 4.3M2

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/FileSystemMailContentStore.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/FileSystemMailContentStore.java
@@ -162,7 +162,7 @@ public class FileSystemMailContentStore implements MailContentStore, Initializab
                 }
             }
         } catch (Exception e) {
-            throw new MailStoreException("Failed to extract temporary file refernces from headers", e);
+            throw new MailStoreException("Failed to extract temporary file references from headers", e);
         }
 
         return temporaryFiles;

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/thread/AbstractMailQueueManager.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/thread/AbstractMailQueueManager.java
@@ -35,7 +35,7 @@ public abstract class AbstractMailQueueManager<T extends MailQueueItem> implemen
 {
     /**
      * The Mail queue that the mail prepare & sender threads will use to send mails. We use separate threads to allow
-     * preaparing and sending mail asynchronously.
+     * preparing and sending mail asynchronously.
      */
     protected BlockingQueue<T> mailQueue;
 

--- a/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSender.java
+++ b/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSender.java
@@ -45,7 +45,7 @@ public interface MailSender
      * 
      * @param xwiki the XWiki object used to get the default values from the XWiki Preferences ("smtp_server" and
      *            "smtp_from").
-     * @return A mail server configuration, initialized with values from XWiki Preferences, but which can be overriden
+     * @return A mail server configuration, initialized with values from XWiki Preferences, but which can be overridden
      *         by users.
      */
     MailConfiguration createMailConfiguration(XWiki xwiki);

--- a/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSenderPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSenderPlugin.java
@@ -179,7 +179,7 @@ public class MailSenderPlugin extends XWikiDefaultPlugin
      * Filters a list of emails : removes illegal addresses
      * 
      * @param email List of emails
-     * @return An Array containing the correct adresses
+     * @return An Array containing the correct addresses
      */
     private static InternetAddress[] toInternetAddresses(String email) throws AddressException
     {
@@ -350,7 +350,7 @@ public class MailSenderPlugin extends XWikiDefaultPlugin
             }
 
             // Loop over the attachments of the email, add images used from the HTML to the list of attachments to be
-            // embedded with the HTML part, add the other attachements to the list of attachments to be attached to the
+            // embedded with the HTML part, add the other attachments to the list of attachments to be attached to the
             // email.
             for (Attachment attachment : rawAttachments) {
                 if (foundEmbeddedImages.contains(attachment.getFilename())) {

--- a/xwiki-platform-core/xwiki-platform-netflux/xwiki-platform-netflux-api/src/main/java/org/xwiki/netflux/internal/EntityChannelScriptAuthorBot.java
+++ b/xwiki-platform-core/xwiki-platform-netflux/xwiki-platform-netflux-api/src/main/java/org/xwiki/netflux/internal/EntityChannelScriptAuthorBot.java
@@ -36,7 +36,7 @@ import org.xwiki.user.UserReferenceResolver;
 import org.xwiki.websocket.WebSocketContext;
 
 /**
- * A bot that protects entity channels, that are used to sychronize content that may contain scripts, by forcing a
+ * A bot that protects entity channels, that are used to synchronize content that may contain scripts, by forcing a
  * content author (i.e. a script author) with minimum script access rights (between all the users that have ever pushed
  * changes to the channel).
  *
@@ -70,7 +70,7 @@ public class EntityChannelScriptAuthorBot extends AbstractBot
     @Override
     public boolean onJoinChannel(Channel channel)
     {
-        // We want to protect only entity channels that are used to sychronize content that may contain scripts.
+        // We want to protect only entity channels that are used to synchronize content that may contain scripts.
         Optional<EntityChannel> entityChannel = this.entityChannels.getChannel(channel.getKey());
         boolean accept = entityChannel.map(this::needsProtection).orElse(false);
         if (accept) {
@@ -95,7 +95,7 @@ public class EntityChannelScriptAuthorBot extends AbstractBot
 
     private boolean needsProtection(EntityChannel entityChannel)
     {
-        // Protect only entity channels that are used to sychronize content that may contain scripts.
+        // Protect only entity channels that are used to synchronize content that may contain scripts.
         List<String> path = entityChannel.getPath();
         return !path.isEmpty() && PROTECTED_CHANNELS.contains(path.get(path.size() - 1));
     }

--- a/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/main/java/org/xwiki/observation/remote/RemoteObservationManagerContext.java
+++ b/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/main/java/org/xwiki/observation/remote/RemoteObservationManagerContext.java
@@ -22,7 +22,7 @@ package org.xwiki.observation.remote;
 import org.xwiki.component.annotation.Role;
 
 /**
- * Provide informations about the event in the current thread.
+ * Provide information about the event in the current thread.
  *
  * @version $Id$
  * @since 2.0M3

--- a/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/main/java/org/xwiki/observation/remote/internal/jgroups/JGroupsNetworkChannel.java
+++ b/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/main/java/org/xwiki/observation/remote/internal/jgroups/JGroupsNetworkChannel.java
@@ -191,7 +191,7 @@ public class JGroupsNetworkChannel implements NetworkChannel, Receiver
 
         // Create the mapping between JGroups member address and XWiki observation id
         this.membersIdMap = new ConcurrentHashMap<>();
-        // Add current instance to the maping
+        // Add current instance to the mapping
         // Need to be done after starting the channel to know the address
         this.membersIdMap.put(this.jchannel.getAddress().toString(), currentMemberId);
         this.members =

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/PanelIT.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/PanelIT.java
@@ -52,9 +52,9 @@ class PanelIT
 {
 
     // TODO: The backslash character is removed from SPECIAL_CONTENT and SPECIAL_TITLE until XWIKI-18653 is fixed.
-    private static final String SPECIAL_CONTENT = "Is # & \\u0163 triky\\\"? c:windows /root $util";
+    private static final String SPECIAL_CONTENT = "Is # & \\u0163 tricky\\\"? c:windows /root $util";
 
-    private static final String SPECIAL_TITLE = "Is # & \u0163 triky\"? c:windows /root $util";
+    private static final String SPECIAL_TITLE = "Is # & \u0163 tricky\"? c:windows /root $util";
 
     private static final String PANELSIZE_SMALL = "Small";
     private static final String PANELSIZE_MEDIUM = "Medium";

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
@@ -214,7 +214,7 @@ public class IncludeMacro extends AbstractIncludeMacro<IncludeMacroParameters>
                         return null;
                     }, translatedDocumentBridge.getContentAuthorReference(), documentBridge.getDocumentReference());
                 } catch (Exception e) {
-                    throw new MacroExecutionException("Failed to execute tranformations for document ["
+                    throw new MacroExecutionException("Failed to execute transformations for document ["
                         + translatedDocumentBridge.getDocumentReference() + "]");
                 } finally {
                     // Put back the macro in the main XDOM (it will be replaced that the current macro transformation)

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-script/src/main/java/org/xwiki/rendering/macro/script/AbstractJSR223ScriptMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-script/src/main/java/org/xwiki/rendering/macro/script/AbstractJSR223ScriptMacro.java
@@ -329,7 +329,7 @@ public abstract class AbstractJSR223ScriptMacro<P extends JSR223ScriptMacroParam
      * @param engine the script engine
      * @param scriptContext the script context
      * @return The value returned from the execution of the script.
-     * @throws ScriptException if an error occurrs in script. ScriptEngines should create and throw
+     * @throws ScriptException if an error occurs in script. ScriptEngines should create and throw
      *             <code>ScriptException</code> wrappers for checked Exceptions thrown by underlying scripting
      *             implementations.
      */

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/test/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/test/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroTest.java
@@ -569,7 +569,7 @@ class DefaultWikiMacroTest
         // Note: We're using XHTML as the output syntax just to make it easy for asserting.
         assertEquals("<p>" + this.wikiMacroDocument.toString() + "</p>", printer.toString());
         assertTrue(this.oldcore.getXWikiContext().hasDroppedPermissions(),
-            "Wiki macro did not properly restord persmission dropping");
+            "Wiki macro did not properly restore permission dropping");
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/script/RenderingScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/script/RenderingScriptService.java
@@ -206,7 +206,7 @@ public class RenderingScriptService implements ScriptService
     }
 
     /**
-     * Performs transformations on the passed block using the passed transformation context using the curent user as
+     * Performs transformations on the passed block using the passed transformation context using the current user as
      * context author. Requires programming rights.
      * 
      * @param block the block on which to perform the transformations

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/RepositoryManager.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/RepositoryManager.java
@@ -1129,7 +1129,7 @@ public class RepositoryManager
                 versionExtension = repository.resolve(new ExtensionId(id, version));
             }
 
-            // Update version related informations
+            // Update version related information
             return updateExtensionVersion(versionExtension, extensionDocument, index);
         } catch (Exception e) {
             this.logger.error("Failed to resolve extension with id [{}] and version [{}] on repository [{}]", id,
@@ -1150,7 +1150,7 @@ public class RepositoryManager
                 versionExtension = repository.resolve(new ExtensionId(id, version));
             }
 
-            // Update version related informations
+            // Update version related information
             return updateProjectVersion(versionExtension, projectDocument, index);
         } catch (Exception e) {
             this.logger.error("Failed to resolve project with id [{}] and version [{}] on repository [{}]", id, version,

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/RepositoryRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/RepositoryRESTResource.java
@@ -38,7 +38,7 @@ import org.xwiki.repository.Resources;
 public class RepositoryRESTResource extends AbstractExtensionRESTResource
 {
     /**
-     * @return the root repository informations
+     * @return the root repository information
      */
     @GET
     public Repository get()

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-test/xwiki-platform-repository-test-docker/src/test/it/org/xwiki/repository/test/docker/RepositoryIT.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-test/xwiki-platform-repository-test-docker/src/test/it/org/xwiki/repository/test/docker/RepositoryIT.java
@@ -128,7 +128,7 @@ class RepositoryIT
         setup.recacheSecretToken();
         setup.setDefaultCredentials(TestUtils.SUPER_ADMIN_CREDENTIALS);
 
-        // base extension informations
+        // base extension information
 
         this.baseExtension =
             repositoryTestUtils.getTestExtension(new ExtensionId(IDPREFIX + "macro-jar-extension", "1.0"), "jar");

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/AbstractSolrCoreInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/AbstractSolrCoreInitializer.java
@@ -799,7 +799,7 @@ public abstract class AbstractSolrCoreInitializer implements SolrCoreInitializer
      * Add a field in the Solr schema.
      * 
      * @param name the name of the field to add
-     * @param type the tpe of the field to addd
+     * @param type the type of the field to add
      * @param dynamic true to create a dynamic field
      * @param attributes attributed to add to the field definition
      * @throws SolrException when failing to add the field

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/IndexingUserConfigurationInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/IndexingUserConfigurationInitializer.java
@@ -43,7 +43,7 @@ import com.xpn.xwiki.doc.XWikiDocument;
 @Component
 @Named("XWiki.SolrSearchAdminIndexingUser")
 @Singleton
-// initalize after the corresponding class
+// initialize after the corresponding class
 @Priority(ComponentDescriptor.DEFAULT_PRIORITY + 100)
 public class IndexingUserConfigurationInitializer extends AbstractMandatoryDocumentInitializer
 {

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/DefaultLinkStore.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/DefaultLinkStore.java
@@ -93,7 +93,7 @@ public class DefaultLinkStore implements LinkStore
         try {
             return this.solr.getClient(SolrClientInstance.CORE_NAME);
         } catch (SolrException e) {
-            throw new LinkException("Failed to acces Solr search core", e);
+            throw new LinkException("Failed to access Solr search core", e);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-embedded/src/test/java/org/xwiki/search/solr/internal/EmbeddedSolrInitializationTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-embedded/src/test/java/org/xwiki/search/solr/internal/EmbeddedSolrInitializationTest.java
@@ -228,7 +228,7 @@ class EmbeddedSolrInitializationTest
         }
         String dataDir = properties.getProperty("dataDir");
         assertNotNull(dataDir, "dataDir property from properties file was null: " + file.toString());
-        assertTrue(dataDir.contains(File.separator), "File seperators were not escaped properly in the "
+        assertTrue(dataDir.contains(File.separator), "File separators were not escaped properly in the "
             + "cache path!: \"" + dataDir + "\" does not contain '" + File.separator + "'!");
 
     }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/java/org/xwiki/security/authentication/internal/DefaultAuthenticationFailureManager.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/java/org/xwiki/security/authentication/internal/DefaultAuthenticationFailureManager.java
@@ -350,7 +350,7 @@ public class DefaultAuthenticationFailureManager implements AuthenticationFailur
 
     /**
      * This class aims at storing the authentication failure record information about a login. It only stores the first
-     * failing date and the number of failing attempts since then. Those two are resetted if another failure happens
+     * failing date and the number of failing attempts since then. Those two are reset if another failure happens
      * outside of the given time window. (See {@link AuthenticationConfiguration#getTimeWindow()})
      */
     class AuthFailureRecord

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/java/org/xwiki/security/authentication/internal/DefaultRetrieveUsernameManager.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/java/org/xwiki/security/authentication/internal/DefaultRetrieveUsernameManager.java
@@ -110,7 +110,7 @@ public class DefaultRetrieveUsernameManager implements RetrieveUsernameManager
             this.authenticationMailSenderProvider.get().sendRetrieveUsernameEmail(email, userReferences);
         } catch (AddressException e) {
             throw new RetrieveUsernameException(
-                String.format("Error with the given email adresse: [%s]", requestEmail), e);
+                String.format("Error with the given email address: [%s]", requestEmail), e);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/main/java/org/xwiki/security/authorization/internal/XWikiCachingRightService.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/main/java/org/xwiki/security/authorization/internal/XWikiCachingRightService.java
@@ -86,7 +86,7 @@ public class XWikiCachingRightService implements XWikiRightService
             .putAction("pdf", Right.VIEW)
             // TODO: The "undelete" action is mapped to the right "undelete" in the legacy
             // implementation.  We should check whether the "undelete" right is actually used or not and
-            // if we need to introduce it here as well for compatiblity reasons.
+            // if we need to introduce it here as well for compatibility reasons.
             .putAction("undelete", Right.EDIT)
             .putAction("reset", Right.DELETE)
             .putAction("commentadd", Right.COMMENT)

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/test/java/org/xwiki/security/authorization/internal/AuthorizationManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/test/java/org/xwiki/security/authorization/internal/AuthorizationManagerTest.java
@@ -259,7 +259,7 @@ class AuthorizationManagerTest extends AbstractWikiTest
         XWikiContext ctx = testWiki.getXWikiContext();
         ctx.setWikiId("wiki");
 
-        assertAccessTrue("Main wiki oner shoudl have Programming Right", Right.PROGRAM,
+        assertAccessTrue("Main wiki oner should have Programming Right", Right.PROGRAM,
             new DocumentReference("wiki", "XWiki", "Admin"), null, ctx);
     }
 

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/AbstractResourceSkinExtensionPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/AbstractResourceSkinExtensionPlugin.java
@@ -96,7 +96,7 @@ public abstract class AbstractResourceSkinExtensionPlugin extends AbstractSkinEx
     public Set<String> getAlwaysUsedExtensions(XWikiContext context)
     {
         // There is no mean to define an always used extension for something else than a document extension now,
-        // so for resources-based extensions, we return an emtpy set.
+        // so for resources-based extensions, we return an empty set.
         // An idea for the future could be to have an API for plugins and components to register always used resources
         // extensions.
         return Collections.emptySet();

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/sx/AbstractSxAction.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/sx/AbstractSxAction.java
@@ -142,7 +142,7 @@ public abstract class AbstractSxAction extends XWikiAction
         try {
             renderExtension(sxSource, getExtensionType(), context);
         } catch (IllegalArgumentException e) {
-            // Simply set a 404 status code and return null, so that no unneeded bytes are transfered
+            // Simply set a 404 status code and return null, so that no unneeded bytes are transferred
             context.getResponse().setStatus(HttpServletResponse.SC_NOT_FOUND);
         }
         return null;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/main/java/org/xwiki/user/Editor.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/main/java/org/xwiki/user/Editor.java
@@ -40,7 +40,7 @@ public enum Editor
     WYSIWYG,
 
     /**
-     * The editor is not explictly defined which means it'll dedcided based on some context information (for example
+     * The editor is not explicitly defined which means it'll dedcided based on some context information (for example
      * based on the wiki's default editor).
      */
     UNDEFINED;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/main/java/org/xwiki/user/UserProperties.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/main/java/org/xwiki/user/UserProperties.java
@@ -25,7 +25,7 @@ import org.xwiki.configuration.ConfigurationSaveException;
 import org.xwiki.configuration.ConfigurationSource;
 
 /**
- * Represents all the properties of an XWiki user. It can represent direct properites or inherited properties.
+ * Represents all the properties of an XWiki user. It can represent direct properties or inherited properties.
  * Note that it's independent from where users are stored, and should remain that way, so that we can switch the user
  * store in the future.
  *

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/DocumentDocumentReferenceUserReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/DocumentDocumentReferenceUserReferenceResolver.java
@@ -55,7 +55,7 @@ public class DocumentDocumentReferenceUserReferenceResolver extends AbstractUser
         if (rawReference == null) {
             reference = GuestUserReference.INSTANCE;
         } else {
-            // small perf improvment to avoid keep duplicated references in memory.
+            // small perf improvement to avoid keep duplicated references in memory.
             DocumentReference documentReference = this.entityReferenceFactory.getReference(rawReference);
             reference = resolveName(documentReference.getName());
             if (reference == null) {

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/group/DefaultGroupManager.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/group/DefaultGroupManager.java
@@ -151,7 +151,7 @@ public class DefaultGroupManager implements GroupManager
             cacheWikis = getSearchWikis(reference, WikiTarget.ALL, resolve);
         } else {
             throw new GroupException(
-                "Unsuported wiki target [" + wikiTarget + "] with class [" + wikiTarget.getClass() + "]");
+                "Unsupported wiki target [" + wikiTarget + "] with class [" + wikiTarget.getClass() + "]");
         }
 
         return cacheWikis;

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-creationjob/src/test/java/org/xwiki/platform/wiki/creationjob/internal/steps/AddUsersStepTest.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-creationjob/src/test/java/org/xwiki/platform/wiki/creationjob/internal/steps/AddUsersStepTest.java
@@ -73,7 +73,7 @@ class AddUsersStepTest
         List<String> members = new ArrayList<>();
         request.setMembers(members);
 
-        Exception exception = new WikiUserManagerException("Execption in WikiUserManager.");
+        Exception exception = new WikiUserManagerException("Exception in WikiUserManager.");
         doThrow(exception).when(this.wikiUserManager).addMembers(anyCollection(), any());
 
         // Test and verify

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/test/java/org/xwiki/wiki/internal/descriptor/DefaultWikiDescriptorTest.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/test/java/org/xwiki/wiki/internal/descriptor/DefaultWikiDescriptorTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * Vaidate {@link DefaultWikiDescriptor}.
+ * Validate {@link DefaultWikiDescriptor}.
  * 
  * @version $Id$
  */

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-user/xwiki-platform-wiki-user-default/src/main/java/org/xwiki/wiki/user/internal/DefaultWikiUserConfigurationHelper.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-user/xwiki-platform-wiki-user-default/src/main/java/org/xwiki/wiki/user/internal/DefaultWikiUserConfigurationHelper.java
@@ -144,7 +144,7 @@ public class DefaultWikiUserConfigurationHelper implements WikiUserConfiguration
             xwiki.saveDocument(document, "Changed configuration.", context);
         } catch (XWikiException e) {
             throw new WikiUserManagerException(
-                    String.format("Fail to save the confguration document for wiki [%s].", wikiId), e);
+                    String.format("Fail to save the configuration document for wiki [%s].", wikiId), e);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/internal/importer/OfficeAttachmentImporter.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/internal/importer/OfficeAttachmentImporter.java
@@ -187,7 +187,7 @@ public class OfficeAttachmentImporter implements AttachmentImporter
         }
 
         throw new OfficeImporterException(
-            String.format("Cannot find temporary uplodaded attachment [%s]", attachmentReference));
+            String.format("Cannot find temporary uploaded attachment [%s]", attachmentReference));
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/script/WysiwygEditorScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/script/WysiwygEditorScriptService.java
@@ -237,7 +237,7 @@ public class WysiwygEditorScriptService implements ScriptService
             // results. We do this because the main caller of this method is the CKEditor extension and it needs to
             // work with several version of XWiki (including versions older than 11.9RC1 - in which this new method
             // signature was added) and for simplicity reasons is currently passing null.
-            // TODO: Fix the CKEditor plugin to call the non-deprecated toAnnotatedXHTML() method and reomve this
+            // TODO: Fix the CKEditor plugin to call the non-deprecated toAnnotatedXHTML() method and remove this
             // fallback.
             EntityReference resolvedSourceReference = sourceReference;
             if (resolvedSourceReference == null) {

--- a/xwiki-platform-core/xwiki-platform-xar/xwiki-platform-xar-model/src/main/java/org/xwiki/xar/XarFile.java
+++ b/xwiki-platform-core/xwiki-platform-xar/xwiki-platform-xar-model/src/main/java/org/xwiki/xar/XarFile.java
@@ -97,7 +97,7 @@ public class XarFile implements Closeable
     {
         XarEntry entry = this.xarPackage.getEntry(reference);
         if (entry == null) {
-            throw new IOException("Failed to find entry for referenc [" + reference + "]");
+            throw new IOException("Failed to find entry for reference [" + reference + "]");
         }
 
         return this.zipFile.getInputStream(this.zipFile.getEntry(entry.getEntryName()));

--- a/xwiki-platform-core/xwiki-platform-yjs/xwiki-platform-yjs-websocket/src/main/java/org/xwiki/yjs/websocket/internal/MessageType.java
+++ b/xwiki-platform-core/xwiki-platform-yjs/xwiki-platform-yjs-websocket/src/main/java/org/xwiki/yjs/websocket/internal/MessageType.java
@@ -49,7 +49,7 @@ public enum MessageType
 
     /**
      * Used by the client to notify the server about changes in the client's awareness state (e.g. the user's cursor
-     * position or text selection). Some clients may send this messsage even when there is no actual change, just to
+     * position or text selection). Some clients may send this message even when there is no actual change, just to
      * keep the connection alive. In that case they expect the server to acknowledge the message by sending it back to
      * them (at least when they are alone in the room).
      */

--- a/xwiki-platform-core/xwiki-platform-yjs/xwiki-platform-yjs-websocket/src/main/java/org/xwiki/yjs/websocket/internal/RoomScriptAuthorTracker.java
+++ b/xwiki-platform-core/xwiki-platform-yjs/xwiki-platform-yjs-websocket/src/main/java/org/xwiki/yjs/websocket/internal/RoomScriptAuthorTracker.java
@@ -45,7 +45,7 @@ import org.xwiki.yjs.websocket.internal.event.RoomScriptAuthorChangeEvent;
  * Keeps track of the script author associated with each Yjs collaboration room. This is important because the users
  * that join a collaboration room can have different script righs and the content synchronized through a Yjs room can
  * contain scripts that must be evaluated server-side with the rights of the room script author (i.e. with the least
- * script rights amoung the users that have made changes).
+ * script rights among the users that have made changes).
  *
  * @version $Id$
  * @since 18.4.0RC1

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-storage/src/test/it/org/xwiki/test/storage/framework/StoreTestUtils.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-storage/src/test/it/org/xwiki/test/storage/framework/StoreTestUtils.java
@@ -93,7 +93,7 @@ public final class StoreTestUtils
     }
 
     /**
-     * Encodes a given string so that it may be used as a URL component. Compatable with javascript decodeURIComponent,
+     * Encodes a given string so that it may be used as a URL component. Compatible with javascript decodeURIComponent,
      * though more strict than encodeURIComponent: all characters except [a-zA-Z0-9], '.', '-', '*', '_' are converted
      * to hexadecimal, and spaces are substituted by '+'.
      * 

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-storage/src/test/it/org/xwiki/test/storage/profiles/ForEachProfileSuite.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-storage/src/test/it/org/xwiki/test/storage/profiles/ForEachProfileSuite.java
@@ -82,7 +82,7 @@ public class ForEachProfileSuite extends ClasspathSuite
                 // All executors are #0 because they will not be run in parallel.
                 executorByProfile.put(((Class<Profile>) profiles.get(i)).newInstance(), new XWikiExecutor(0));
             } catch (Exception e) {
-                throw new RuntimeException("Failed to instanciate configuration profile.", e);
+                throw new RuntimeException("Failed to instantiate configuration profile.", e);
             }
         }
 


### PR DESCRIPTION
## Description

Continuation of the spelling sweep of #6072 and #6073. Those took the six, then the nine largest
top-level modules; this one takes **every remaining module other than `oldcore` that has 2 or more
sites** — 25 modules, **68 corrections in 59 files**. The threshold is what picks the modules, so
nothing is chosen by hand.

| Module | Fixes | In string literals |
|---|---:|---:|
| `rendering` | 5 | 2 |
| `search` | 5 | 2 |
| `repository` | 4 | — |
| `security` | 4 | 2 |
| `user` | 4 | 1 |
| `component` | 3 | — |
| `export` | 3 | 1 |
| `legacy` | 3 | 1 |
| `localization` | 3 | — |
| `mailsender` | 3 | — |
| `netflux` | 3 | — |
| `wiki` | 3 | 2 |
| `annotation`, `bridge`, `ckeditor`, `crypto`, `distribution-flavor`, `flamingo`, `mail`, `observation`, `panels`, `skin`, `wysiwyg`, `yjs` | 2 each | 5 |
| `xar` | 1 | 1 |

The list comes from a codespell-dictionary run over every string literal, Javadoc block and `//`
comment in `xwiki-platform-core`, `xwiki-platform-distribution` and `xwiki-platform-tools`, keeping
only unambiguous single-suggestion corrections. Most frequent: `informations` → `information` (9),
`instanciate` → `instantiate` (4), `referenc` → `reference` (3), `sychronize` → `synchronize` (3).

### Policy

Same as #6072 and #6073:

* **Prose only — never an identifier.** Every character of every file is classified as comment /
  string literal / code, and only the first two are rewritten. Words glued inside a larger token are
  skipped, `@param` / `@throws` names are skipped outright, and case is preserved.
* Two Javadoc lines crossed 120 characters after their correction (`RSACryptoScriptService`) and
  were rewrapped by hand.

### Three misspellings deliberately left alone

Each of these is a word the dictionary is right about in general, but wrong about here — and each
would have gone green in its own module while breaking a test elsewhere or changing user-facing
text:

* **`Unparseable`** in `DateXarObjectPropertySerializerTest` — that is the **JDK's own
  `ParseException` message** (`Unparseable date: "…"`), which the test asserts on verbatim through
  `LogCaptureExtension`. Not ours to spell.
* **`Varius`** in `PDFExportIT` — `Varius sit amet mattis vulputate enim nulla aliquet.` is
  **lorem-ipsum Latin**, and the assertion matches it character-for-character against the
  `ResizedTable.xml` test-content page.
* **`occured`** in `WikiEditIT` — the test asserts on the rendered
  `core.editors.saveandcontinue.exceptionWhileSaving` translation, which itself reads "An error
  occured while saving". Correcting the assertion alone breaks the test, and correcting the bundle
  too would be a user-facing translation change that desynchronises the English default from every
  translation on l10n.xwiki.org — a separate change, not a Java-source spelling fix.

### Four corrections the dictionary could not make on its own

* **`certificat` → `certificates`, not `certificate`** in `RSACryptoScriptService` (2 sites). The
  dictionary's single suggestion is the singular, but the sentence reads "If null, certificat should
  all be embedded in the signature" — the singular leaves it ungrammatical. Same situation as
  #6072's `Dependencied`.
* **`tpe` → `type`** (`AbstractSolrCoreInitializer`) and **`restord` → `restore`**
  (`DefaultWikiMacroTest`), both too short for the dictionary's 4-character minimum and both on a
  line this change was rewriting anyway for a neighbouring correction.

### The 18 string-literal changes

Exception messages (`XWikiQuery`, `FileSystemMailContentStore`, `IncludeMacro`, `DefaultLinkStore`,
`DefaultRetrieveUsernameManager`, `DefaultGroupManager`, `DefaultWikiUserConfigurationHelper`,
`OfficeAttachmentImporter`, `XarFile`, `ForEachProfileSuite`), assertion messages (`PDFExportIT`,
`DefaultWikiMacroTest`, `EmbeddedSolrInitializationTest`, `AuthorizationManagerTest`) and three
fixture values (`AddUsersStepTest`'s exception text, and `PanelIT`'s `SPECIAL_CONTENT` /
`SPECIAL_TITLE`, which move together and are used only within that file). Every one was grepped
repo-wide with `git grep -lwF` before being kept; that grep is what surfaced the three exclusions
above.

## Verification

`mvn -B -ntp test checkstyle:check -Plegacy,quality` run from each of the **39 leaf Maven modules**
that contain a changed file — all green. Running at the leaf rather than at the 25 top-level
directories covers exactly the same changed code for a fraction of the wall clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
