### PR TITLE
[Misc] Keep the eager String for log arguments that must not be serialized

### DIFF
--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/main/java/org/xwiki/attachment/internal/listener/MovedAttachmentListener.java
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/main/java/org/xwiki/attachment/internal/listener/MovedAttachmentListener.java
@@ -107,8 +107,11 @@ public class MovedAttachmentListener implements EventListener
             try {
                 updateBackLinks(attachmentMovedEvent, canEdit);
             } catch (RefactoringException e) {
+                // Build the String on purpose: log arguments are kept as objects in the captured LogEvent and
+                // XStream-serialized into the job log (see SafeMessageConverter in xwiki-commons). A Request is
+                // Serializable, so the move job would end up with a copy of its own request in its own log.
                 this.logger.error("Failed to update backlinks targeting attachment [{}] for request [{}]",
-                    attachmentMovedEvent.getSourceReference(), moveAttachmentRequest, e);
+                    attachmentMovedEvent.getSourceReference(), moveAttachmentRequest.toString(), e);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/DefaultWikiComponentInvocationHandler.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/DefaultWikiComponentInvocationHandler.java
@@ -123,8 +123,12 @@ public class DefaultWikiComponentInvocationHandler implements InvocationHandler
                     componentDependency = componentManager.getInstance(cd.getRoleType(), cd.getRoleHint());
                 }
             } catch (ComponentLookupException e) {
+                // Pass the role type name rather than the Type: log arguments are kept as objects in the captured
+                // LogEvent and XStream-serialized into the job log (see SafeMessageConverter in xwiki-commons), and
+                // a Type is backed by a Class that cannot always be resolved when that log is read back. The
+                // document reference stays an object on purpose, since the log displayers render it as a link.
                 LOGGER.warn("No component found for role [{}] with hint [{}], declared as dependency for wiki "
-                    + "component [{}]. Root cause is [{}]", cd.getRoleType(), cd.getRoleHint(),
+                    + "component [{}]. Root cause is [{}]", cd.getRoleType().getTypeName(), cd.getRoleHint(),
                     this.wikiComponent.getDocumentReference(), ExceptionUtils.getRootCauseMessage(e));
             }
             methodContext.put(dependency.getKey(), componentDependency);

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/main/java/org/xwiki/mail/internal/DatabaseMailStatusStore.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/main/java/org/xwiki/mail/internal/DatabaseMailStatusStore.java
@@ -311,7 +311,11 @@ public class DatabaseMailStatusStore implements MailStatusStore
                     builder.append(',').append((' '));
                 }
             }
-            this.logger.debug("Find mail statuses for query [{}] and parameters [{}]", queryString, builder);
+            // Build the String on purpose: log arguments are kept as objects in the captured LogEvent and
+            // XStream-serialized into the job log (see SafeMessageConverter in xwiki-commons), and a StringBuilder
+            // would be written out as its internal char array.
+            this.logger.debug("Find mail statuses for query [{}] and parameters [{}]", queryString,
+                builder.toString());
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSenderPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSenderPlugin.java
@@ -636,6 +636,7 @@ public class MailSenderPlugin extends XWikiDefaultPlugin
      * @param emails Mail Collection
      * @return True in any case (TODO ?)
      */
+    @SuppressWarnings("java:S2629")
     public boolean sendMails(Collection<Mail> emails, MailConfiguration mailConfiguration, XWikiContext context)
         throws MessagingException, UnsupportedEncodingException
     {
@@ -649,7 +650,10 @@ public class MailSenderPlugin extends XWikiDefaultPlugin
                 count++;
 
                 Mail mail = emailIt.next();
-                LOGGER.info("Sending email [{}]", mail);
+                // Build the String on purpose: log arguments are kept as objects in the captured LogEvent and
+                // XStream-serialized into the job log (see SafeMessageConverter in xwiki-commons), and a Mail holds
+                // the body and the attachments, none of which its toString() prints.
+                LOGGER.info("Sending email [{}]", mail.toString());
 
                 if ((transport == null) || (session == null)) {
                     // initialize JavaMail Session and Transport
@@ -688,7 +692,8 @@ public class MailSenderPlugin extends XWikiDefaultPlugin
                 } catch (SendFailedException ex) {
                     sendFailedCount++;
                     LOGGER.error("SendFailedException has occurred.", ex);
-                    LOGGER.error("Detailed email information: [{}]", mail);
+                    // See the comment above about building the String rather than passing the Mail.
+                    LOGGER.error("Detailed email information: [{}]", mail.toString());
                     if (emailCount == 1) {
                         throw ex;
                     }
@@ -697,7 +702,8 @@ public class MailSenderPlugin extends XWikiDefaultPlugin
                     }
                 } catch (MessagingException mex) {
                     LOGGER.error(MESSAGING_EXCEPTION_ERROR, mex);
-                    LOGGER.error("Detailed email information: [{}]", mail);
+                    // See the comment above about building the String rather than passing the Mail.
+                    LOGGER.error("Detailed email information: [{}]", mail.toString());
                     if (emailCount == 1) {
                         throw mex;
                     }

--- a/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSenderPluginApi.java
+++ b/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSenderPluginApi.java
@@ -179,7 +179,10 @@ public class MailSenderPluginApi extends PluginApi<MailSenderPlugin> implements 
             if (e.getMessage() != null) {
                 this.context.put(ERROR_KEY, e.getMessage());
             }
-            LOGGER.error("Failed to send email [{}]", mail, e);
+            // Build the String on purpose: log arguments are kept as objects in the captured LogEvent and
+            // XStream-serialized into the job log (see SafeMessageConverter in xwiki-commons), and a Mail holds the
+            // body and the attachments, none of which its toString() prints.
+            LOGGER.error("Failed to send email [{}]", mail.toString(), e);
             result = -1;
         }
 
@@ -203,7 +206,11 @@ public class MailSenderPluginApi extends PluginApi<MailSenderPlugin> implements 
             if (e.getMessage() != null) {
                 this.context.put(ERROR_KEY, e.getMessage());
             }
-            LOGGER.error("Failed to send email [{}] using mail configuration [{}]", mail, mailConfiguration, e);
+            // Build the Strings on purpose: log arguments are kept as objects in the captured LogEvent and
+            // XStream-serialized into the job log (see SafeMessageConverter in xwiki-commons). A Mail holds the body
+            // and the attachments, and MailConfiguration.toString() masks the SMTP password that the object carries.
+            LOGGER.error("Failed to send email [{}] using mail configuration [{}]", mail.toString(),
+                mailConfiguration.toString(), e);
             result = -1;
         }
 

--- a/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/main/java/org/xwiki/observation/remote/internal/jgroups/JGroupsNetworkAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/main/java/org/xwiki/observation/remote/internal/jgroups/JGroupsNetworkAdapter.java
@@ -61,9 +61,13 @@ public class JGroupsNetworkAdapter implements NetworkAdapter, Disposable
     private Logger logger;
 
     @Override
+    @SuppressWarnings("java:S2629")
     public void send(RemoteEventData remoteEvent)
     {
-        this.logger.debug("Send JGroups remote event [{}]", remoteEvent);
+        // Build the String on purpose: log arguments are kept as objects in the captured LogEvent and
+        // XStream-serialized into the job log (see SafeMessageConverter in xwiki-commons), and a RemoteEventData
+        // is Serializable by design since it is the replicated payload, so it would be written out in full.
+        this.logger.debug("Send JGroups remote event [{}]", remoteEvent.toString());
 
         // Send the message to the whole group
         // Using BytesMessage and not ObjectMessage (which would have been much better for the memory) here because it's
@@ -75,7 +79,9 @@ public class JGroupsNetworkAdapter implements NetworkAdapter, Disposable
             try {
                 entry.getValue().send(message);
             } catch (Exception e) {
-                this.logger.error("Failed to send message [{}] to the channel [{}]", remoteEvent, entry.getKey(), e);
+                // See the comment above about building the String rather than passing the event.
+                this.logger.error("Failed to send message [{}] to the channel [{}]", remoteEvent.toString(),
+                    entry.getKey(), e);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateBaseStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateBaseStore.java
@@ -632,12 +632,16 @@ public class XWikiHibernateBaseStore extends AbstractXWikiStore
      *
      * @param inputxcontext
      */
+    @SuppressWarnings("java:S2629")
     public void cleanUp(XWikiContext inputxcontext)
     {
         try {
             Session session = this.store.getCurrentSession();
             if (session != null) {
-                LOGGER.warn("Cleanup of session was needed: [{}]", session);
+                // Build the String on purpose: log arguments are kept as objects in the captured LogEvent and
+                // XStream-serialized into the job log (see SafeMessageConverter in xwiki-commons), and a Session is
+                // a live resource that implements Serializable, so it would be walked field by field.
+                LOGGER.warn("Cleanup of session was needed: [{}]", session.toString());
 
                 this.store.endTransaction(false);
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R40000XWIKI6990DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R40000XWIKI6990DataMigration.java
@@ -1385,7 +1385,13 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
         }
 
         logProgress("%d schema updates required.", this.logCount);
-        this.logger.debug("About to execute this Liquibase XML: [{}]", sb);
-        return sb.toString();
+
+        // Build the String on purpose (it is needed for the return value anyway): log arguments are kept as objects
+        // in the captured LogEvent and XStream-serialized into the job log (see SafeMessageConverter in
+        // xwiki-commons), and this builder holds the whole Liquibase XML of the migration.
+        String liquibaseXML = sb.toString();
+        this.logger.debug("About to execute this Liquibase XML: [{}]", liquibaseXML);
+
+        return liquibaseXML;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrIndexAvailableLocalesListener.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrIndexAvailableLocalesListener.java
@@ -183,7 +183,10 @@ public class SolrIndexAvailableLocalesListener implements EventListener
                 }
             }
         } catch (Exception e) {
-            this.logger.error("Failed to handle event [{}] with source [{}]", event, source, e);
+            // Build the String on purpose: log arguments are kept as objects in the captured LogEvent and
+            // XStream-serialized into the job log (see SafeMessageConverter in xwiki-commons), and the source is
+            // an arbitrary object whose graph would be written out and read back as null if it cannot be resolved.
+            this.logger.error("Failed to handle event [{}] with source [{}]", event, String.valueOf(source), e);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrIndexEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrIndexEventListener.java
@@ -176,7 +176,10 @@ public class SolrIndexEventListener implements EventListener
                 }
             }
         } catch (Exception e) {
-            this.logger.error("Failed to handle event [{}] with source [{}]", event, source, e);
+            // Build the String on purpose: log arguments are kept as objects in the captured LogEvent and
+            // XStream-serialized into the job log (see SafeMessageConverter in xwiki-commons), and the source is
+            // an arbitrary object whose graph would be written out and read back as null if it cannot be resolved.
+            this.logger.error("Failed to handle event [{}] with source [{}]", event, String.valueOf(source), e);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-workspaces-migrator/src/main/java/org/xwiki/wiki/workspacesmigrator/internal/WorkspacesMigration.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-workspaces-migrator/src/main/java/org/xwiki/wiki/workspacesmigrator/internal/WorkspacesMigration.java
@@ -157,6 +157,7 @@ public class WorkspacesMigration extends AbstractHibernateDataMigration
      *
      * @param wikiId id of the wiki to upgrade
      */
+    @SuppressWarnings("java:S2629")
     private void restoreDeletedDocuments(String wikiId)
     {
         XWikiContext xcontext = getXWikiContext();
@@ -208,9 +209,12 @@ public class WorkspacesMigration extends AbstractHibernateDataMigration
                 }
                 documentsToRestoreAsString.append(d);
             }
+            // Build the String on purpose: log arguments are kept as objects in the captured LogEvent and
+            // XStream-serialized into the job log (see SafeMessageConverter in xwiki-commons), and a StringBuilder
+            // would be written out as its internal char array.
             logger.warn("Failed to restore some documents: [{}]. You should import manually "
                     + "(1) xwiki-platform-administration-ui.xar and then (2) xwiki-platform-wiki-ui-wiki.xar into your"
-                    + " wiki, to restore these documents.", documentsToRestoreAsString);
+                    + " wiki, to restore these documents.", documentsToRestoreAsString.toString());
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-workspaces-migrator/src/test/java/org/xwiki/wiki/workspacesmigrator/internal/WorkspaceMigrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-workspaces-migrator/src/test/java/org/xwiki/wiki/workspacesmigrator/internal/WorkspaceMigrationTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatcher;
 import org.slf4j.Logger;
 import org.xwiki.context.Execution;
 import org.xwiki.context.ExecutionContext;
@@ -41,7 +40,6 @@ import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.store.migration.hibernate.HibernateDataMigration;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -191,15 +189,10 @@ class WorkspaceMigrationTest
             any(XWikiException.class));
     }
 
-    /**
-     * The list of documents is passed as the {@link StringBuilder} it is built into, so it is matched on its rendered
-     * value rather than by equality.
-     */
     private void verifyDocumentsToRestoreLogged(String expectedDocuments)
     {
-        verify(this.logger).warn(eq("Failed to restore some documents: [{}]. You should import manually "
+        verify(this.logger).warn("Failed to restore some documents: [{}]. You should import manually "
             + "(1) xwiki-platform-administration-ui.xar and then (2) xwiki-platform-wiki-ui-wiki.xar into your"
-            + " wiki, to restore these documents."), argThat(
-                (ArgumentMatcher<Object>) documents -> expectedDocuments.equals(documents.toString())));
+            + " wiki, to restore these documents.", expectedDocuments);
     }
 }


### PR DESCRIPTION
The xwiki-commons counterpart is xwiki/xwiki-commons#1872, which has the full reasoning. In short: @tmortagne pointed out that explicit `toString()` calls on log arguments are often deliberate, and he's right. Log arguments are kept as objects in the captured `LogEvent` and XStream-serialized into the job log (`SafeMessageConverter` in xwiki-commons), and `XStreamUtils.isSerializable()` says yes by default, so dropping the `toString()` changes what lands in the job log file — the whole object graph gets written, and `SafeArrayConverter` turns any read failure into `null`, losing the information the String would have preserved.

This applies the same fix to the sites the logging best practices pass (#6055 … #6079) changed here.

## Reverted, with the reason at each site

| Site | Argument | Why the String |
|---|---|---|
| `XWikiHibernateBaseStore` | Hibernate `Session` | A live resource that implements `Serializable`, so it would be walked field by field |
| `MailSenderPluginApi` | `MailConfiguration` | Its `toString()` masks the SMTP password (`Password [*****]`) that the object carries in clear text |
| `MailSenderPlugin` x3, `MailSenderPluginApi` | `Mail` | Holds the body and the `List<Attachment>`, none of which its `toString()` prints |
| `MovedAttachmentListener` | `MoveAttachmentRequest` | `Request` is `Serializable`, so the move job would put a copy of its own request in its own log |
| `SolrIndexEventListener`, `SolrIndexAvailableLocalesListener` | arbitrary `source` | Unknown type, same case as `DefaultJobProgress` in commons |
| `JGroupsNetworkAdapter` x2 | `RemoteEventData` | `Serializable` by design, being the replicated payload |
| `DatabaseMailStatusStore`, `WorkspacesMigration` | `StringBuilder` | Would be written out as its internal char array, and it is mutable |
| `R40000XWIKI6990DataMigration` | `StringBuilder` | Holds the whole Liquibase XML of the migration |
| `DefaultWikiComponentInvocationHandler` | role `Type` | Backed by a `Class` that cannot always be resolved when the log is read back |

`R40000XWIKI6990DataMigration` reuses the converted String for the return value instead of building it twice, and `DefaultWikiComponentInvocationHandler` uses `getTypeName()`.

## Left alone on purpose

`EntityReference` arguments (`MailConfigMandatoryDocumentInitializer`, and the document reference in `DefaultWikiComponentInvocationHandler`) — that is precisely the case the typed form exists for, since the log displayers render them as links and `Importer` casts `log.getArgumentArray()[0]` to `EntityReference`. Also left: enums (`DefaultSolrIndexer`), a `File` (`FileSystemURLFactory`), a `Version` (`XWikiRCSArchive`), and `DefaultQuery`'s `QueryFilter`, which is a component and so is already stringified by the converter.

## SonarQube

`java:S2629` only examines arguments whose static type is `String`, exempts no-arg `get*`/`is*` calls, and skips log calls inside a `catch` block (`LazyArgEvaluationCheck`). So only four sites need `@SuppressWarnings("java:S2629")`: `XWikiHibernateBaseStore.cleanUp`, `JGroupsNetworkAdapter.send`, `MailSenderPlugin.sendMails` and `WorkspacesMigration.restoreDeletedDocuments`. The rest are in `catch` blocks, inside an `isDebugEnabled()` guard, or pass a String local or a getter result.

## Verification

`mvn test checkstyle:check -Pquality` green in the seven non-oldcore modules: attachment-api (49 tests), component-wiki (35), mail-send-storage (40), mailsender (14), observation-remote (12), search-solr-api (120), wiki-workspaces-migrator (9), with 0 Checkstyle violations each.

For **oldcore** I ran `test-compile checkstyle:check -Pquality` only — green, 0 violations — rather than its full suite. Neither changed site has a dedicated test class, and no test asserts either message.

One test was simplified: `WorkspaceMigrationTest` had been adapted by the earlier pass to match the `StringBuilder` on its rendered value with `argThat`; it now verifies the String directly again, and its two matcher imports are dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
