### PR TITLE
[Misc] Fix misspellings in the JavaScript, CSS and XML comments of web and ckeditor

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-icon/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-icon/plugin.js
@@ -43,7 +43,7 @@
         feed: function (opts, callback) {
           require(['xwiki-wysiwyg-icon-service'], function (iconService) {
             iconService.getIconThemes().then(function (iconThemes) {
-              // Retreive the list of available icons from the current icon theme that match the query.
+              // Retrieve the list of available icons from the current icon theme that match the query.
               iconService.getIcons(iconThemes.currentIconTheme, opts.query).then(function (icons) {
                 callback(icons.map(icon => ({
                   id: icon.name,

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-link/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-link/plugin.js
@@ -440,7 +440,7 @@
             '</button>',
       onLoad: function() {
         // Since we do not (and cannot without deeper changes) use the 'button' type, 
-        // we need to add this element explicitely to the Dialog focus list.
+        // we need to add this element explicitly to the Dialog focus list.
         // We need to hardcode the position since we do not have access to the setupFocus function to reorder the list
         // relative to native tab order.
         // The four elements before this button are: display link, page selection *3

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/plugin.js
@@ -157,7 +157,7 @@
 
       /**
        * @param node an instance of CKEDITOR.htmlParser.node
-       * @return true if the given node is a macro placeholder, false othewise
+       * @return true if the given node is a macro placeholder, false otherwise
        */
       var isMacroPlaceholder = function(node) {
         return (node.name === 'div' || node.name === 'span') && node.hasClass('macro-placeholder');
@@ -174,7 +174,7 @@
         // placeholder).
         const placeholder = $(macroWidget.element.$).children('.macro-placeholder').addClass('hidden');
         if (!isWidgetVisible(macroWidget)) {
-          // Show the placeholder if the macro widget is not visible, either because the macro doesn't have ouput or
+          // Show the placeholder if the macro widget is not visible, either because the macro doesn't have output or
           // because its output is not visible).
           placeholder.removeClass('hidden');
         }
@@ -890,7 +890,7 @@
       var macroPlugin = this;
       editor.addCommand(definition.commandId, {
         exec: function(editor) {
-          // The macro can be inserted either direcly (using the parameter values specified in the macro call) or after
+          // The macro can be inserted either directly (using the parameter values specified in the macro call) or after
           // filling the missing parameter values in the Macro Editor dialog (which is prefilled with the parameter
           // values from the macro call).
           editor.execCommand(definition.insertDirectly ? 'xwiki-macro-insert' : 'xwiki-macro', definition.macroCall);

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-realtime/ckeditorRealtimeAdapter.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-realtime/ckeditorRealtimeAdapter.js
@@ -353,8 +353,8 @@ define('xwiki-ckeditor-realtime-adapter', [
       // Widget#setData() checks if the data has changed before firing the data event, but unfortunately the code
       // expects the data values to be primitives, which is not the case for macro widget data where the parameters data
       // is an object and this makes the check always return false. The problem with this is that when the data event is
-      // fired the scroll postion is updated, making it hard to scroll the content while remote changes are applied (the
-      // scroll bar jumps). So we have to check ourselves if the data has changed.
+      // fired the scroll position is updated, making it hard to scroll the content while remote changes are applied
+      // (the scroll bar jumps). So we have to check ourselves if the data has changed.
       if (widgetData !== this._serializeWidgetData(widget)) {
         widgetData = JSON.parse(widgetData);
         widget.setData(widgetData);
@@ -392,7 +392,7 @@ define('xwiki-ckeditor-realtime-adapter', [
       if (widget.name === 'xwiki-macro') {
         // Whether a macro widget is inline or block depends on the macro output, which is not synchronized and thus is
         // missing from the new content that we want to apply to the editor. When the macro widgets from the new content
-        // are initialized the inline flag is set (in the absence of the macro outut) based on the siblings and the
+        // are initialized the inline flag is set (in the absence of the macro output) based on the siblings and the
         // parent of the macro widget. But there are cases where the macro can be both inline and block in the same
         // context (parent and siblings) so we don't know for sure if the original macro widget was inline or block
         // (e.g. an info box can technically be both inline and block inside a table cell because a table cell accepts
@@ -438,9 +438,9 @@ define('xwiki-ckeditor-realtime-adapter', [
             }
           });
         }
-        // Most of the macro parametes are kept on the macro wrapper, so if the macro wrapper was updated then it's very
-        // likely that the macro parameters were also updated. Some macro parameters are edited in-place using nested
-        // editables. We need to re-render the macro if a new nested editable is added.
+        // Most of the macro parameters are kept on the macro wrapper, so if the macro wrapper was updated then it's
+        // very likely that the macro parameters were also updated. Some macro parameters are edited in-place using
+        // nested editables. We need to re-render the macro if a new nested editable is added.
         shouldRefreshContent = shouldRefreshContent ||
           updatedNode.tagName.toLowerCase() === 'xwiki-widget-xwiki-macro' ||
           (updatedNode.tagName.toLowerCase() === 'xwiki-editable' && widget?.name === 'xwiki-macro' &&

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-realtime/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-realtime/plugin.js
@@ -154,7 +154,7 @@
           await editor._realtime.disconnect();
         }
       } else if (previousMode === 'source' && editor.mode === 'wysiwyg' && editor._realtime.rejoin) {
-        // Swithing from Source back to WYSIWYG mode, which had realtime enabled before the switch.
+        // Switching from Source back to WYSIWYG mode, which had realtime enabled before the switch.
         editor.showNotification(editor.localization.get('xwiki-realtime.joiningCollaboration'));
         editor._realtime.context.realtimeEnabled = true;
         await editor._realtime.connect();

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-slash/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-slash/plugin.js
@@ -40,7 +40,7 @@
       // Configuration for the quick actions search.
       this.config.search = Object.assign({
         includeScore: true,
-        // Allow one character missmatch in 4 (i.e. match at least 3 characters when the input text is 4 characters).
+        // Allow one character mismatch in 4 (i.e. match at least 3 characters when the input text is 4 characters).
         // With the default distance parameter being 100 and location 0 this also means we're matching only the first 25
         // characters which is fine considering that we split the indexed information into tokens (by whitespace).
         threshold: 0.25,
@@ -363,14 +363,14 @@
 
   /**
    * Make CKEDITOR.tools.htmlEncode temporarily behave as CKEDITOR.tools.htmlEncodeAttr while the given action is
-   * executed. This is useful to enfore more strict HTML encoding, e.g. to encode quotes also.
+   * executed. This is useful to enforce more strict HTML encoding, e.g. to encode quotes also.
    *
    * @param {Function} action - the function to execute
    */
   const withStrictHTMLEncoding = function(action) {
     const originalHTMLEncode = CKEDITOR.tools.htmlEncode;
     try {
-      // Follow the implementation of CKEDITOR.tools.htmlEncodeAttr which we cannot call direcly because it calls
+      // Follow the implementation of CKEDITOR.tools.htmlEncodeAttr which we cannot call directly because it calls
       // CKEDITOR.tools.htmlEncode thus leading to an infinite recursion.
       CKEDITOR.tools.htmlEncode = function(text) {
         return originalHTMLEncode(text).replace(/"/g, '&quot;').replace(/'/g, '&#39;');

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-syntax/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-syntax/plugin.js
@@ -123,7 +123,7 @@
     // Destroy the editor without updating the content / value of the underlying element because we're going to use the
     // given content. Wait for the async destroy handlers to be executed.
     await editor.destroy(/* noUpdate: */ true);
-    // Trigger the actual reload of the editor, passing custom editor configuration. Note that the statup mode is not
+    // Trigger the actual reload of the editor, passing custom editor configuration. Note that the startup mode is not
     // taken into account when the editor is loaded in-line. This is why we still need to set the edit mode below after
     // the editor is re-loaded.
     callReloadAsyncHandlers({startupMode: mode});

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-upload/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-upload/plugin.js
@@ -309,7 +309,7 @@
               // Mark the pasted image in order to upload it afterwards.
               image.dataset.xwikiPastedImage = true;
               if (!imageFileStore[image.src] && pastedImageFiles.length) {
-                // Unfortunatelly, there's no explicit mapping between the HTML image elements an the image file objects
+                // Unfortunately, there's no explicit mapping between the HTML image elements and the image file objects
                 // (from the clipboard). We assume that:
                 // * the HTML image elements and the image files are in the same order
                 // * the image files are not duplicated if the same image URL is used multiple times in the HTML

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/resources/logback.xml
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/resources/logback.xml
@@ -76,7 +76,7 @@
   <!-- Log prepared statement cache activity -->
   <logger name="org.hibernate.ps.PreparedStatementCache" level="warn"/>
 
-  <!-- Deactive PDF Export CSS Applier warnings -->
+  <!-- Deactivate PDF Export CSS Applier warnings -->
   <logger name="org.apache.fop.layoutmgr.inline.ContentLayoutManager" level="error"/>
   <logger name="info.informatica.doc.style.css.dom" level="error"/>
 

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/WEB-INF/web.xml
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/WEB-INF/web.xml
@@ -352,7 +352,7 @@
   </servlet-mapping>
 
   <!-- We override the mime type definition for javascript and css files, as some containers don't
-       provide it, causing problems for javascript files containg velocity code, like
+       provide it, causing problems for javascript files containing velocity code, like
        fullscreen.js -->
   <mime-mapping>
     <extension>js</extension>

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.js
@@ -34,7 +34,7 @@ var XWiki = (function(XWiki) {
   }
 
   /**
-   * Allow custom validation messages to be set on the validated field usin data attributes.
+   * Allow custom validation messages to be set on the validated field using data attributes.
    *
    * @param field the validated field
    */

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/compatibility.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/compatibility.js
@@ -512,7 +512,7 @@ Object.extend(XWiki.watchlist, {
   var html = $$('html')[0];
   var head = $$('head')[0];
 
-  // Function that creates a meta tag with the value taken from the new HTML data-* attrribute
+  // Function that creates a meta tag with the value taken from the new HTML data-* attribute
   var addMetaTag = function(name, value) {
     head.insert(new Element('meta', {'name': name, 'content': html.readAttribute('data-xwiki-'+value)}));
   };

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.js
@@ -52,7 +52,7 @@
     class XDataEditors {
       constructor() {
         let self = this;
-        // Maintain informations about actions performed on the editor.
+        // Maintain information about actions performed on the editor.
         // Data abouts xobjects are map whom keys are xclass names and values are list of sorted xobjects ids
         this.editorStatus = {
           savedXObjects: {}, // already saved objects
@@ -709,7 +709,7 @@
         if(!startExpanded) {
           property.addClass('collapsed');
         }
-        // The click event is catched only on the icon and title to avoid breaking behaviour when using actions, 
+        // The click event is caught only on the icon and title to avoid breaking behaviour when using actions, 
         // especially the move action which is dragAndDrop.
         propertyTitle.find('.toggle-collapsable, h2').on('click', function() {
           propertyTitle.parent().toggleClass('collapsed');

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/importer/import.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/importer/import.js
@@ -111,7 +111,7 @@ var XWiki = (function(XWiki){
     });
 
     /**
-     * Helper class to request the server informations about a package via AJAX.
+     * Helper class to request the server information about a package via AJAX.
      */
     importer.PackageInformationRequest = Class.create({
 
@@ -408,7 +408,7 @@ var XWiki = (function(XWiki){
          * - The username of the author of the package (for example XWiki.Admin)
          * - Wether the package is a back up pack or not (contains revisions along with documents)
          *
-         * @param infos the array that contains the informations to build the header upon
+         * @param infos the array that contains the information to build the header upon
          */
         createPackageHeader:function(infos)
         {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/markerScript.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/markerScript.js
@@ -22,7 +22,7 @@
  * after all the deferred scripts have executed. This is needed because sometimes the browser fires DOMContentLoaded
  * before deferred scripts have actually executed, against the HTML5 specification. However, all browsers do respect
  * the order in which the scripts are declared. This script should always be the last script declared in the HEAD,
- * so that it will be executed when all the other scripts have trully executed.
+ * so that it will be executed when all the other scripts have truly executed.
  */
 XWiki.lastScriptLoaded = true;
 if (XWiki.failedInit) {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/panelwizard/toolTip.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/panelwizard/toolTip.js
@@ -59,7 +59,7 @@ function positionTip(e){
 
     var leftedge=(offsetxpoint<0) ? offsetxpoint*(-1) : -1000
 
-    //if the horizontal distance isn't enough to accomodate the width of the context menu
+    //if the horizontal distance isn't enough to accommodate the width of the context menu
     if (rightedge<tipobj.offsetWidth) {
       //move the horizontal position of the menu to the left by it's width
       tipobj.style.left=ie? ietruebody().scrollLeft+event.clientX-tipobj.offsetWidth+"px" : window.pageXOffset+e.clientX-tipobj.offsetWidth+"px"

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/table/livetable.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/table/livetable.js
@@ -447,7 +447,7 @@ XWiki.widgets.LiveTable = Class.create({
     var container = td;
     if (descriptor.link && row['doc_viewable']) {
       const link = new Element(descriptor.link === 'editor' ? 'span' : 'a');
-      // Automatic: the link URL is in JSON results, with the '_url' sufix.
+      // Automatic: the link URL is in JSON results, with the '_url' suffix.
       if (descriptor.link === 'auto') {
         link.href = row[fieldName + '_url'] || row['doc_url'];
       } else if (descriptor.link === 'field') {
@@ -920,7 +920,7 @@ var LiveTablePagination = Class.create({
          });
          this.pagesNodes.invoke("insert", " ");
       }
-      // alwyas display the last page.
+      // always display the last page.
       if (i<pages) {
         if (i+1 < pages) {
           this.pagesNodes.invoke("insert", " ... ");

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/table/tablefilterNsort.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/table/tablefilterNsort.js
@@ -41,8 +41,8 @@
                                    for creating alternating tables
     sortHeader (tr)(mandatory) = is the row in the table that is the header row
     noFilter (td)(optional) =  declares a column as non filterable
-    selectFilter (td) (optional)  = declares a column as filterable using a selct box,
-                                    that is autimatically populated with "available" line values
+    selectFilter (td) (optional)  = declares a column as filterable using a select box,
+                                    that is automatically populated with "available" line values
     unsortable (td) (optional) = declares a column as non sortable
     sortBottom (tr) (optional) = declares a row as the bottom of the sortable rows ( used for totals etc...)
 
@@ -86,7 +86,7 @@ addEvent(window, "load", init_sortnfilter);
 var SORT_COLUMN_INDEX;
 
 function init_sortnfilter() {
-// Intiates the sorting and filtering triggered on an event
+// Initiates the sorting and filtering triggered on an event
   sortables_init();
   filterable_init();
 }
@@ -375,7 +375,7 @@ function ts_makeSortable(table) {
 function alternate(table) {
 /*====================================================
   - check if the table passed to the function is set
-  to doOddEven, if that is the case it colors the lines acordingly.
+  to doOddEven, if that is the case it colors the lines accordingly.
 =====================================================*/
   if (table.className.indexOf("doOddEven") > -1) {
     var visibleRows = 1;
@@ -545,7 +545,7 @@ function AddRow(id,n,f) {
 function PopulateOptions(id, cellIndex, ncells) {
 /*====================================================
   - populates select
-  - adds only 1 occurence of a value
+  - adds only 1 occurrence of a value
 =====================================================*/
   var t = document.getElementById(id);
   var start_row = getStartRow(id);

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/usersandgroups/usersandgroups.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/usersandgroups/usersandgroups.js
@@ -593,7 +593,7 @@ function setBooleanPropertyFromLiveCheckbox(self, saveDocumentURL, configuration
 }
 
 /*
- * Depricated Since 2.3M1
+ * Deprecated Since 2.3M1
  * Use setBooleanPropertyFromLiveCheckbox
  */
 function setGuestExtendedRights(self)

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/widgets/jumpToPage.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/widgets/jumpToPage.js
@@ -40,7 +40,7 @@
   ## An action can have multiple  keyboard shortcuts associated (comma separated).
   #set ($values = $services.localization.render($entry.value).split('\s*,\s*'))
   #foreach ($value in $values)
-    ## Each keyboard shortcut is wrapped in quotes because it was (poorly) designed to be injected direcly in JavaScript,
+    ## Each keyboard shortcut is wrapped in quotes because it was (poorly) designed to be injected directly in JavaScript,
     ## which we don't do anymore. So we need to remove the quotes.
     #set ($discard = $values.set($foreach.index, $value.replaceAll('(^[''"])|([''"]$)', '')))
   #end

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
@@ -319,8 +319,8 @@ Object.extend(XWiki, {
   },
 
   /**
-   * Add click listeners on all rendereing error messages to let the user read the detailed error description.
-   * If a content is passed, add click listener for errors reported in this content (usefull for AJAX requests response)
+   * Add click listeners on all rendering error messages to let the user read the detailed error description.
+   * If a content is passed, add click listener for errors reported in this content (useful for AJAX requests response)
    * Otherwise make all the document's body errors expandable.
    */
   makeRenderingErrorsExpandable: function(content) {
@@ -528,7 +528,7 @@ Object.extend(XWiki, {
    * Then it fires an custom event to signify the (modified) DOM is now loaded.
    */
   initialize: function() {
-    // Extra security to make sure we do not get initalized twice.
+    // Extra security to make sure we do not get initialized twice.
     // It would fire the custom xwiki:dom:loaded event twice, which could make their observers misbehave.
     if (typeof this.isInitialized == "undefined" || this.isInitialized == false) {
       // This variable is set when the marker script is executed, which should always be the last script to execute.
@@ -984,7 +984,7 @@ window.shortcut = new Object({
      *
      * @param callback the callback used for the shortcut
      * @param shortcut_type the shortcut type
-     * @retun {*} The new callback to be used for defining the shortcut against Keypress JS libray
+     * @return {*} The new callback to be used for defining the shortcut against Keypress JS library
      * @private
      */
     _wrap_shortcut_call: function(callback, shortcut_type) {
@@ -1648,7 +1648,7 @@ document.observe("xwiki:dom:loaded", function() {
    * The clone will be stored in the __fm_ghost property of the element and is inserted
    * after the element in the DOM. The clone is not visible initially.
    *
-   * @param element the element whose position and dimesions should be cloned
+   * @param element the element whose position and dimensions should be cloned
    */
   function createGhost(element) {
     if (typeof(element.__fm_ghost) == 'undefined') {
@@ -1708,7 +1708,7 @@ document.observe("xwiki:dom:loaded", function() {
 
   /**
    * Injects the given HTML into the page head after removing the stylesheets and JavaScript files that are already
-   * present in the page head (othewise they may be loaded again).
+   * present in the page head (otherwise they may be loaded again).
    *
    * @param {String} html the HTML to extend the page head with
    */

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/extension.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/extension.css
@@ -448,7 +448,7 @@ ul.document-tree {
   margin: 0;
 }
 .document-tree ul {
-  /* Reduce the default identation. */
+  /* Reduce the default indentation. */
   margin-left: 1.3em;
   padding: 0;
 }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/hierarchy/hierarchy.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/hierarchy/hierarchy.js
@@ -37,13 +37,13 @@ require(['jquery', 'xwiki-events-bridge'], function($) {
   $(function() {
 
     /**
-     * Function that expand a breadcumb on some events.
+     * Function that expand a breadcrumb on some events.
      */
     var expandBreadCrumb = function(event) {
       event.preventDefault();
       var ellipsis = $(this).parent('li');
       ellipsis.addClass('loading');
-      // Get the full breadcumb with an AJAX call
+      // Get the full breadcrumb with an AJAX call
       var breadcrumb = $(this).parents('.breadcrumb-expandable');
       var breadcrumbURL = new XWiki.Document(XWiki.Model.resolve(breadcrumb.data('entity'), XWiki.EntityType.DOCUMENT))
         .getURL('get', 'xpage=hierarchy_reference');

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
@@ -100,7 +100,7 @@ var XWiki = (function(XWiki){
     // Default is null, which falls back on the input itself. This option is used only when unifiedLoader is true.
     loaderNode: null,
     // A list of key codes for which to propagate the keyboard event.
-    // Useful when another keyboard event listener exists on the input field, even if it may be registered at a diferent level.
+    // Useful when another keyboard event listener exists on the input field, even if it may be registered at a different level.
     // By default, the handled key events do not propagate, the rest do. See #onKeyDown
     propagateEventKeyCodes : []
   },
@@ -158,7 +158,7 @@ var XWiki = (function(XWiki){
 
     // Initialize a request number that will keep track of the latest request being fired.
     // This will help to discard potential non-last requests callbacks ; this in order to have better performance
-    // (less unneccessary DOM manipulation, and less unneccessary highlighting computation).
+    // (less unnecessary DOM manipulation, and less unnecessary highlighting computation).
     this.latestRequest = 0;
 
   },
@@ -502,7 +502,7 @@ var XWiki = (function(XWiki){
       var pos = $(this.options.parentContainer).tagName.toLowerCase() == 'body' ? this.fld.cumulativeOffset() : this.fld.positionedOffset();
 
       // Container width is passed as an option, or field width if no width provided.
-      // The 2px substracted correspond to one pixel of border on each side of the field,
+      // The 2px subtracted correspond to one pixel of border on each side of the field,
       // this allows to have the suggestion box borders well aligned with the field borders.
       // FIXME this should be computed instead, since border might not always be 1px.
       var fieldWidth = this.fld.offsetWidth - 2;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggestAttachments.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggestAttachments.js
@@ -414,7 +414,7 @@ define('xwiki-suggestAttachments', [
     var attachments = convertFilesToAttachments(files, selectize.settings);
     attachments = attachmentsFilter.filter(attachments, selectize.settings.accept);
     if (selectize.settings.maxItems === 1) {
-      // Upload only a single file if single selecion is on.
+      // Upload only a single file if single selection is on.
       attachments = attachments.slice(0, 1);
     }
     attachments = processAttachments(selectize.settings, {attachments: attachments});

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
@@ -246,7 +246,7 @@ define('xwiki-selectize', [
   // This started as a hack needed in order to be able to access internal selectize fields that are prefixed with $ when
   // the JavaScript is minified, because this code is parsed with Velocity. Otherwise, if we access these fields directly
   // by their name (e.g. selectize.$control) then we might get a Velocity syntax error on the minified JavaScript file.
-  // We keept this after replacing selectize.js with Tom Select in order to keep backwards compatibility.
+  // We kept this after replacing selectize.js with Tom Select in order to keep backwards compatibility.
   TomSelect.prototype.get$ = function(key) {
     return $(this[key]);
   };

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/tools/formAsyncValidation.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/tools/formAsyncValidation.js
@@ -18,7 +18,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 define('xwiki-form-validation-async', ['jquery'], function($) {
-  // Enable or disable the first submit button from the specifid HTML form.
+  // Enable or disable the first submit button from the specified HTML form.
   const enableSubmit = (form, enabled) => {
     form.find('input[type="submit"], button[type="submit"]').first().prop('disabled', !enabled);
   };

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/tools/pageReady.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/tools/pageReady.js
@@ -95,7 +95,7 @@
     };
 
     // Scripts are loaded only once and thus the load event is triggered only the first time a script is loaded, which is
-    // why we need to keep track of the URLs that are successfuly loaded.
+    // why we need to keep track of the URLs that are successfully loaded.
     const loadedURLs = new Set();
 
     /**

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/comments.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/comments.js
@@ -319,7 +319,7 @@ viewers.Comments = Class.create({
           formData.set('xpage', 'xpart');
           formData.set('vm', 'commentsinline.vm');
           formData.set('skin', XWiki.skin);
-          // Strip form parameters from the form action query string to prevent them from being overwriten.
+          // Strip form parameters from the form action query string to prevent them from being overwritten.
           var queryStringParams = $H(form.action.toQueryParams());
           formData.keys().each(queryStringParams.unset.bind(queryStringParams));
           var url = form.action.replace(/\?.*/, '?' + queryStringParams.toQueryString());
@@ -700,7 +700,7 @@ require(['jquery', 'xwiki-events-bridge'], function($) {
     var notification;
     /**
      * Ajax request made for deleting the comment.
-     * Delete the HTML element on succes (replace it with a box message).
+     * Delete the HTML element on success (replace it with a box message).
      * Display error message on failure.
      * Disable the delete button before the request is send, so the user cannot resend it in case it takes longer.
      */

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/diff.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/diff.js
@@ -200,5 +200,5 @@ define('xwiki-diff', ['jquery', 'xwiki-events-bridge'], function($) {
 });
 
 // Execute the code when this file is loaded with $xwiki.jsfx.use(). This is not needed if the file is loaded with
-// RequireJS but it shoudn't hurt either. We do this in order to ensure that the module code is executed only once.
+// RequireJS but it shouldn't hurt either. We do this in order to ensure that the module code is executed only once.
 require(['xwiki-diff'], function() {});

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.js
@@ -311,7 +311,7 @@ require(['jquery', 'xwiki-meta', 'xwiki-events-bridge', 'xwiki-form-validation-a
 
     // Synchronize the location fields while the user types.
     // We catch the change event because we want to make sure everything's updated when the user change fields
-    // (particulary useful in our automated tests).
+    // (particularly useful in our automated tests).
     titleInput.on('input change', scheduleUpdateOfLocationAndNameFromTitleInput);
     wikiField.on('change', updateLocationFromWikiField);
     nameInput.on('input change', updateLocationFromNameInput);
@@ -534,7 +534,7 @@ require(['jquery'], function($) {
 
       var allowedSpaces = [];
       var allowedSpacesData = input.attr('data-allowed-spaces');
-      // Read the alowed spaces specified by the template provider, unless they are just suggestions in which case they
+      // Read the allowed spaces specified by the template provider, unless they are just suggestions in which case they
       // should be ignored by validation.
       if (!restrictionsAreSuggestions && allowedSpacesData) {
         allowedSpaces = JSON.parse(input.attr('data-allowed-spaces'));


### PR DESCRIPTION
Batch 15 of the spelling sweep, and the first one to read the **front-end sources**: the
hand-written JavaScript and CSS, plus the `.xml` files that are not XAR wiki pages
(`web.xml`, `logback.xml`). It takes the two largest modules of that sweep, `xwiki-platform-web`
(41) and `xwiki-platform-ckeditor` (14) — 55 word fixes over 31 files.

**Every site is a comment.** Not one string literal is touched, so nothing a test asserts on and
nothing a user reads changes.

### Why this bucket was deferred until now

The earlier estimate said ~338 hits in `.js` alone, which is why it kept being put off as needing a
"source vs vendored split" first. That number was inflated about threefold by **generated bundles**:
every built artifact in the tree sits in a `dist/` directory that `.gitignore` already excludes, so
listing files with `git ls-files` instead of walking the filesystem drops 90 `.js` and 233 `.ts`
files of build output with no heuristic at all. The real figure for the whole front end is 112 word
fixes; this PR is 55 of them and the remaining 57 (mostly the `node/` Vue/TypeScript packages) are
the next batch.

### Not fixed, on purpose

- **`collapsable` → `collapsible` (6 sites)** — a CSS class: `.xclass.collapsable`,
  `toggle-collapsable`, `addClass('collapsable')`, matched from `dataeditors.css`, `dataeditors.js`
  and the Flamingo `editclass.vm` / `editobject.vm`. Renaming a class across four files in two
  modules is a refactoring, not a spelling fix, and the comments describing the class have to keep
  its spelling to stay greppable.
- **`indx`** in `livetable.js` — it is the `@param` name of `deleteRow: function(indx)`, so
  correcting the doc alone would desynchronise it from the code.
- **`Nott`** in `xwiki.js` — a surname: "Author: Chris Nott", crediting the vendored Browser Detect
  snippet.
- **`livevalidation_prototype.js`** (LiveValidation 1.4, © Alec Hill, MIT) and
  **`panelwizard/ieemu.js`** (WebFX, © Erik Arvidsson) — third-party files, where a correction is a
  conflict on the next upstream sync. `panelwizard/toolTip.js` next door *is* ours, so its
  `accomodate` is fixed.

### Two extra fixes, on lines the sweep was already rewriting

- `@retun {*}` → `@return` in `xwiki.js`, on the same line as `libray` → `library`. A misspelled tag
  is invisible to JSDoc tooling.
- `the HTML image elements an the image file objects` → `and`, in `xwiki-upload/plugin.js`, on the
  `Unfortunatelly` line.

### Verification

`mvn -B -ntp verify` from `xwiki-platform-web-war` and from `xwiki-platform-ckeditor-plugins`, both
green. `verify` matters here: `ckeditor-plugins` binds `jshint-maven-plugin`, which caught two
comments in `ckeditorRealtimeAdapter.js` where the longer correct spelling pushed a line that was
sitting at exactly 120 characters over the limit. Both were rewrapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)