### PR TITLE
XWIKI-24323: Update icons on quick search so they use the icon theme

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/pom.xml
@@ -83,7 +83,7 @@
       <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-icon-script</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.xwiki.platform</groupId>

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/pom.xml
@@ -78,6 +78,13 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- Icon script service, used to test rendering icon theme icons in the search suggest sources. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-icon-script</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-web-templates</artifactId>

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/pom.xml
@@ -71,19 +71,19 @@
       <type>xar</type>
       <scope>runtime</scope>
     </dependency>
+    <!-- Icon script service, used to render icon theme icons in the search suggest sources. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-icon-script</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
     <!-- Test dependencies. -->
     <dependency>
       <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-test-page</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
-    </dependency>
-    <!-- Icon script service, used to test rendering icon theme icons in the search suggest sources. -->
-    <dependency>
-      <groupId>org.xwiki.platform</groupId>
-      <artifactId>xwiki-platform-icon-script</artifactId>
-      <version>${project.version}</version>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.xwiki.platform</groupId>

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/SearchSuggestCode.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/SearchSuggestCode.xml
@@ -36,7 +36,8 @@
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
-  <content>{{velocity output="false"}}
+  <content>{{include reference="XWiki.SearchSuggestMacros" /}}
+{{velocity output="false"}}
 #if ($xcontext.action == 'get')
 ## Iterate over the sources defined in the configuration document, and create a source array to be passed to the
 ## search suggest contructor.
@@ -66,10 +67,8 @@
         ## Evaluate the Velocity code for backward compatibility.
         #set ($name =  $evaluatedSource.name)
       #end
-      #set ($icon = $source.getProperty('icon').value)
-      #if ($icon.startsWith('icon:'))
-        #set ($icon = $xwiki.getSkinFile("icons/silk/${icon.substring(5)}.png"))
-      #elseif ("$!evaluatedSource" != '')
+      #resolveSearchSuggestSourceIcon($source.getProperty('icon').value)
+      #if (!$isIconThemeIcon &amp;&amp; "$!evaluatedSource" != '')
         ## Evaluate the Velocity code for backward compatibility.
         #set ($icon = $evaluatedSource.icon)
       #end
@@ -92,6 +91,7 @@
         'varname': 'input',
         'script': $service,
         'icon': $icon,
+        'iconHTML': $iconHTML,
         'highlight': $highlight
       }))
     #end

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/SearchSuggestConfigSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/SearchSuggestConfigSheet.xml
@@ -37,6 +37,7 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{include reference="XWiki.SearchCode" /}}
+{{include reference="XWiki.SearchSuggestMacros" /}}
 
 {{velocity output="false"}}
 #macro (displayObjectPropertyValue $propertyName $mode)
@@ -45,12 +46,11 @@
 
 #macro (displaySearchSuggestSource $source)
   #set ($evaluatedSource = $source.evaluate())
-  #set ($icon = $source.getProperty('icon').value)
-  #if ($icon.startsWith('icon:'))
-    #set ($icon = $xwiki.getSkinFile("icons/silk/${icon.substring(5)}.png"))
-  #else
+  #resolveSearchSuggestSourceIcon($source.getProperty('icon').value)
+  #if (!$isIconThemeIcon)
     ## Evaluate the Velocity code for backward compatibility.
     #set ($icon = $evaluatedSource.icon)
+    #set ($iconHTML = "&lt;img class='icon' src='$escapetool.xml($!icon)' alt='' /&gt;")
   #end
   #set ($name = $source.getProperty('name').value)
   #if ($services.localization.get($name))
@@ -68,7 +68,7 @@
   #end
   &lt;li class="source"&gt;
     &lt;div class="$style"&gt;
-      &lt;img class="icon" src="$escapetool.xml($!icon)" alt="" /&gt;
+      $iconHTML
       &lt;span class="limit"&gt;$escapetool.xml($!source.getProperty('resultsNumber').value)&lt;/span&gt;
       &lt;span class="name"&gt;$escapetool.xml($!name)&lt;/span&gt;
       #if ($editing)

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/SearchSuggestMacros.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/SearchSuggestMacros.xml
@@ -1,0 +1,60 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.5" reference="XWiki.SearchSuggestMacros" locale="">
+  <web>XWiki</web>
+  <name>SearchSuggestMacros</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>XWiki.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title/>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content>{{velocity output="false"}}
+## Resolve the icon of a search suggest source, shared between XWiki.SearchSuggestCode (the suggest JSON source)
+## and XWiki.SearchSuggestConfigSheet (the admin preview), so the icon theme detection stays in a single place.
+##
+## Sets $icon and $isIconThemeIcon in the caller's context:
+## - if $rawIcon starts with "icon:", $icon is cleared and $isIconThemeIcon is true; the caller is expected to use
+##   $iconHTML (also set by this macro) to display the icon.
+## - otherwise $icon is left untouched (the raw source icon property value) and $isIconThemeIcon is false; the
+##   caller is responsible for resolving the legacy icon value (e.g. evaluating it for backward compatibility) and
+##   building the corresponding markup.
+#macro (resolveSearchSuggestSourceIcon $rawIcon)
+  #set ($icon = $rawIcon)
+  #set ($iconHTML = '')
+  #set ($isIconThemeIcon = $icon.startsWith('icon:'))
+  #if ($isIconThemeIcon)
+    ## Use the icon theme currently configured on the wiki, instead of hard-coding the Silk icon set.
+    #set ($iconHTML = $services.icon.renderHTML($icon.substring(5)))
+    #set ($icon = '')
+  #end
+#end
+{{/velocity}}</content>
+</xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/SearchSuggestMacros.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/SearchSuggestMacros.xml
@@ -37,9 +37,7 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{velocity output="false"}}
-## Resolve the icon of a search suggest source, shared between XWiki.SearchSuggestCode (the suggest JSON source)
-## and XWiki.SearchSuggestConfigSheet (the admin preview), so the icon theme detection stays in a single place.
-##
+## Resolve the icon of a search suggest source
 ## Sets $icon and $isIconThemeIcon in the caller's context:
 ## - if $rawIcon starts with "icon:", $icon is cleared and $isIconThemeIcon is true; the caller is expected to use
 ##   $iconHTML (also set by this macro) to display the icon.
@@ -51,7 +49,6 @@
   #set ($iconHTML = '')
   #set ($isIconThemeIcon = $icon.startsWith('icon:'))
   #if ($isIconThemeIcon)
-    ## Use the icon theme currently configured on the wiki, instead of hard-coding the Silk icon set.
     #set ($iconHTML = $services.icon.renderHTML($icon.substring(5)))
     #set ($icon = '')
   #end

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/SearchSuggestMacros.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/SearchSuggestMacros.xml
@@ -49,7 +49,7 @@
   #set ($iconHTML = '')
   #set ($isIconThemeIcon = $icon.startsWith('icon:'))
   #if ($isIconThemeIcon)
-    #set ($iconHTML = $services.icon.renderHTML($icon.substring(5)))
+    #set ($iconHTML = "$!services.icon.renderHTML($rawIcon.substring(5))")
     #set ($icon = '')
   #end
 #end

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/test/java/org/xwiki/search/ui/SearchSuggestConfigSheetPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/test/java/org/xwiki/search/ui/SearchSuggestConfigSheetPageTest.java
@@ -172,11 +172,10 @@ class SearchSuggestConfigSheetPageTest extends PageTest
         assertEquals(this.testString + "SearchSuggestSources", presentationLink.attr("aria-controls"));
         assertEquals(this.testString + "SearchSuggestSources", result.getElementsByClass("tab-pane").get(0).attr("id"));
         assertEquals(this.testString, result.getElementsByClass("limit").text());
-
-        // This should not be evaluated.
+        
         assertEquals(this.testString, result.getElementsByClass("name").text());
 
-        // The icon theme icon is rendered directly and no longer goes through the legacy "icon" image markup.
+        // The icon is rendered as expected.
         assertEquals(0, result.getElementsByClass("icon").size());
         assertEquals(1, result.getElementsByClass("fa-user").size());
     }

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/test/java/org/xwiki/search/ui/SearchSuggestConfigSheetPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/test/java/org/xwiki/search/ui/SearchSuggestConfigSheetPageTest.java
@@ -150,10 +150,7 @@ class SearchSuggestConfigSheetPageTest extends PageTest
     {
         when(this.oldcore.getMockDocumentAuthorizationManager()
             .hasAccess(Right.SCRIPT, EntityType.DOCUMENT, AUTHOR_REFERENCE, TEST_PAGE)).thenReturn(false);
-
-        // Use an icon theme icon rather than the escaping test string, to exercise the icon theme rendering
-        // ($services.icon.renderHTML() in SearchSuggestConfigSheet.xml), which bypasses Velocity evaluation and
-        // thus doesn't require script rights.
+        
         this.testPageDocument.getXObject(SEARCH_SUGGEST_SOURCE_CLASS).setStringValue("icon", "icon:user");
         this.xwiki.saveDocument(this.testPageDocument, this.context);
         String iconHTML = "<span class=\"fa fa-user\"></span>";

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/test/java/org/xwiki/search/ui/SearchSuggestConfigSheetPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/test/java/org/xwiki/search/ui/SearchSuggestConfigSheetPageTest.java
@@ -150,8 +150,14 @@ class SearchSuggestConfigSheetPageTest extends PageTest
     {
         when(this.oldcore.getMockDocumentAuthorizationManager()
             .hasAccess(Right.SCRIPT, EntityType.DOCUMENT, AUTHOR_REFERENCE, TEST_PAGE)).thenReturn(false);
-        
-        this.testPageDocument.getXObject(SEARCH_SUGGEST_SOURCE_CLASS).setStringValue("icon", "icon:user");
+
+        // Add a second source using an icon-theme icon, next to the legacy one created in setUp(), so both the
+        // legacy and the icon-theme rendering paths are checked in the same render.
+        BaseObject iconThemeSource = this.testPageDocument.newXObject(SEARCH_SUGGEST_SOURCE_CLASS, this.context);
+        iconThemeSource.setStringValue("name", this.testString);
+        iconThemeSource.setStringValue("icon", "icon:user");
+        iconThemeSource.setStringValue("resultsNumber", this.testString);
+        iconThemeSource.setStringValue("engine", this.testString);
         this.xwiki.saveDocument(this.testPageDocument, this.context);
         String iconHTML = "<span class=\"fa fa-user\"></span>";
         IconManager iconManager = this.componentManager.getInstance(IconManager.class);
@@ -160,23 +166,29 @@ class SearchSuggestConfigSheetPageTest extends PageTest
         this.context.setDoc(this.testPageDocument);
         Document result = renderHTMLPage(this.searchSuggestConfigSheetDocument);
 
-        verify(this.oldcore.getMockDocumentAuthorizationManager()).hasAccess(Right.SCRIPT, EntityType.DOCUMENT,
-            AUTHOR_REFERENCE, TEST_PAGE);
+        verify(this.oldcore.getMockDocumentAuthorizationManager(), times(2)).hasAccess(Right.SCRIPT,
+            EntityType.DOCUMENT, AUTHOR_REFERENCE, TEST_PAGE);
         verify(this.velocityEngine, never()).evaluate(any(), any(), any(), eq(this.testString));
 
         Element presentationLink =
             result.getElementsByAttributeValue("role", "presentation").get(0).getElementsByTag("a").get(0);
-        // Escaping tests only.
+        // Escaping tests only. Both sources share the same engine, so there is still a single tab.
         assertEquals("#" + this.testString + "SearchSuggestSources", presentationLink.attr("href"));
         assertEquals(this.testString, presentationLink.text());
         assertEquals(this.testString + "SearchSuggestSources", presentationLink.attr("aria-controls"));
         assertEquals(this.testString + "SearchSuggestSources", result.getElementsByClass("tab-pane").get(0).attr("id"));
-        assertEquals(this.testString, result.getElementsByClass("limit").text());
-        
-        assertEquals(this.testString, result.getElementsByClass("name").text());
+        for (Element limitElement : result.getElementsByClass("limit")) {
+            assertEquals(this.testString, limitElement.text());
+        }
+        for (Element nameElement : result.getElementsByClass("name")) {
+            assertEquals(this.testString, nameElement.text());
+        }
 
-        // The icon is rendered as expected.
-        assertEquals(0, result.getElementsByClass("icon").size());
+        // The legacy icon value (not prefixed with "icon:") is not evaluated.
+        assertEquals(1, result.getElementsByClass("icon").size());
+        assertEquals(this.testString, result.getElementsByClass("icon").get(0).attr("src"));
+
+        // The icon-theme icon is rendered as expected.
         assertEquals(1, result.getElementsByClass("fa-user").size());
     }
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/test/java/org/xwiki/search/ui/SearchSuggestConfigSheetPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/test/java/org/xwiki/search/ui/SearchSuggestConfigSheetPageTest.java
@@ -90,8 +90,6 @@ class SearchSuggestConfigSheetPageTest extends PageTest
 
     private AuthorExecutor authorExecutor;
 
-    private IconManager iconManager;
-
     private VelocityEngine velocityEngine;
 
     private XWikiDocument testPageDocument;
@@ -108,7 +106,7 @@ class SearchSuggestConfigSheetPageTest extends PageTest
         // Minimal icon environment: only IconManager#renderHTML() is actually exercised by these tests.
         this.componentManager.registerMockComponent(IconSetManager.class);
         this.componentManager.registerMockComponent(IconRenderer.class);
-        this.iconManager = this.componentManager.registerMockComponent(IconManager.class);
+        IconManager iconManager = this.componentManager.registerMockComponent(IconManager.class);
 
         this.xwiki.initializeMandatoryDocuments(this.context);
         loadPage(SEARCH_SUGGEST_SOURCE_CLASS);
@@ -159,7 +157,8 @@ class SearchSuggestConfigSheetPageTest extends PageTest
         this.testPageDocument.getXObject(SEARCH_SUGGEST_SOURCE_CLASS).setStringValue("icon", "icon:user");
         this.xwiki.saveDocument(this.testPageDocument, this.context);
         String iconHTML = "<span class=\"fa fa-user\"></span>";
-        when(this.iconManager.renderHTML("user")).thenReturn(iconHTML);
+        IconManager iconManager = this.componentManager.getInstance(IconManager.class);
+        when(iconManager.renderHTML("user")).thenReturn(iconHTML);
 
         this.context.setDoc(this.testPageDocument);
         Document result = renderHTMLPage(this.searchSuggestConfigSheetDocument);

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/test/java/org/xwiki/search/ui/SearchSuggestConfigSheetPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/test/java/org/xwiki/search/ui/SearchSuggestConfigSheetPageTest.java
@@ -27,6 +27,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.xwiki.evaluation.internal.DefaultObjectEvaluator;
 import org.xwiki.evaluation.internal.VelocityObjectPropertyEvaluator;
+import org.xwiki.icon.IconManager;
+import org.xwiki.icon.IconManagerScriptService;
+import org.xwiki.icon.IconRenderer;
+import org.xwiki.icon.IconSetManager;
 import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.rendering.RenderingScriptServiceComponentList;
@@ -63,6 +67,7 @@ import static org.mockito.Mockito.when;
     VelocityObjectPropertyEvaluator.class,
     SearchSuggestSourceObjectEvaluator.class,
     TestNoScriptMacro.class,
+    IconManagerScriptService.class,
 })
 class SearchSuggestConfigSheetPageTest extends PageTest
 {
@@ -74,6 +79,9 @@ class SearchSuggestConfigSheetPageTest extends PageTest
     private static final DocumentReference SEARCH_SUGGEST_SOURCE_CLASS =
         new DocumentReference(WIKI_NAME, "XWiki", "SearchSuggestSourceClass");
 
+    private static final DocumentReference SEARCH_SUGGEST_MACROS =
+        new DocumentReference(WIKI_NAME, "XWiki", "SearchSuggestMacros");
+
     private static final DocumentReference TEST_PAGE =
         new DocumentReference(WIKI_NAME, "Test", "TestDocument");
 
@@ -81,6 +89,8 @@ class SearchSuggestConfigSheetPageTest extends PageTest
         new DocumentReference(WIKI_NAME, "XWiki", "TestUser");
 
     private AuthorExecutor authorExecutor;
+
+    private IconManager iconManager;
 
     private VelocityEngine velocityEngine;
 
@@ -95,8 +105,14 @@ class SearchSuggestConfigSheetPageTest extends PageTest
     @BeforeEach
     void setUp() throws Exception
     {
+        // Minimal icon environment: only IconManager#renderHTML() is actually exercised by these tests.
+        this.componentManager.registerMockComponent(IconSetManager.class);
+        this.componentManager.registerMockComponent(IconRenderer.class);
+        this.iconManager = this.componentManager.registerMockComponent(IconManager.class);
+
         this.xwiki.initializeMandatoryDocuments(this.context);
         loadPage(SEARCH_SUGGEST_SOURCE_CLASS);
+        loadPage(SEARCH_SUGGEST_MACROS);
         loadPage(SEARCH_SUGGEST_CONFIG_SHEET);
 
         this.testString = "$doc.getDocumentReference().getName(){{/html}}{{noscript /}}";
@@ -137,6 +153,14 @@ class SearchSuggestConfigSheetPageTest extends PageTest
         when(this.oldcore.getMockDocumentAuthorizationManager()
             .hasAccess(Right.SCRIPT, EntityType.DOCUMENT, AUTHOR_REFERENCE, TEST_PAGE)).thenReturn(false);
 
+        // Use an icon theme icon rather than the escaping test string, to exercise the icon theme rendering
+        // ($services.icon.renderHTML() in SearchSuggestConfigSheet.xml), which bypasses Velocity evaluation and
+        // thus doesn't require script rights.
+        this.testPageDocument.getXObject(SEARCH_SUGGEST_SOURCE_CLASS).setStringValue("icon", "icon:user");
+        this.xwiki.saveDocument(this.testPageDocument, this.context);
+        String iconHTML = "<span class=\"fa fa-user\"></span>";
+        when(this.iconManager.renderHTML("user")).thenReturn(iconHTML);
+
         this.context.setDoc(this.testPageDocument);
         Document result = renderHTMLPage(this.searchSuggestConfigSheetDocument);
 
@@ -153,9 +177,12 @@ class SearchSuggestConfigSheetPageTest extends PageTest
         assertEquals(this.testString + "SearchSuggestSources", result.getElementsByClass("tab-pane").get(0).attr("id"));
         assertEquals(this.testString, result.getElementsByClass("limit").text());
 
-        // These should not be evaluated.
-        assertEquals(this.testString, result.getElementsByClass("icon").get(0).attr("src"));
+        // This should not be evaluated.
         assertEquals(this.testString, result.getElementsByClass("name").text());
+
+        // The icon theme icon is rendered directly and no longer goes through the legacy "icon" image markup.
+        assertEquals(0, result.getElementsByClass("icon").size());
+        assertEquals(1, result.getElementsByClass("fa-user").size());
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/test/java/org/xwiki/search/ui/SearchSuggestConfigSheetPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/test/java/org/xwiki/search/ui/SearchSuggestConfigSheetPageTest.java
@@ -106,7 +106,7 @@ class SearchSuggestConfigSheetPageTest extends PageTest
         // Minimal icon environment: only IconManager#renderHTML() is actually exercised by these tests.
         this.componentManager.registerMockComponent(IconSetManager.class);
         this.componentManager.registerMockComponent(IconRenderer.class);
-        IconManager iconManager = this.componentManager.registerMockComponent(IconManager.class);
+        this.componentManager.registerMockComponent(IconManager.class);
 
         this.xwiki.initializeMandatoryDocuments(this.context);
         loadPage(SEARCH_SUGGEST_SOURCE_CLASS);

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.css
@@ -139,6 +139,9 @@ ul.xlist li.showAllResults {
   margin-left:10px;
 }
 
+/* Indent the source's icon/name/results from the left edge, while its border-top separator still spans the full
+   width; that separator is cancelled below on sourceName/showAllResults. The 12px value is a visual value tuned
+   against the design mockup, it is not derived from another token. */
 div.suggestItems.searchSuggest div.resultContainer div.results {
   padding-left: 12px;
   border-top: 1px solid var(--xwiki-border-color);

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.css
@@ -139,6 +139,17 @@ ul.xlist li.showAllResults {
   margin-left:10px;
 }
 
+div.suggestItems.searchSuggest div.resultContainer div.results {
+  padding-left: 12px;
+  border-top: 1px solid var(--xwiki-border-color);
+}
+
+/* Cancel these elements' own border-top (see above) so div.results doesn't draw two stacked separator lines. */
+div.suggestItems.searchSuggest div.resultContainer div.sourceName,
+div.suggestItems.searchSuggest div.resultContainer li.showAllResults {
+  border-top: none;
+}
+
 .horizontalLayout div.resultContainer div.results {
   clear:both;
 }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.css
@@ -125,6 +125,12 @@ div.resultContainer div.sourceName {
   padding: 5px 0;
 }
 
+div.resultContainer div.sourceName.withIcon {
+  align-items: center;
+  display: flex;
+  gap: 5px;
+}
+
 ul.xlist li.showAllResults {
   border-top: 1px solid var(--xwiki-border-color);
 }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
@@ -585,9 +585,14 @@ var XWiki = (function(XWiki){
             sourceContainer.addClassName('hidden').addClassName('loading');
           }
 
-          if (typeof source.icon != 'undefined') {
-            // If there is an icon for this source group, set it as background image
-            // TODO: Replace with the use of the icon theme (see XWIKI-24323).
+          if (source.iconHTML) {
+            // Use the icon theme currently configured on the wiki to display the source group icon.
+            sourceHeader.insert({top: source.iconHTML});
+            sourceHeader.addClassName('withIcon');
+          } else if (source.icon) {
+            // Fallback for sources that specify a plain icon URL (e.g. for backward compatibility): set it as
+            // background image. Note that an empty icon (e.g. because the icon theme lookup failed) must not reach
+            // this branch, otherwise the empty src would make the browser fetch the current page as an "image".
             var iconImage = new Image();
             iconImage.onload = function(){
               this.sourceHeader.setStyle({


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24323

# Changes

## Description

* Replace the hard-coded Silk icon set lookup in the quick search suggest sources (`SearchSuggestCode.xml`, the suggest JSON source, and `SearchSuggestConfigSheet.xml`, its admin config preview) with `$services.icon.renderHTML()`, so the quick search follows icon theme.
* Extract the icon-theme detection logic shared by both sources into a new `XWiki.SearchSuggestMacros` page, instead of duplicating it.
* Add test coverage in `SearchSuggestConfigSheetPageTest` for the icon-theme rendering path, which previously had none.

## Clarifications

* Part of the improvements from XWIKI-22019, following https://github.com/xwiki/xwiki-platform/pull/5451 .
* The configured icon names already used in the default sources (e.g. `page_white_text`, `attach`, `page_white_picture`, `user`, `chart_organisation`) already exist in the default icon set.

# Screenshots & Video

<img width="3080" height="3545" alt="comparison-trimmed" src="https://github.com/user-attachments/assets/451f514d-8aa4-4aa6-96e6-a473929fc633" />
Note that the final state is still different from the prototype, there are problems to be solved in https://jira.xwiki.org/browse/XWIKI-24324 for example.

# Executed Tests

* `mvn -o test` on `xwiki-platform-search-ui` (includes `SearchSuggestConfigSheetPageTest`, extended to cover the icon-theme rendering path): all passed.
* Manual verification in a running instance, see above.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * 18.4.X to match https://github.com/xwiki/xwiki-platform/pull/5451