### PR TITLE
[Misc] Fix misspellings in the remaining front-end sources, poms and XML configuration

### DIFF
--- a/xwiki-platform-core/xwiki-platform-blocknote/xwiki-platform-blocknote-webjar/src/main/node/src/services/macros/MacroWizard.ts
+++ b/xwiki-platform-core/xwiki-platform-blocknote/xwiki-platform-blocknote-webjar/src/main/node/src/services/macros/MacroWizard.ts
@@ -107,7 +107,7 @@ type MacroWizardOptions = {
  */
 interface MacroWizard {
   /**
-   * Inserts a new macro call or updates an existing one based on the provided options. If the given macro call doen't
+   * Inserts a new macro call or updates an existing one based on the provided options. If the given macro call doesn't
    * specify the macro name the user will be asked to select a macro first. Even if the macro name is specified, the
    * user can still change the macro. This means the output macro call can have a different macro name than the input
    * one.

--- a/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-test/xwiki-platform-export-pdf-test-content/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-test/xwiki-platform-export-pdf-test-content/pom.xml
@@ -56,7 +56,7 @@
       <type>xar</type>
     </dependency>
     <dependency>
-      <!-- Used to test how floating images (with left / right aligment) are exported to PDF. -->
+      <!-- Used to test how floating images (with left / right alignment) are exported to PDF. -->
       <groupId>${project.groupId}</groupId>
       <artifactId>xwiki-platform-image-style-ui</artifactId>
       <version>${project.version}</version>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-designsystem-webjar/src/main/node/src/vue/style.css
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-designsystem-webjar/src/main/node/src/vue/style.css
@@ -1,5 +1,5 @@
 :root {
-    --cr-sizes-max-page-width: calc(var(--max-screen-size) * 1px); /*This value controls the width of the main content. It should be 100% for spanning text along the whole width or an arbitraty value*/
+    --cr-sizes-max-page-width: calc(var(--max-screen-size) * 1px); /*This value controls the width of the main content. It should be 100% for spanning text along the whole width or an arbitrary value*/
     --cr-sizes-main-sidebar-width: var(--panel-column-left-width); /*The default width of the main sidebar*/
     --cr-sizes-main-sidebar-min-width: 0; /*The minimum width of the main sidebar*/
     --cr-base-font-size: var(--font-size-base);

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/edit.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/edit.less
@@ -91,10 +91,10 @@
  */
 @document-title-input-padding-vertical: @line-height-computed / 4 - 1;
 #document-title h1.editable {
-  /* Move the title heading a bit to the top and to the left in order to accomodate the input border and padding. */
+  /* Move the title heading a bit to the top and to the left in order to accommodate the input border and padding. */
   margin-top: -@line-height-computed / 4;
   margin-left: -(ceil(@grid-gutter-width / 2));
-  /* Reduce the bottom margin in order to accomodate the input border and bottom padding. */
+  /* Reduce the bottom margin in order to accommodate the input border and bottom padding. */
   margin-bottom: @line-height-computed / 4;
 
   & > input[name="title"] {

--- a/xwiki-platform-core/xwiki-platform-logging/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-logging/pom.xml
@@ -28,9 +28,9 @@
     <version>18.7.0-SNAPSHOT</version>
   </parent>
   <artifactId>xwiki-platform-logging</artifactId>
-  <name>XWiki Platform - Loggging</name>
+  <name>XWiki Platform - Logging</name>
   <packaging>pom</packaging>
-  <description>XWiki Platform - Loggging</description>
+  <description>XWiki Platform - Logging</description>
   <modules>
     <module>xwiki-platform-logging-script</module>
     <module>xwiki-platform-logging-ui</module>

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/attachments/attachments-default/src/__tests__/defaultAttachmentsService.test.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/attachments/attachments-default/src/__tests__/defaultAttachmentsService.test.ts
@@ -52,7 +52,7 @@ describe("defaultAttachmentsService", () => {
     await service.upload(pageReference, []);
     expect(service.isLoading().value).eq(false);
 
-    // Check individiually each method before checking if they are called in the
+    // Check individually each method before checking if they are called in the
     // right order, to make it easier to debug in case of failure.
     expect(storageMock.saveAttachments).toHaveBeenCalled();
     expect(storageMock.getAttachments).toHaveBeenCalled();

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/collaboration/collaboration-xwiki/src/xwikiProviderWebSocket.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/collaboration/collaboration-xwiki/src/xwikiProviderWebSocket.ts
@@ -43,7 +43,7 @@ function registerClient(websocketProvider: WebsocketProvider) {
 /**
  * Decode the client id from a message handler of index 4.
  *
- * @param handlerDecoder - the decoder, usually provided by the hander
+ * @param handlerDecoder - the decoder, usually provided by the handler
  */
 function readClientId(handlerDecoder: decoding.Decoder) {
   const decoder = decoding.createDecoder(handlerDecoder.arr);

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/fn-utils/src/index.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/fn-utils/src/index.ts
@@ -115,7 +115,7 @@ function tryFallibleOrError<T>(func: () => T): T | Error {
 }
 
 /**
- * Get a funcion's promise's output or the thrown error
+ * Get a function's promise's output or the thrown error
  * Will construct a new Error object if the thrown value is not an instance of the Error class
  *
  * @since 18.0.0RC1

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/link-modal/link-modal-ui/src/data/linkType.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/link-modal/link-modal-ui/src/data/linkType.ts
@@ -40,7 +40,7 @@ type LinkData = {
  * @since 18.4.0RC-1
  * @beta
  */
-// TODO: allow arbitraty link targets using extensions - https://jira.xwiki.org/browse/XWIKI-23927
+// TODO: allow arbitrary link targets using extensions - https://jira.xwiki.org/browse/XWIKI-23927
 type LinkTarget =
   | { type: "page"; config: LinkPageConfig }
   | { type: "attachment"; config: LinkAttachmentConfig }

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/link-modal/link-modal-ui/src/vue/SearchBox.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/link-modal/link-modal-ui/src/vue/SearchBox.vue
@@ -95,7 +95,7 @@ const { t } = useI18n({ messages: translations });
 
 const query = ref(initialValue ?? "");
 
-// When programatically updating `query` (e.g. after the user selected a suggestion),
+// When programmatically updating `query` (e.g. after the user selected a suggestion),
 // this trigger prevents the query watcher from performing a new search (which would be pointless)
 const justDynamicallyUpdatedQuery = ref(false);
 

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-api/src/logic.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-api/src/logic.ts
@@ -24,7 +24,7 @@ import type { Reactive, Ref } from "vue";
 
 /**
  * Present the public API of the logic used inside the Live Data UI.
- * It provides the operations and data to display Live Datas. It is build to be shared by most of the UI elements of
+ * It provides the operations and data to display Live Data. It is build to be shared by most of the UI elements of
  * a Live Data.
  * @since 18.2.0RC1
  * @beta
@@ -48,7 +48,7 @@ export interface Logic {
   /**
    * Listen for an event.
    * @param event - the event to listen to
-   * @param callback - a callback, taking the received event in paramter
+   * @param callback - a callback, taking the received event in parameter
    */
   onEvent(event: string, callback: (e: Event) => void): void;
 

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-api/src/queryConstraint.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-api/src/queryConstraint.ts
@@ -28,7 +28,7 @@ export interface QueryConstraint {
    */
   operator: string;
   /**
-   * An arbitrary value to apply on the operator (e.g., a string to use for the equals comparion).
+   * An arbitrary value to apply on the operator (e.g., a string to use for the equals comparison).
    */
   value: unknown;
 }

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataPersistentConfiguration.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataPersistentConfiguration.vue
@@ -179,7 +179,7 @@ export default {
     // More detail about u-node can be found at:
     // https://github.com/ananthakumaran/u
     // The keys of the properties are the computed property names defined above,
-    // so that we can retreive the computed property and use it to get and set
+    // so that we can retrieve the computed property and use it to get and set
     // the values during encoding and decoding
     encodingSpecsV1() {
       return {
@@ -214,8 +214,8 @@ export default {
 
     // The coders that are going to be used for encoding the config
     // It is an array so that we can specify several encoding specs.
-    // Using several encoding specs can be usefull to keep backward
-    // compability between two different versions of encodings.
+    // Using several encoding specs can be useful to keep backward
+    // compatibility between two different versions of encodings.
     coders() {
       return [
         // the first parameter is the encoding version
@@ -248,7 +248,7 @@ export default {
 
   watch: {
     // Watch for any changes from the data we want to save
-    // We are watching for the encoded config chagnes, because
+    // We are watching for the encoded config changes, because
     // it means that the data to save has changed too
     // On changes, either save or delete config
     encodedConfig() {
@@ -268,7 +268,7 @@ export default {
     //   much less space
     // - Second: compresse the encoded config using lz-string. The resulted
     //   string might be a bit longer, but any plain text is now hashed
-    // On error, return emty string, that will delete existing config.
+    // On error, return empty string, that will delete existing config.
     encodeConfig(config) {
       try {
         const encoded = encode(this.coders[this.coders.length - 1], config);

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/displayers/BaseDisplayer.test.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/displayers/BaseDisplayer.test.js
@@ -45,7 +45,7 @@ describe("BaseDisplayer.vue", () => {
       },
     });
 
-    // Manuelly triggers setEdit until we find a way to simulate the hovering of the displayer and
+    // Manually triggers setEdit until we find a way to simulate the hovering of the displayer and
     // get access the popover content.
     wrapper.vm.setEdit();
 

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/filters/LivedataFilter.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/filters/LivedataFilter.vue
@@ -110,7 +110,7 @@ export default {
     },
 
     // Load the filter component corresponding to the given filterId
-    // On success, set `this.filterComponent` to the retreived component,
+    // On success, set `this.filterComponent` to the retrieved component,
     // which automatically insert the component in the html
     async loadFilter(filterId) {
       const component = await componentStore.load(

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/filters/filterMixin.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/filters/filterMixin.js
@@ -76,7 +76,7 @@ export default {
      * @param newValue - the new filtering value
      * @param filterOperator - the operator to apply, when undefined the default operator is used
      * @param skipFetch - when true, the filter will be applied on the reactive variables, but will not trigger an
-     * fetch. When undefined, the default value is false. This paramter is important in the case of asynchronous
+     * fetch. When undefined, the default value is false. This parameter is important in the case of asynchronous
      * methods where we need to have an instance feedback on the UI (e.g., between the advanced filtering panel and
      * the top filters in the table layout)
      */
@@ -157,7 +157,7 @@ export default {
           if (!rule.to.includes(newOperator)) {
             return;
           }
-          // Rule matches the `from` and `to` operator criterias
+          // Rule matches the `from` and `to` operator criteria
           const newValue = rule.getValue({
             oldValue: this.filterEntry.value,
             oldOperator,
@@ -181,7 +181,7 @@ export default {
         if (e.detail.oldEntry.operator === e.detail.newEntry.operator) {
           return;
         }
-        // We don't want the other filter widget to call the hanlder the same value
+        // We don't want the other filter widget to call the handler the same value
         e.stopImmediatePropagation();
         this._operatorChangeHandler(
           e.detail.oldEntry.operator,

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/LivedataLayout.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/LivedataLayout.vue
@@ -141,7 +141,7 @@ export default {
     },
 
     // Load the layout component corresponding to the given layoutId
-    // On success, set `this.layoutComponent` to the retreived component,
+    // On success, set `this.layoutComponent` to the retrieved component,
     // which automatically insert the component in the html
     async loadLayout(layoutId) {
       const component = await componentStore.load("layout", layoutId);

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/table/LayoutTableRow.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/table/LayoutTableRow.vue
@@ -147,7 +147,7 @@ export default {
 }
 
 .layout-table tbody tr:first-child td.cell {
-  /* Removes the top border on the first line of the table, it's unecessary since the header itself has a background color */
+  /* Removes the top border on the first line of the table, it's unnecessary since the header itself has a background color */
   border-top: 0;
 }
 </style>

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/panels/LivedataAdvancedPanelFilter.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/panels/LivedataAdvancedPanelFilter.vue
@@ -211,11 +211,11 @@ export default {
       this.$refs.selectFilterPropertiesNone.selected = true;
     },
     // Event handler called when filter entries are dragged and dropped
-    // When a property is simply reodered, it dispatches only one "move" event
+    // When a property is simply reordered, it dispatches only one "move" event
     // When a property is move between two different properties
     // it dispatches two event:
     // - a "remove" event for the property that had the moved property
-    // - a "added" evnet for the property that receive the moved property
+    // - a "added" event for the property that receive the moved property
     reorderFilter(e, filterGroup) {
       // Filter entry reordered in the same property
       if (e.moved) {

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/services/jsonMerge.test.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/services/jsonMerge.test.js
@@ -39,7 +39,7 @@ describe("jsonMerge.js", () => {
     expect(merge({ a: 1 }, {})).toEqual({ a: 1 });
   });
 
-  it("merge objects with simmilar ids", () => {
+  it("merge objects with similar ids", () => {
     expect(merge({ id: 1, a: 1 }, { id: 1, a: 2 })).toEqual({ id: 1, a: 2 });
   });
 

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/utilities/XWikiLoader.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/utilities/XWikiLoader.vue
@@ -21,8 +21,8 @@
 <template>
   <!--
   v-show is used here instead of v-if to prevent the loader to be re-rendered each time the show data field changes.
-  This change can happen two times in a short time span, once when the component is first rendered, then when the timout
-  is switched to true (by default 200ms after the component is mounted).
+  This change can happen two times in a short time span, once when the component is first rendered, then when the
+  timeout is switched to true (by default 200ms after the component is mounted).
   -->
   <div class="xwiki-loader" v-show="show"></div>
 </template>

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-xwiki/src/liveDataSource.test.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-xwiki/src/liveDataSource.test.ts
@@ -25,7 +25,7 @@ import { stub } from "sinon";
 import { describe, expect, it, vi } from "vitest";
 
 const getJSONStub = stub($, "getJSON");
-// @ts-expect-error leftover from inintial javascript implementation
+// @ts-expect-error leftover from initial javascript implementation
 getJSONStub.returns(Promise.resolve({ count: 0, entries: [] }));
 
 global.XWiki = { contextPath: "http://localhost/" };

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/macros/macros-api/src/index.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/macros/macros-api/src/index.ts
@@ -74,7 +74,7 @@ interface MacroInfos<Parameters extends Record<string, MacroParameterType>> {
  * @beta
  */
 interface BlockMacro<Parameters extends Record<string, MacroParameterType>> {
-  /** Macro informations */
+  /** Macro information */
   infos: MacroInfos<Parameters>;
 
   /** Indicator that the macro renders as a block */
@@ -101,7 +101,7 @@ interface BlockMacro<Parameters extends Record<string, MacroParameterType>> {
  * @beta
  */
 interface InlineMacro<Parameters extends Record<string, MacroParameterType>> {
-  /** Macro informations */
+  /** Macro information */
   infos: MacroInfos<Parameters>;
 
   /** Indicator that the macro renders as an inline content */

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/macros/macros-ast-react-jsx/src/converter.tsx
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/macros/macros-ast-react-jsx/src/converter.tsx
@@ -64,7 +64,7 @@ export class MacrosAstToReactJsxConverter {
    * Render a macro's AST blocks to JSX elements
    *
    * Will force re-render every time, even if the AST is exactly the same
-   * (see the private `generateId` function for more informations)
+   * (see the private `generateId` function for more information)
    *
    * @param blocks - The blocks to render
    * @param editableZoneRef - The macro's editable zone reference
@@ -84,7 +84,7 @@ export class MacrosAstToReactJsxConverter {
    * Render a macro's AST inline contents to JSX elements
    *
    * Will force re-render every time, even if the AST is exactly the same
-   * (see the private `generateId` function for more informations)
+   * (see the private `generateId` function for more information)
    *
    * @param inlineContents - The inline contents to render
    * @param editableZoneRef - The macro's editable zone reference

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/__tests__/playwright-ct/BlockNote.spec.tsx
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/__tests__/playwright-ct/BlockNote.spec.tsx
@@ -62,7 +62,7 @@ test("BlockNote's content can be modified", async ({ mount }) => {
 });
 
 // eslint-disable-next-line max-statements
-test("Image insertion UI can be overriden", async ({ mount, page }) => {
+test("Image insertion UI can be overridden", async ({ mount, page }) => {
   let overrideFnCalledWithUrl: string | null = null;
 
   const component = await mount(

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/components/files/FilePanel.tsx
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/components/files/FilePanel.tsx
@@ -38,5 +38,5 @@ export const FilePanel: React.FC<FilePanelProps> = ({ blockId, editor }) => {
     return <ImageFilePanel currentBlock={block} />;
   }
 
-  throw new Error(`Assertion failed: unkown block type: ${block.type}`);
+  throw new Error(`Assertion failed: unknown block type: ${block.type}`);
 };

--- a/xwiki-platform-core/xwiki-platform-oldcore/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-oldcore/pom.xml
@@ -136,7 +136,7 @@
     </dependency>
 
     <!-- Used by parse groovy from page -->
-    <!-- Note: We only depend on the miniumum required to compile oldcore since the distributions will depend on
+    <!-- Note: We only depend on the minimum required to compile oldcore since the distributions will depend on
          xwiki-commons-groovy which has dependencies on all the various groovy jars and thus they'll be bundled -->
     <dependency>
       <groupId>org.apache.groovy</groupId>

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/xwiki.oracle.hbm.xml
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/xwiki.oracle.hbm.xml
@@ -95,7 +95,7 @@
             <column name="XWS_ID" not-null="true" />
             <generator class="assigned" />
         </id>
-        <!-- Note: We don't create an index explicity for this column since Hibernate/Oracle will create one by default
+        <!-- Note: We don't create an index explicitly for this column since Hibernate/Oracle will create one by default
              since we have a unique constraint -->
         <property name="reference" type="string" column="XWS_REFERENCE" length="768" not-null="true" />
         <property name="name" type="string" column="XWS_NAME" length="768" index="SPACE_NAME" not-null="true" />

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-webjar/src/main/webjar/saver.js
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-webjar/src/main/webjar/saver.js
@@ -440,7 +440,7 @@ define('xwiki-realtime-saver', [
       const newAjaxSaveAndContinue = {
         // Prevent the save buttons from reloading the page. Instead, reset the editor's content.
         // FIXME: The in-place editor is also overriding reloadEditor, before this code is executed, so here we're
-        // actually overwritting in-place editor's behavior.
+        // actually overwriting in-place editor's behavior.
         reloadEditor: () => {
           xwikiDocument.reload();
           // HACK: Replicate the behavior from the in-place editor.

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-webjar/src/main/webjar/toolbar.js
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-webjar/src/main/webjar/toolbar.js
@@ -72,10 +72,10 @@ define('xwiki-realtime-toolbar', [
         event.preventDefault();
         // FIXME: We can't rely on the save status to determine whether to save or cancel (e.g. to prevent creating a
         // new version when there are no changes and the document is not new) because:
-        // * the save status takes into account only the fiels that are synchronized in realtime
-        // * not all form fiels are synchronized
-        // The document title is currenly not synchronized, so when someone changes the title the others don't know that
-        // the document is dirty and thus has to be saved.
+        // * the save status takes into account only the fields that are synchronized in realtime
+        // * not all form fields are synchronized
+        // The document title is currently not synchronized, so when someone changes the title the others don't know
+        // that the document is dirty and thus has to be saved.
         // We should catch changes on all non-hidden form fields (that the user can change) and synchronize them. Once
         // we do this we can use the following code:
         //

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wysiwyg/xwiki-platform-realtime-wysiwyg-webjar/src/main/webjar/wysiwygEditor.js
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wysiwyg/xwiki-platform-realtime-wysiwyg-webjar/src/main/webjar/wysiwygEditor.js
@@ -297,7 +297,7 @@ define('xwiki-realtime-wysiwyg', [
         this._onLocal();
         // Push commits to the server.
         this._connection.chainpad.sync();
-        // Wait for aknowledgement.
+        // Wait for acknowledgement.
         await new Promise(resolve => this._connection.chainpad.onSettle(resolve));
       }
     }

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-server/xwiki-platform-search-solr-server-core-search/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-server/xwiki-platform-search-solr-server-core-search/pom.xml
@@ -37,7 +37,7 @@
   <dependencies>
     <dependency>
       <!-- This is needed at runtime by solrconfig.xml which is why we package below in the lib/ directory of the
-           generatd JAR which will be used and transformed into a zip file in the xwiki-platform-search-solr-api
+           generated JAR which will be used and transformed into a zip file in the xwiki-platform-search-solr-api
            module. -->
       <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-search-solr-server-plugin</artifactId>

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-server/xwiki-platform-search-solr-server-core-search/src/main/resources/conf/managed-schema.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-server/xwiki-platform-search-solr-server-core-search/src/main/resources/conf/managed-schema.xml
@@ -99,7 +99,7 @@
          It's recommended to use migrations when possible (so only when the required changes can be fully done using SolrJ API):
            * it avoid starting from scratch re-indexing sometimes huge instances
            * it makes the upgrade of Solr standalone setups much easier
-           * it better support customizations of the Solr configuration (i.e. they are not reseted)
+           * it better support customizations of the Solr configuration (i.e. they are not reset)
     -->
     <fieldType name="__cversion" class="solr.TextField"  positionIncrementGap="160600000"/>
     <fieldType name="__cmversion" class="solr.TextField" positionIncrementGap="171009000"/>
@@ -543,7 +543,7 @@
     <!-- A text field with defaults appropriate for English: it tokenizes with StandardTokenizer,
          removes English stop words (lang/stopwords_en.txt), down cases, protects words from protwords.txt, and
          finally applies Porter's stemming.  The query time analyzer also applies synonyms from synonyms.txt. -->
-    <!-- XWiki: XWiki historically uses a diffferent suffix than the standard one -->
+    <!-- XWiki: XWiki historically uses a different suffix than the standard one -->
     <dynamicField name="*_en" type="text_en"  indexed="true"  stored="true" multiValued="true"/>
     <dynamicField name="*_en_GB" type="text_en"  indexed="true"  stored="true" multiValued="true"/>
     <dynamicField name="*_en_US" type="text_en"  indexed="true"  stored="true" multiValued="true"/>

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-webjar/src/main/webjar/searchSuggest.js
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-webjar/src/main/webjar/searchSuggest.js
@@ -133,7 +133,7 @@ var XWiki = (function (XWiki) {
     },
 
     /**
-     * Creates the underlaying suggest widget.
+     * Creates the underlying suggest widget.
      */
     createSuggest: function() {
       // Create dummy suggestion node to hold the "Go to search page..." option.

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/resources/logback.xml
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/resources/logback.xml
@@ -78,7 +78,7 @@
   <!-- Deactivate Struts warnings -->
   <logger name="org.apache.struts.util.RequestUtils" level="error"/>
 
-  <!-- Deactive PDF Export CSS Applier warnings -->
+  <!-- Deactivate PDF Export CSS Applier warnings -->
   <logger name="org.apache.fop.layoutmgr.inline.ContentLayoutManager" level="error"/>
   <logger name="info.informatica.doc.style.css.dom" level="error"/>
 

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/resources/logback-override.xml
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/resources/logback-override.xml
@@ -78,7 +78,7 @@
   <!-- Deactivate Struts warnings -->
   <logger name="org.apache.struts.util.RequestUtils" level="error"/>
 
-  <!-- Deactive PDF Export CSS Applier warnings -->
+  <!-- Deactivate PDF Export CSS Applier warnings -->
   <logger name="org.apache.fop.layoutmgr.inline.ContentLayoutManager" level="error"/>
   <logger name="info.informatica.doc.style.css.dom" level="error"/>
 

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/webapp/WEB-INF/classes/logback.xml
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/webapp/WEB-INF/classes/logback.xml
@@ -81,7 +81,7 @@
   <!-- Deactivate Struts warnings -->
   <logger name="org.apache.struts.util.RequestUtils" level="error"/>
 
-  <!-- Deactive PDF Export CSS Applier warnings -->
+  <!-- Deactivate PDF Export CSS Applier warnings -->
   <logger name="org.apache.fop.layoutmgr.inline.ContentLayoutManager" level="error"/>
   <logger name="info.informatica.doc.style.css.dom" level="error"/>
 

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-webjar/src/main/webjar/image/imageEditor.js
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-webjar/src/main/webjar/image/imageEditor.js
@@ -301,7 +301,7 @@ define('xwiki-wysiwyg-image-editor', [
        * and a ratio of 0.5, the result is 15px.
        * @param field the field type ('width' or 'height')
        * @param inputvalue the input value of the updated field (e.g., 100, or 33px)
-       * @returns {*|jQuery} a Defered, resolved with the computed value
+       * @returns {*|jQuery} a Deferred, resolved with the computed value
        */
       function updateRatio(field, inputvalue) {
         return loadImage(modal).then(function (image) {

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-data/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-data/pom.xml
@@ -166,7 +166,7 @@
               <artifactId>xwiki-platform-legacy-events-hibernate-api</artifactId>
               <version>${project.version}</version>
             </dependency>
-            <!-- Annotation has it own migrator that we need to execute to set the rigth version to the DB. -->
+            <!-- Annotation has it own migrator that we need to execute to set the right version to the DB. -->
             <dependency>
               <groupId>org.xwiki.platform</groupId>
               <artifactId>xwiki-platform-annotation-io</artifactId>

--- a/xwiki-platform-tools/xwiki-platform-tool-xmldoc-update-plugin/pom.xml
+++ b/xwiki-platform-tools/xwiki-platform-tool-xmldoc-update-plugin/pom.xml
@@ -30,7 +30,7 @@
   <artifactId>xwiki-platform-tool-xmldoc-update-plugin</artifactId>
   <name>XWiki Platform - Tools - XML Doc Update Plugin</name>
   <packaging>maven-plugin</packaging>
-  <description>A Maven plugin to load XWiki documents from XML and perform file attachment or setting object properties, before writting the document back to XML </description>
+  <description>A Maven plugin to load XWiki documents from XML and perform file attachment or setting object properties, before writing the document back to XML </description>
   <properties>
     <xwiki.jacoco.instructionRatio>0.74</xwiki.jacoco.instructionRatio>
   </properties>


### PR DESCRIPTION
Closes the source spelling sweep that #6079 started: the **53 remaining sites**, over 40 files and 13 top-level modules. `python3 docs/spellscan.py scan-src` now returns zero, as `scan` and `scan-wiki` already did after #6075 and #6077.

| Module | Sites |
|---|---:|
| `node` (the Vue/TypeScript packages) | 31 |
| `search` | 4 |
| `flamingo`, `realtime` | 3 each |
| `logging`, `oldcore`, `wiki` | 2 each |
| `blocknote`, `export`, `test`, `wysiwyg`, `distribution-flavor`, `tool-xmldoc-update-plugin` | 1 each |

**All but three sites are comments.** The three string literals are two test titles (`"merge objects with similar ids"`, `"Image insertion UI can be overridden"`) and one assertion-failure message (`"unknown block type"`); a repo-wide grep confirms nothing asserts on any of them. Two of the corrections are user-visible rather than developer-only: `xwiki-platform-logging`'s `<name>` and `<description>` read *"XWiki Platform - Loggging"*, which is what the build log and Nexus show.

### Deliberately left alone

- **The What's New `blogrss.xml` fixtures (3 hits).** They are recorded captures of the real xwiki.org blog feed, so the `improvments` sits inside the captured `<description>` of an actual blog post — third-party data reproduced verbatim, not prose of ours. Respelling it would make the fixture a forgery of the feed it stands in for.
- **`SortableTextField generaly functions exactly like TextField` in `managed-schema.xml`.** That file is Solr's stock schema with XWiki comments grafted onto it, so it is ours word by word rather than file by file: this sentence is Solr's and belongs to whoever we next sync the schema from, while the two comments prefixed `XWiki:` in the same file are ours and are fixed.

### Three fixes the dictionary could not make

Each is the `Dependencied` lesson again — a single-suggestion mapping is still only a suggestion:

- **`doen't` → `doesn't`** in `MacroWizard.ts`. codespell maps `doen` to `done`, which would have produced `done't`.
- **`form fiels` → `form fields`** (×2) in `toolbar.js`, on the two lines above a comment the sweep was already rewrapping. codespell drops `fiels` as ambiguous (fields / files / feels); the sentence settles it.

Two comment lines that a correction pushed from exactly 120 to 121 characters were rewrapped by hand (`XWikiLoader.vue`, `toolbar.js`). Lines that were *already* over the limit before the correction were left as they were, as in #6079.

### Verification

- `nx run-many -t lint` green for the 10 affected `node` projects (31 of the 53 sites).
- `mvn -B -ntp verify` green from `xwiki-platform-search-solr-server-core-search` (the module that packages the Solr schema) and from `xwiki-platform-tool-xmldoc-update-plugin`.
- Every changed `.xml` re-parsed to confirm well-formedness.
- The remaining files are `.less` / `.css` / webjar `.js` comments in modules that bind no JSHint (unlike `ckeditor-plugins` in #6079), so nothing in them is build-measured.

Note that `pnpm run build` currently fails in this checkout for a reason unrelated to this branch — the `tools/tool-*config` packages declare no `build` target, so `vite.config.ts` loads `tool-viteconfig/src/index.ts` unbuilt and Node rejects the `.ts` extension. It fails identically for projects this branch does not touch (`platform-model-api`, `platform-icons`, …), which is why the node verification above is the lint target rather than `mvn verify`.
