### PR TITLE
XWIKI-24665: Apply the logging best practices across commons, rendering and platform

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/rights/internal/XWikiAnnotationRightService.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/rights/internal/XWikiAnnotationRightService.java
@@ -23,7 +23,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.annotation.Annotation;
 import org.xwiki.annotation.io.IOService;
@@ -150,7 +149,6 @@ public class XWikiAnnotationRightService implements AnnotationRightService
      */
     private void logException(Exception e, String target, String user)
     {
-        this.logger.warn("Couldn't get access rights for the target [{}] for user [{}]. Root cause is [{}]", target,
-            user, ExceptionUtils.getRootCauseMessage(e));
+        this.logger.warn("Couldn't get access rights for the target [{}] for user [{}]", target, user, e);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-maintainer/src/main/java/org/xwiki/annotation/maintainer/internal/DocumentContentAnnotationUpdateListener.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-maintainer/src/main/java/org/xwiki/annotation/maintainer/internal/DocumentContentAnnotationUpdateListener.java
@@ -23,7 +23,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.annotation.maintainer.AnnotationMaintainer;
 import org.xwiki.annotation.maintainer.MaintainerServiceException;
@@ -98,8 +97,8 @@ public class DocumentContentAnnotationUpdateListener extends AbstractLocalEventL
                 maintainer.updateAnnotations(this.serializer.serialize(currentDocument.getDocumentReference()),
                     previousContent, content);
             } catch (MaintainerServiceException e) {
-                this.logger.warn("Failed to maintain the annotations of document [{}]. Root cause is [{}]",
-                    currentDocument.getDocumentReference(), ExceptionUtils.getRootCauseMessage(e));
+                this.logger.warn("Failed to maintain the annotations of document [{}]",
+                    currentDocument.getDocumentReference(), e);
                 // nothing else, just go further
             }
             isUpdating = false;

--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/bridge/WikiObjectComponentManagerEventListenerProxy.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/bridge/WikiObjectComponentManagerEventListenerProxy.java
@@ -101,8 +101,7 @@ public class WikiObjectComponentManagerEventListenerProxy
                 wikiObjectsList.add(componentBuilder.getClassReference());
             }
         } catch (ComponentLookupException e) {
-            logger.warn("Unable to collect a list of wiki objects components. Root cause is [{}]",
-                ExceptionUtils.getRootCauseMessage(e));
+            logger.warn("Unable to collect a list of wiki objects components", e);
         }
 
         return wikiObjectsList;

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/main/java/org/xwiki/display/internal/AbstractDocumentTitleDisplayer.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/main/java/org/xwiki/display/internal/AbstractDocumentTitleDisplayer.java
@@ -29,7 +29,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.bridge.DocumentAccessBridge;
 import org.xwiki.bridge.DocumentModelBridge;
@@ -158,8 +157,7 @@ public abstract class AbstractDocumentTitleDisplayer implements DocumentDisplaye
 
                 return parseTitle(title);
             } catch (Exception e) {
-                logger.warn("Failed to interpret title of document [{}]. Root cause is [{}]",
-                    document.getDocumentReference(), ExceptionUtils.getRootCauseMessage(e));
+                logger.warn("Failed to interpret title of document [{}]", document.getDocumentReference(), e);
             }
         }
 
@@ -171,8 +169,8 @@ public abstract class AbstractDocumentTitleDisplayer implements DocumentDisplaye
                     return title;
                 }
             } catch (Exception e) {
-                logger.warn("Failed to extract title from content of document [{}]. Root cause is [{}]",
-                    document.getDocumentReference(), ExceptionUtils.getRootCauseMessage(e));
+                logger.warn("Failed to extract title from content of document [{}]",
+                    document.getDocumentReference(), e);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/AbstractRecordableEventDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/AbstractRecordableEventDescriptor.java
@@ -23,7 +23,6 @@ import javax.inject.Inject;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.component.manager.NamespacedComponentManager;
@@ -93,8 +92,7 @@ public abstract class AbstractRecordableEventDescriptor implements RecordableEve
                         () -> contextualLocalizationManager.getTranslationPlain(key));
                 } catch (Exception e) {
                     logger.warn("Failed to render the translation key [{}] in the namespace [{}] for the event "
-                            + "descriptor of [{}]. Root cause is [{}]", key, namespaceOfTheDescriptor, getEventType(),
-                        ExceptionUtils.getRootCauseMessage(e));
+                        + "descriptor of [{}]", key, namespaceOfTheDescriptor, getEventType(), e);
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/AbstractAsynchronousEventStore.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/AbstractAsynchronousEventStore.java
@@ -32,7 +32,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.descriptor.ComponentDescriptor;
 import org.xwiki.component.manager.ComponentLifecycleException;
@@ -315,8 +314,8 @@ public abstract class AbstractAsynchronousEventStore implements EventStore, Init
             try {
                 firstTask = this.queue.take();
             } catch (InterruptedException e) {
-                this.logger.warn("The thread handling asynchronous storage for event store [{}] has been interrupted. "
-                    + "Root cause is [{}]", this.descriptor.getRoleHint(), ExceptionUtils.getRootCauseMessage(e));
+                this.logger.warn("The thread handling asynchronous storage for event store [{}] has been interrupted",
+                    this.descriptor.getRoleHint(), e);
 
                 Thread.currentThread().interrupt();
                 break;
@@ -576,8 +575,8 @@ public abstract class AbstractAsynchronousEventStore implements EventStore, Init
         try {
             this.thread.join(10000);
         } catch (InterruptedException e) {
-            this.logger.warn("The thread handling asynchronous storage for event store [{}] has been interrupted. "
-                + "Root cause is [{}]", this.descriptor.getRoleHint(), ExceptionUtils.getRootCauseMessage(e));
+            this.logger.warn("The thread handling asynchronous storage for event store [{}] has been interrupted",
+                this.descriptor.getRoleHint(), e);
 
             this.thread.interrupt();
         }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/AbstractRecordableEventDescriptorTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/AbstractRecordableEventDescriptorTest.java
@@ -138,13 +138,13 @@ class AbstractRecordableEventDescriptorTest
                 fakeRecordableEventDescriptor.getDescription());
         assertEquals(1, this.logCapture.size());
         assertEquals("Failed to render the translation key [descriptionKey] in the namespace [wiki:subwiki] "
-                + "for the event descriptor of [fake]. Root cause is [Exception: some error]",
+                + "for the event descriptor of [fake]",
             this.logCapture.getMessage(0));
         assertEquals("My nice application name",
                 fakeRecordableEventDescriptor.getApplicationName());
         assertEquals(2, this.logCapture.size());
         assertEquals("Failed to render the translation key [applicationKey] in the namespace [wiki:subwiki] "
-                + "for the event descriptor of [fake]. Root cause is [Exception: some error]",
+                + "for the event descriptor of [fake]",
             this.logCapture.getMessage(1));
     }
 

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/main/java/org/xwiki/eventstream/internal/DefaultUntypedRecordableEventDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/main/java/org/xwiki/eventstream/internal/DefaultUntypedRecordableEventDescriptor.java
@@ -22,7 +22,6 @@ package org.xwiki.eventstream.internal;
 import java.lang.reflect.Type;
 import java.util.List;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.component.namespace.Namespace;
@@ -304,9 +303,8 @@ public class DefaultUntypedRecordableEventDescriptor implements UntypedRecordabl
                 () -> contextualLocalizationManager.getTranslationPlain(key)
             );
         } catch (Exception e) {
-            LOGGER.warn("Failed to render the translation key [{}] in the namespace [{}] for the event "
-                    + "descriptor of [{}]. Root cause is [{}]", key, namespaceOfTheDescriptor, getEventType(),
-                ExceptionUtils.getRootCauseMessage(e));
+            LOGGER.warn("Failed to render the translation key [{}] in the namespace [{}] for the event descriptor of "
+                + "[{}]", key, namespaceOfTheDescriptor, getEventType(), e);
             return contextualLocalizationManager.getTranslationPlain(key);
         }
     }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/main/java/org/xwiki/eventstream/internal/UntypedEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/main/java/org/xwiki/eventstream/internal/UntypedEventListener.java
@@ -31,7 +31,6 @@ import javax.inject.Singleton;
 import javax.script.ScriptContext;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentLookupException;
@@ -202,8 +201,7 @@ public class UntypedEventListener extends AbstractEventListener
             return "true".equals(render);
 
         } catch (Exception e) {
-            logger.warn("Unable to render a notification validation template. Root cause is [{}]",
-                ExceptionUtils.getRootCauseMessage(e));
+            logger.warn("Unable to render a notification validation template", e);
             return false;
         }
     }
@@ -232,8 +230,7 @@ public class UntypedEventListener extends AbstractEventListener
             }
 
         } catch (Exception e) {
-            logger.warn("Unable to render the target template. Root cause is [{}]",
-                ExceptionUtils.getRootCauseMessage(e));
+            logger.warn("Unable to render the target template", e);
         }
 
         // Fallback to empty set

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/test/java/org/xwiki/eventstream/internal/DefaultUntypedRecordableEventDescriptorTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/test/java/org/xwiki/eventstream/internal/DefaultUntypedRecordableEventDescriptorTest.java
@@ -181,7 +181,7 @@ class DefaultUntypedRecordableEventDescriptorTest
             .thenThrow(new Exception("Some error"));
         assertEquals("applicationName", this.descriptor.getApplicationName());
         assertEquals("Failed to render the translation key [applicationName] in the namespace "
-            + "[wiki:someWiki] for the event descriptor of [eventType]. Root cause is [Exception: Some error]",
+            + "[wiki:someWiki] for the event descriptor of [eventType]",
             this.logCapture.getMessage(0));
     }
 
@@ -195,7 +195,7 @@ class DefaultUntypedRecordableEventDescriptorTest
         when(this.namespaceContextExecutor.execute(any(Namespace.class), any(Callable.class))).thenThrow(e);
         assertEquals("eventDescription", this.descriptor.getDescription());
         assertEquals("Failed to render the translation key [eventDescription] in the namespace "
-            + "[wiki:someWiki] for the event descriptor of [eventType]. Root cause is [Exception: Some error]",
+            + "[wiki:someWiki] for the event descriptor of [eventType]",
             this.logCapture.getMessage(0));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-common/src/main/java/org/xwiki/eventstream/store/internal/RecordableEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-common/src/main/java/org/xwiki/eventstream/store/internal/RecordableEventListener.java
@@ -23,7 +23,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentManager;
@@ -97,13 +96,11 @@ public class RecordableEventListener extends AbstractEventListener
         try {
             this.eventStore.saveEvent(convertEvent(event, source, data)).whenComplete((e, ex) -> {
                 if (ex != null) {
-                    logger.warn("Failed to save the event [{}]. Root cause is [{}]",
-                        event.getClass().getCanonicalName(), ExceptionUtils.getRootCauseMessage(ex));
+                    logger.warn("Failed to save the event [{}]", event.getClass().getCanonicalName(), ex);
                 }
             });
         } catch (Exception e) {
-            logger.warn("Failed to convert event [{}]. Root cause is [{}]", event.getClass().getCanonicalName(),
-                ExceptionUtils.getRootCauseMessage(e));
+            logger.warn("Failed to convert event [{}]", event.getClass().getCanonicalName(), e);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-api/src/main/java/org/xwiki/export/pdf/browser/AbstractBrowserPDFPrinter.java
+++ b/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-api/src/main/java/org/xwiki/export/pdf/browser/AbstractBrowserPDFPrinter.java
@@ -325,8 +325,7 @@ public abstract class AbstractBrowserPDFPrinter implements PDFPrinter<URL>
         try {
             return getBrowserManager().isConnected();
         } catch (Exception e) {
-            this.logger.warn("Failed to connect to the web browser used for server-side PDF printing. "
-                + "Root cause is [{}]", ExceptionUtils.getRootCauseMessage(e));
+            this.logger.warn("Failed to connect to the web browser used for server-side PDF printing", e);
             return false;
         }
     }

--- a/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-api/src/test/java/org/xwiki/export/pdf/browser/BrowserPDFPrinterTest.java
+++ b/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-api/src/test/java/org/xwiki/export/pdf/browser/BrowserPDFPrinterTest.java
@@ -271,8 +271,7 @@ class BrowserPDFPrinterTest
         when(this.browserManager.isConnected()).thenThrow(exception);
         assertFalse(this.printer.isAvailable());
 
-        verify(this.logger).warn("Failed to connect to the web browser used for server-side PDF printing. "
-            + "Root cause is [{}]", "RuntimeException: Connection failed!");
+        verify(this.logger).warn("Failed to connect to the web browser used for server-side PDF printing", exception);
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/handler/XarExtensionJobFinishedListener.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/handler/XarExtensionJobFinishedListener.java
@@ -34,7 +34,6 @@ import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.extension.ExtensionContext;
@@ -191,8 +190,8 @@ public class XarExtensionJobFinishedListener implements EventListener
                             }
                         }
                     } catch (Exception e) {
-                        this.logger.warn("Exception when cleaning pages removed since previous xar extension version. "
-                            + "Root cause is [{}]", ExceptionUtils.getRootCauseMessage(e));
+                        this.logger.warn("Exception when cleaning pages removed since previous xar extension version",
+                            e);
                     }
                 }
             }
@@ -261,8 +260,7 @@ public class XarExtensionJobFinishedListener implements EventListener
                 try {
                     job.getStatus().ask(question);
                 } catch (InterruptedException e) {
-                    this.logger.warn("The thread has been interrupted. Root cause is [{}]",
-                        ExceptionUtils.getRootCauseMessage(e));
+                    this.logger.warn("The thread has been interrupted", e);
 
                     // The thread has been interrupted, do nothing
                     return;

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/job/RepairXarJob.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/job/RepairXarJob.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.extension.Extension;
 import org.xwiki.extension.ExtensionDependency;
@@ -322,8 +321,7 @@ public class RepairXarJob extends AbstractExtensionJob<InstallRequest, DefaultJo
                             extensionDependency.getVersionConstraint().getVersion()),
                         namespace, true, new ExtensionPlanContext(extensionContext, extensionDependency));
                 } catch (InstallException e) {
-                    this.logger.warn("Failed to repair dependency [{}]. Root cause is [{}]", extensionDependency,
-                        ExceptionUtils.getRootCauseMessage(e));
+                    this.logger.warn("Failed to repair dependency [{}]", extensionDependency, e);
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-versioncheck/src/main/java/org/xwiki/extension/versioncheck/internal/VersionCheckInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-versioncheck/src/main/java/org/xwiki/extension/versioncheck/internal/VersionCheckInitializer.java
@@ -23,7 +23,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.phase.InitializationException;
@@ -71,8 +70,7 @@ public class VersionCheckInitializer extends AbstractEventListener
             try {
                 environmentVersionCheckTimer.initialize();
             } catch (InitializationException e) {
-                logger.warn("Failed to initialize timer for checking new environment versions. Root cause is [{}]",
-                    ExceptionUtils.getRootCauseMessage(e));
+                logger.warn("Failed to initialize timer for checking new environment versions", e);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/WikiReader.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/WikiReader.java
@@ -161,8 +161,8 @@ public class WikiReader
             }
         } catch (Exception e) {
             if (this.properties.isVerbose()) {
-                this.logger.warn(LOG_DOCUMENT_FAILREAD, "Failed to read XAR XML document from entry [{}]: [{}]",
-                    entry.getName(), ExceptionUtils.getRootCauseMessage(e));
+                this.logger.warn(LOG_DOCUMENT_FAILREAD, "Failed to read XAR XML document from entry [{}]",
+                    entry.getName(), e);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-plugin/src/main/java/com/xpn/xwiki/plugin/image/ImagePlugin.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-plugin/src/main/java/com/xpn/xwiki/plugin/image/ImagePlugin.java
@@ -156,8 +156,7 @@ public class ImagePlugin extends XWikiDefaultPlugin
                     this.capacity = Integer.parseInt(capacityParam.trim());
                 } catch (NumberFormatException e) {
                     LOGGER.warn("Failed to parse the [xwiki.plugin.image.cache.capacity] configuration parameter. "
-                        + "Using [{}] as the cache capacity. Root cause is [{}]", this.capacity,
-                        ExceptionUtils.getRootCauseMessage(e));
+                        + "Using [{}] as the cache capacity", this.capacity, e);
                 }
             }
             lru.setMaxEntries(this.capacity);

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-notifications/xwiki-platform-legacy-notifications-notifiers/xwiki-platform-legacy-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/LiveNotificationEmailListener.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-notifications/xwiki-platform-legacy-notifications-notifiers/xwiki-platform-legacy-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/LiveNotificationEmailListener.java
@@ -25,7 +25,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
@@ -146,8 +145,7 @@ public class LiveNotificationEmailListener extends AbstractEventListener
                 }
 
             } catch (EventStreamException e) {
-                logger.warn("Unable to retrieve a full list of RecordableEventDescriptor. Root cause is [{}]",
-                    ExceptionUtils.getRootCauseMessage(e));
+                logger.warn("Unable to retrieve a full list of RecordableEventDescriptor", e);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/web/TempResourceAction.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/web/TempResourceAction.java
@@ -39,7 +39,6 @@ import jakarta.inject.Inject;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.tika.mime.MimeTypes;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
@@ -120,8 +119,8 @@ public class TempResourceAction extends XWikiAction
         try {
             contentType = TikaUtils.detect(tempFile);
         } catch (IOException ex) {
-            this.logger.warn("Unable to determine mime type for temporary resource [{}]. Root cause is [{}]",
-                tempFile.getAbsolutePath(), ExceptionUtils.getRootCauseMessage(ex));
+            this.logger.warn("Unable to determine mime type for temporary resource [{}]",
+                tempFile.getAbsolutePath(), ex);
         }
         response.setContentType(contentType);
         if ("1".equals(request.getParameter("force-download"))) {

--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-script/src/main/java/org/xwiki/localization/script/LocalizationScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-script/src/main/java/org/xwiki/localization/script/LocalizationScriptService.java
@@ -35,7 +35,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.environment.Environment;
@@ -402,8 +401,7 @@ public class LocalizationScriptService implements ScriptService
             iterator.close();
 
         } catch (Exception e) {
-            this.logger.warn("Exception while looking for XWiki Locales. Root cause is [{}]",
-                ExceptionUtils.getRootCauseMessage(e));
+            this.logger.warn("Exception while looking for XWiki Locales", e);
         }
 
         return locales;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/DeletedDocumentCleanUpFilterProcessingQueue.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/DeletedDocumentCleanUpFilterProcessingQueue.java
@@ -29,7 +29,6 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.apache.commons.lang3.Strings;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentLifecycleException;
@@ -136,8 +135,7 @@ public class DeletedDocumentCleanUpFilterProcessingQueue implements Initializabl
             try {
                 cleanUpFilterData = this.cleanupQueue.take();
             } catch (InterruptedException e) {
-                this.logger.warn("The thread handling filter clean up has been interrupted. Root cause is [{}]",
-                    ExceptionUtils.getRootCauseMessage(e));
+                this.logger.warn("The thread handling filter clean up has been interrupted", e);
                 Thread.currentThread().interrupt();
                 break;
             }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/user/EventUserFilterPreferencesGetter.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/user/EventUserFilterPreferencesGetter.java
@@ -27,7 +27,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.apache.commons.lang3.Strings;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.notifications.NotificationFormat;
@@ -133,8 +132,7 @@ public class EventUserFilterPreferencesGetter
                     && matchAllEvents(pref)
             );
         } catch (Exception e) {
-            logger.warn("Failed to get the list of UserFilter notification preferences. Root cause is [{}]",
-                ExceptionUtils.getRootCauseMessage(e));
+            logger.warn("Failed to get the list of UserFilter notification preferences", e);
             return Stream.empty();
         }
     }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/migrators/ScopeNotificationFilterClassMigrator.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/migrators/ScopeNotificationFilterClassMigrator.java
@@ -131,8 +131,7 @@ public class ScopeNotificationFilterClassMigrator extends AbstractHibernateDataM
                 try {
                     migrateDocument(userDocument);
                 } catch (XWikiException e) {
-                    logger.warn("Failed to migrate document [{}]. Root cause is [{}]", result,
-                        ExceptionUtils.getRootCauseMessage(e));
+                    logger.warn("Failed to migrate document [{}]", result, e);
                 }
             }
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/main/java/org/xwiki/notifications/filters/watch/internal/AutomaticWatchModeListener.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/main/java/org/xwiki/notifications/filters/watch/internal/AutomaticWatchModeListener.java
@@ -26,7 +26,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.bridge.event.DocumentCreatedEvent;
 import org.xwiki.bridge.event.DocumentUpdatedEvent;
@@ -143,8 +142,8 @@ public class AutomaticWatchModeListener extends AbstractEventListener
                 watchedEntitiesManager.watchEntity(
                         factory.createWatchedLocationReference(currentDoc.getDocumentReference()), userReference);
             } catch (NotificationException e) {
-                logger.warn("Failed to watch document [{}] for user [{}]. Root cause is [{}]",
-                        currentDoc.getDocumentReference(), userReference, ExceptionUtils.getRootCauseMessage(e));
+                logger.warn("Failed to watch document [{}] for user [{}]",
+                    currentDoc.getDocumentReference(), userReference, e);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/PrefilteringLiveNotificationEmailManager.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/PrefilteringLiveNotificationEmailManager.java
@@ -26,7 +26,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentLifecycleException;
@@ -105,8 +104,7 @@ public class PrefilteringLiveNotificationEmailManager implements Initializable, 
             try {
                 event = this.preQueue.take();
             } catch (InterruptedException e) {
-                this.logger.warn("The thread handling live event optimization has been interrupted. Root cause is "
-                    + "[{}]", ExceptionUtils.getRootCauseMessage(e));
+                this.logger.warn("The thread handling live event optimization has been interrupted", e);
 
                 Thread.currentThread().interrupt();
                 break;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/AbstractMimeMessageIterator.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/AbstractMimeMessageIterator.java
@@ -351,7 +351,7 @@ public abstract class AbstractMimeMessageIterator implements Iterator<MimeMessag
         try {
             getAttachments().add(this.logoAttachmentExtractor.getLogo());
         } catch (Exception e) {
-            this.logger.warn("Failed to get the logo. Root cause is [{}]", ExceptionUtils.getRootCauseMessage(e));
+            this.logger.warn("Failed to get the logo", e);
         }
     }
 
@@ -379,8 +379,7 @@ public abstract class AbstractMimeMessageIterator implements Iterator<MimeMessag
             try {
                 attachments.add(userAvatarAttachmentExtractor.getUserAvatar(userAvatar, 32));
             } catch (Exception e) {
-                this.logger.warn("Failed to add the avatar of [{}] in the email. Root cause is [{}]", userAvatar,
-                    ExceptionUtils.getRootCauseMessage(e));
+                this.logger.warn("Failed to add the avatar of [{}] in the email", userAvatar, e);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/UserAvatarAttachmentExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/UserAvatarAttachmentExtractor.java
@@ -30,7 +30,6 @@ import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.environment.Environment;
@@ -114,8 +113,7 @@ public class UserAvatarAttachmentExtractor
                     return attachment.getContentInputStream(context);
                 }
             } catch (Exception e) {
-                logger.warn("Failed to get the avatar of [{}]. Fallback to default one. Root cause is [{}]",
-                    userReference, ExceptionUtils.getRootCauseMessage(e));
+                logger.warn("Failed to get the avatar of [{}]. Fallback to default one", userReference, e);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-default/src/main/java/org/xwiki/notifications/preferences/internal/email/DefaultNotificationEmailUserPreferenceManager.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-default/src/main/java/org/xwiki/notifications/preferences/internal/email/DefaultNotificationEmailUserPreferenceManager.java
@@ -29,7 +29,6 @@ import javax.inject.Singleton;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.BaseObject;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.bridge.DocumentAccessBridge;
 import org.xwiki.component.annotation.Component;
@@ -191,8 +190,7 @@ public class DefaultNotificationEmailUserPreferenceManager implements Notificati
                 }
             }
         } catch (Exception e) {
-            logger.warn("Failed to get the email property [{}] for the user [{}]. Root cause is [{}]", propertyName,
-                user, ExceptionUtils.getRootCauseMessage(e));
+            logger.warn("Failed to get the email property [{}] for the user [{}]", propertyName, user, e);
         }
 
         return returnValue;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/TagNotificationFilter.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/TagNotificationFilter.java
@@ -26,7 +26,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.eventstream.Event;
@@ -120,8 +119,7 @@ public class TagNotificationFilter implements NotificationFilter
             return value(EventProperty.PAGE).inStrings(pagesHoldingTags)
                     .and(value(EventProperty.WIKI).eq(value(currentWiki)));
         } catch (QueryException e) {
-            logger.warn("Failed to get the list of documents holding some tags. Root cause is [{}]",
-                ExceptionUtils.getRootCauseMessage(e));
+            logger.warn("Failed to get the list of documents holding some tags", e);
             return null;
         }
     }

--- a/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/main/java/org/xwiki/observation/remote/internal/jgroups/JGroupsNetworkChannel.java
+++ b/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/main/java/org/xwiki/observation/remote/internal/jgroups/JGroupsNetworkChannel.java
@@ -32,7 +32,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Inject;
 import javax.management.MBeanServer;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jgroups.Address;
 import org.jgroups.Global;
 import org.jgroups.JChannel;
@@ -185,8 +184,7 @@ public class JGroupsNetworkChannel implements NetworkChannel, Receiver
             MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
             JmxConfigurator.registerChannel(this.jchannel, mbs, this.jchannel.getClusterName() + '-' + currentMemberId);
         } catch (Exception e) {
-            this.logger.warn("Failed to register channel [{}] against the JMX Server. Root cause is [{}]", getId(),
-                ExceptionUtils.getRootCauseMessage(e));
+            this.logger.warn("Failed to register channel [{}] against the JMX Server", getId(), e);
         }
 
         // Create the mapping between JGroups member address and XWiki observation id
@@ -223,8 +221,7 @@ public class JGroupsNetworkChannel implements NetworkChannel, Receiver
             JmxConfigurator.unregisterChannel(this.jchannel, mbs,
                 this.jchannel.getClusterName() + '-' + currentMemberId);
         } catch (Exception e) {
-            this.logger.warn("Failed to unregister channel [{}] from the JMX Server. Root cause is [{}]", this.id,
-                ExceptionUtils.getRootCauseMessage(e));
+            this.logger.warn("Failed to unregister channel [{}] from the JMX Server", this.id, e);
         }
 
         // Unregister the channel

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/server/DefaultOfficeServer.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/server/DefaultOfficeServer.java
@@ -27,7 +27,6 @@ import java.util.Date;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jodconverter.core.document.JsonDocumentFormatRegistry;
 import org.jodconverter.core.office.OfficeManager;
 import org.jodconverter.local.LocalConverter;
@@ -159,8 +158,8 @@ public class DefaultOfficeServer implements OfficeServer
                     DOCUMENT_FORMATS_PATH);
             }
         } catch (Exception e) {
-            this.logger.warn("Failed to parse [{}]. The default document format registry will be used instead. "
-                + "Root cause is [{}]", DOCUMENT_FORMATS_PATH, ExceptionUtils.getRootCauseMessage(e));
+            this.logger.warn("Failed to parse [{}]. The default document format registry will be used instead",
+                DOCUMENT_FORMATS_PATH, e);
         }
 
         if (this.jodConverter == null) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -1683,8 +1683,8 @@ public class XWiki implements EventListener
                 }
             } catch (Exception e) {
                 // Failed to retrieve the version, log a warning
-                LOGGER.warn("Failed to retrieve XWiki's version from [{}], using the [{}] property. Root cause is "
-                    + "[{}]", VERSION_FILE, VERSION_FILE_PROPERTY, ExceptionUtils.getRootCauseMessage(e));
+                LOGGER.warn("Failed to retrieve XWiki's version from [{}], using the [{}] property",
+                    VERSION_FILE, VERSION_FILE_PROPERTY, e);
             }
 
             if (this.version == null) {
@@ -3974,7 +3974,7 @@ public class XWiki implements EventListener
                 }
             } catch (RuntimeException ex) {
                 LOGGER.warn("Invalid regular expression for the [xwiki.validusername] property. Falling back on the "
-                    + "default one. Root cause is [{}]", ExceptionUtils.getRootCauseMessage(ex));
+                    + "default one", ex);
                 if (!context.getUtil().match(defaultValidationRegex, xwikiname)) {
                     return -4;
                 }
@@ -4014,8 +4014,7 @@ public class XWiki implements EventListener
                 try {
                     sendValidationEmail(xwikiname, password, email, validkey, "validation_email_content", context);
                 } catch (XWikiException e) {
-                    LOGGER.warn("User [{}] created but failed to send the validation mail to them. Root cause is "
-                        + "[{}]", xwikiname, ExceptionUtils.getRootCauseMessage(e));
+                    LOGGER.warn("User [{}] created but failed to send the validation mail to them", xwikiname, e);
                     return -11;
                 }
 
@@ -4503,8 +4502,7 @@ public class XWiki implements EventListener
                         XWikiException.ERROR_XWIKI_ACCESS_DENIED, "Access to this document is denied: " + doc);
                 }
             } catch (XWikiException e) {
-                LOGGER.warn("Failed to include topic [{}]. Root cause is [{}]", topic,
-                    ExceptionUtils.getRootCauseMessage(e));
+                LOGGER.warn("Failed to include topic [{}]", topic, e);
                 return "Topic " + topic + " does not exist";
             }
 
@@ -6076,7 +6074,7 @@ public class XWiki implements EventListener
             LOGGER.debug("Initialized AuthService using Reflection.");
         } catch (Exception e) {
             LOGGER.warn("Failed to initialize the AuthService from class [{}], falling back on the standard "
-                + "authenticator. Root cause is [{}]", authClass.getName(), ExceptionUtils.getRootCauseMessage(e));
+                + "authenticator", authClass.getName(), e);
 
             this.authService = new XWikiAuthServiceImpl();
 
@@ -6109,8 +6107,7 @@ public class XWiki implements EventListener
 
                     if (!DEFAULT_RIGHT_SERVICE_CLASS.equals(rightsClass)) {
                         LOGGER.warn("Failed to initialize custom RightService [{}] by Reflection, using default "
-                            + "implementation [{}]. Root cause is [{}]", rightsClass, DEFAULT_RIGHT_SERVICE_CLASS,
-                            ExceptionUtils.getRootCauseMessage(e));
+                            + "implementation [{}]", rightsClass, DEFAULT_RIGHT_SERVICE_CLASS, e);
                         rightsClass = DEFAULT_RIGHT_SERVICE_CLASS;
                         try {
                             this.rightService = (XWikiRightService) Class.forName(rightsClass).newInstance();
@@ -6177,8 +6174,7 @@ public class XWiki implements EventListener
                 factoryService = (XWikiURLFactoryService) Class.forName(urlFactoryServiceClass)
                     .getConstructor(XWiki.class).newInstance(this);
             } catch (Exception e) {
-                LOGGER.warn("Failed to initialize URLFactory Service [{}]. Root cause is [{}]", urlFactoryServiceClass,
-                    ExceptionUtils.getRootCauseMessage(e));
+                LOGGER.warn("Failed to initialize URLFactory Service [{}]", urlFactoryServiceClass, e);
             }
         }
         if (factoryService == null) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/DeletedAttachment.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/DeletedAttachment.java
@@ -22,7 +22,6 @@ package com.xpn.xwiki.api;
 import java.util.Calendar;
 import java.util.Date;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -131,8 +130,7 @@ public class DeletedAttachment extends Api
                 return new Attachment(doc, attachment, this.context);
             }
         } catch (XWikiException ex) {
-            LOGGER.warn("Failed to restore deleted attachment [{}] of document [{}]. Root cause is [{}]",
-                getFilename(), getDocName(), ExceptionUtils.getRootCauseMessage(ex));
+            LOGGER.warn("Failed to restore deleted attachment [{}] of document [{}]", getFilename(), getDocName(), ex);
         }
 
         return null;
@@ -196,8 +194,7 @@ public class DeletedAttachment extends Api
             return cal.before(Calendar.getInstance());
         } catch (Exception ex) {
             // Public APIs should not throw exceptions
-            LOGGER.warn("Failed to check if entry [{}] can be removed from the recycle bin. Root cause is [{}]",
-                getId(), ExceptionUtils.getRootCauseMessage(ex));
+            LOGGER.warn("Failed to check if entry [{}] can be removed from the recycle bin", getId(), ex);
             return false;
         }
     }
@@ -215,8 +212,8 @@ public class DeletedAttachment extends Api
             try {
                 this.context.getWiki().getAttachmentRecycleBinStore().deleteFromRecycleBin(getId(), this.context, true);
             } catch (Exception ex) {
-                LOGGER.warn("Failed to purge deleted attachment [{}] of document [{}]. Root cause is [{}]",
-                    getFilename(), getDocName(), ExceptionUtils.getRootCauseMessage(ex));
+                LOGGER.warn("Failed to purge deleted attachment [{}] of document [{}]",
+                    getFilename(), getDocName(), ex);
             }
         } else {
             java.lang.Object[] args = { this.getFilename(), this.getDocName() };

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/DeletedDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/DeletedDocument.java
@@ -23,7 +23,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.component.util.DefaultParameterizedType;
@@ -210,8 +209,7 @@ public class DeletedDocument extends Api
             return cal.before(Calendar.getInstance());
         } catch (Exception ex) {
             // Public APIs should not throw exceptions
-            LOGGER.warn("Failed to check if entry [{}] can be removed from the recycle bin. Root cause is [{}]",
-                getId(), ExceptionUtils.getRootCauseMessage(ex));
+            LOGGER.warn("Failed to check if entry [{}] can be removed from the recycle bin", getId(), ex);
             return false;
         }
     }
@@ -238,8 +236,7 @@ public class DeletedDocument extends Api
             try {
                 return new Document(this.deletedDoc.restoreDocument(null, this.context), this.context);
             } catch (XWikiException e) {
-                LOGGER.warn("Failed to restore deleted document [{}]. Root cause is [{}]", getFullName(),
-                    ExceptionUtils.getRootCauseMessage(e));
+                LOGGER.warn("Failed to restore deleted document [{}]", getFullName(), e);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/User.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/User.java
@@ -19,7 +19,6 @@
  */
 package com.xpn.xwiki.api;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.model.EntityType;
@@ -122,8 +121,8 @@ public class User extends Api
                 result = this.user.isUserInGroup(groupName, getXWikiContext());
             }
         } catch (Exception ex) {
-            LOGGER.warn("Unhandled exception while checking if user [{}] belongs to group [{}]. Root cause is [{}]",
-                this.user, groupName, ExceptionUtils.getRootCauseMessage(ex));
+            LOGGER.warn("Unhandled exception while checking if user [{}] belongs to group [{}]",
+                this.user, groupName, ex);
         }
         return result;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
@@ -485,8 +485,7 @@ public class XWiki extends Api
             }
             return result;
         } catch (Exception ex) {
-            LOGGER.warn("Failed to retrieve the deleted attachments of document [{}]. Root cause is [{}]", docName,
-                ExceptionUtils.getRootCauseMessage(ex));
+            LOGGER.warn("Failed to retrieve the deleted attachments of document [{}]", docName, ex);
         }
         return Collections.emptyList();
     }
@@ -517,8 +516,8 @@ public class XWiki extends Api
             }
             return result;
         } catch (Exception ex) {
-            LOGGER.warn("Failed to retrieve the deleted attachments named [{}] of document [{}]. Root cause is [{}]",
-                filename, docName, ExceptionUtils.getRootCauseMessage(ex));
+            LOGGER.warn("Failed to retrieve the deleted attachments named [{}] of document [{}]",
+                filename, docName, ex);
         }
         return Collections.emptyList();
     }
@@ -537,8 +536,7 @@ public class XWiki extends Api
                 return new DeletedAttachment(attachment, this.context);
             }
         } catch (Exception ex) {
-            LOGGER.warn("Failed to retrieve the deleted attachment with id [{}]. Root cause is [{}]", id,
-                ExceptionUtils.getRootCauseMessage(ex));
+            LOGGER.warn("Failed to retrieve the deleted attachment with id [{}]", id, ex);
         }
         return null;
     }
@@ -2405,8 +2403,7 @@ public class XWiki extends Api
         try {
             return this.xwiki.getURLContent(surl, username, password, this.context);
         } catch (Exception e) {
-            LOGGER.warn("Failed to retrieve content from [{}]. Root cause is [{}]", surl,
-                ExceptionUtils.getRootCauseMessage(e));
+            LOGGER.warn("Failed to retrieve content from [{}]", surl, e);
             return "";
         }
     }
@@ -2428,8 +2425,7 @@ public class XWiki extends Api
         try {
             return this.xwiki.getURLContent(surl, this.context);
         } catch (Exception e) {
-            LOGGER.warn("Failed to retrieve content from [{}]. Root cause is [{}]", surl,
-                ExceptionUtils.getRootCauseMessage(e));
+            LOGGER.warn("Failed to retrieve content from [{}]", surl, e);
             return "";
         }
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiAttachment.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiAttachment.java
@@ -1177,11 +1177,9 @@ public class XWikiAttachment implements Cloneable
 
                     this.attachment_archive = store.loadArchive(this, xcontext, true);
                 } catch (Exception e) {
-                    LOGGER.warn(
-                        "Failed to load archive for attachment [{}@{}]. "
-                            + "This attachment is broken, please consider re-uploading it. Root cause is [{}]",
-                        this.doc != null ? this.doc.getDocumentReference() : "<unknown>", getFilename(),
-                        ExceptionUtils.getRootCauseMessage(e));
+                    LOGGER.warn("Failed to load archive for attachment [{}@{}]. This attachment is broken, please "
+                        + "consider re-uploading it",
+                        this.doc != null ? this.doc.getDocumentReference() : "<unknown>", getFilename(), e);
                 }
             } finally {
                 if (currentWiki != null) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -1649,8 +1649,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         } catch (ParseException e) {
             // Failed to render for some reason. This method should normally throw an exception but this
             // requires changing the signature of calling methods too.
-            LOGGER.warn("Failed to render content [{}]. Root cause is [{}]", text,
-                ExceptionUtils.getRootCauseMessage(e));
+            LOGGER.warn("Failed to render content [{}]", text, e);
         }
 
         return "";
@@ -1739,8 +1738,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         } catch (Exception e) {
             // Failed to render for some reason. This method should normally throw an exception but this
             // requires changing the signature of calling methods too.
-            LOGGER.warn("Failed to render content [{}]. Root cause is [{}]", text,
-                ExceptionUtils.getRootCauseMessage(e));
+            LOGGER.warn("Failed to render content [{}]", text, e);
         } finally {
             if (backup != null) {
                 restoreContext(backup, context);
@@ -2739,8 +2737,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
             // may be null (tests)
             // To maintain the behavior of this method we can't throw an exception.
             // Formerly, null was returned if there was no SoftReference.
-            LOGGER.warn("Failed to get the archive of document [{}]. Root cause is [{}]", getDocumentReference(),
-                ExceptionUtils.getRootCauseMessage(e));
+            LOGGER.warn("Failed to get the archive of document [{}]", getDocumentReference(), e);
             return null;
         }
     }
@@ -3331,8 +3328,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
                 return getXObject(resolvedClassReference);
             }
 
-            LOGGER.warn("Failed to access the objects of document [{}]. Root cause is [{}]", getDocumentReference(),
-                ExceptionUtils.getRootCauseMessage(e));
+            LOGGER.warn("Failed to access the objects of document [{}]", getDocumentReference(), e);
             return null;
         }
     }
@@ -4028,9 +4024,8 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         } catch (Exception ex) {
             // TODO: It would better to check if the field exists rather than catching an exception
             // raised by a NPE as this is currently the case here...
-            LOGGER.warn("Failed to display field [{}] in [{}] mode for Object of Class [{}]. Root cause is [{}]",
-                fieldname, type, getDefaultEntityReferenceSerializer().serialize(obj.getDocumentReference()),
-                ExceptionUtils.getRootCauseMessage(ex));
+            LOGGER.warn("Failed to display field [{}] in [{}] mode for Object of Class [{}]",
+                fieldname, type, getDefaultEntityReferenceSerializer().serialize(obj.getDocumentReference()), ex);
             return "";
         } finally {
             if (!backup.isEmpty()) {
@@ -4320,9 +4315,9 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
             syntax = getSyntaxRegistry().resolveSyntax(syntaxId);
         } catch (ParseException e) {
             syntax = getDefaultDocumentSyntax();
-            LOGGER.warn("Failed to set syntax [{}] for [{}], setting syntax [{}] instead. Root cause is [{}]", syntaxId,
-                getDefaultEntityReferenceSerializer().serialize(getDocumentReference()), syntax.toIdString(),
-                ExceptionUtils.getRootCauseMessage(e));
+            LOGGER.warn("Failed to set syntax [{}] for [{}], setting syntax [{}] instead",
+                syntaxId, getDefaultEntityReferenceSerializer().serialize(getDocumentReference()), syntax.toIdString(),
+                e);
         }
         return syntax;
     }
@@ -9620,8 +9615,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
             try {
                 return Utils.getContextComponentManager().getInstance(XWikiAttachmentStoreInterface.class, storeType);
             } catch (ComponentLookupException e) {
-                LOGGER.warn("Can't find attachment content store for type [{}]. Root cause is [{}]", storeType,
-                    ExceptionUtils.getRootCauseMessage(e));
+                LOGGER.warn("Can't find attachment content store for type [{}]", storeType, e);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/DefaultCoreConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/DefaultCoreConfiguration.java
@@ -24,7 +24,6 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.configuration.ConfigurationSource;
@@ -94,8 +93,8 @@ public class DefaultCoreConfiguration implements CoreConfiguration
         try {
             syntax = Syntax.valueOf(syntaxId);
         } catch (ParseException e) {
-            this.logger.warn("Invalid default document Syntax [{}], defaulting to [{}] instead. Root cause is [{}]",
-                syntaxId, Syntax.XWIKI_2_1.toIdString(), ExceptionUtils.getRootCauseMessage(e));
+            this.logger.warn("Invalid default document Syntax [{}], defaulting to [{}] instead",
+                syntaxId, Syntax.XWIKI_2_1.toIdString(), e);
             syntax = Syntax.XWIKI_2_1;
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/context/XWikiContextContextStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/context/XWikiContextContextStore.java
@@ -602,8 +602,7 @@ public class XWikiContextContextStore extends AbstractContextStore
                     restoreDocument(wikiDescriptor.getMainPageReference(), xcontext);
                 }
             } catch (WikiManagerException e) {
-                this.logger.warn("Can't access the descriptor of the restored context wiki [{}]. Root cause is [{}]",
-                    storedWikiId, ExceptionUtils.getRootCauseMessage(e));
+                this.logger.warn("Can't access the descriptor of the restored context wiki [{}]", storedWikiId, e);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/export/OfficeExporter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/export/OfficeExporter.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.officeimporter.converter.OfficeConverter;
@@ -126,8 +125,7 @@ public class OfficeExporter extends PdfExportImpl
                 // Embedded files are placed in the same folder as the HTML input file during office conversion.
                 inputStreams.put(file.getName(), new FileInputStream(file));
             } catch (Exception e) {
-                LOGGER.warn("Failed to embed [{}] in the office export. Root cause is [{}]", file.getName(),
-                    ExceptionUtils.getRootCauseMessage(e));
+                LOGGER.warn("Failed to embed [{}] in the office export", file.getName(), e);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/query/ConfiguredQueryExecutorProvider.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/query/ConfiguredQueryExecutorProvider.java
@@ -75,10 +75,9 @@ public class ConfiguredQueryExecutorProvider implements Provider<QueryExecutor>
         try {
             context = (XWikiContext) this.exec.getContext().getProperty("xwikicontext");
         } catch (NullPointerException e) {
-            this.logger.warn("The QueryExecutor was called without an XWikiContext available. "
-                + "This means the old core (and likely the storage engine) is probably "
-                + "not yet initialized. The default QueryExecutor will be returned. Root cause is [{}]",
-                ExceptionUtils.getRootCauseMessage(e));
+            this.logger.warn("The QueryExecutor was called without an XWikiContext available. This means the old "
+                + "core (and likely the storage engine) is probably not yet initialized. The default QueryExecutor "
+                + "will be returned", e);
             return;
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/sheet/AbstractSheetBinder.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/sheet/AbstractSheetBinder.java
@@ -150,8 +150,7 @@ public abstract class AbstractSheetBinder implements SheetBinder, Initializable
             }
             return documentReferences;
         } catch (QueryException e) {
-            this.logger.warn("Failed to query sheet bindings. Root cause is [{}]",
-                ExceptionUtils.getRootCauseMessage(e));
+            this.logger.warn("Failed to query sheet bindings", e);
             return Collections.emptyList();
         }
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/sheet/DefaultModelBridge.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/sheet/DefaultModelBridge.java
@@ -90,8 +90,7 @@ public class DefaultModelBridge implements ModelBridge
             } catch (XWikiException e) {
                 String stringReference =
                     this.defaultEntityReferenceSerializer.serialize(document.getDocumentReference());
-                this.logger.warn("Failed to load the default translation of [{}]. Root cause is [{}]", stringReference,
-                    ExceptionUtils.getRootCauseMessage(e));
+                this.logger.warn("Failed to load the default translation of [{}]", stringReference, e);
             }
         }
         return document;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/PropertyConverter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/PropertyConverter.java
@@ -25,7 +25,6 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 
@@ -88,9 +87,8 @@ public class PropertyConverter
                     try {
                         newProperty = modifiedPropertyClass.fromString(storedProperty.toText());
                     } catch (XWikiException ex) {
-                        this.logger.warn("Incompatible data migration when changing field [{}] of class [{}]. Root "
-                            + "cause is [{}]", modifiedPropertyClass.getName(), modifiedPropertyClass.getClassName(),
-                            ExceptionUtils.getRootCauseMessage(ex));
+                        this.logger.warn(errorLog, modifiedPropertyClass.getName(),
+                            modifiedPropertyClass.getClassName(), ex);
                     }
                 }
                 if (newProperty != null) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/GroupsClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/GroupsClass.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.dom4j.Element;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.model.reference.EntityReference;
@@ -103,8 +102,7 @@ public class GroupsClass extends ListClass
             return (List<String>) context.getWiki().getGroupService(context)
                 .getAllMatchedGroups(null, false, 0, 0, null, context);
         } catch (XWikiException e) {
-            LOGGER.warn("Failed to retrieve the list of groups. Root cause is [{}]",
-                ExceptionUtils.getRootCauseMessage(e));
+            LOGGER.warn("Failed to retrieve the list of groups", e);
             return Collections.emptyList();
         }
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/UsersClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/UsersClass.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.dom4j.Element;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.model.reference.EntityReference;
@@ -113,8 +112,7 @@ public class UsersClass extends ListClass
             return (List<String>) context.getWiki().getGroupService(context)
                 .getAllMatchedUsers(null, false, 0, 0, null, context);
         } catch (XWikiException e) {
-            LOGGER.warn("Failed to retrieve the list of users. Root cause is [{}]",
-                ExceptionUtils.getRootCauseMessage(e));
+            LOGGER.warn("Failed to retrieve the list of users", e);
             return Collections.emptyList();
         }
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactory.java
@@ -34,7 +34,6 @@ import java.util.Objects;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.model.reference.AttachmentReference;
@@ -70,7 +69,7 @@ public class FileSystemURLFactory extends XWikiServletURLFactory
     private static final String FILE_MAPPING_KEY = "pdfexport-file-mapping";
 
     /** Logged when an attachment cannot be copied to the temporary export folder. */
-    private static final String SAVE_IMAGE_ERROR = "Failed to save image for PDF export. Root cause is [{}]";
+    private static final String SAVE_IMAGE_ERROR = "Failed to save image for PDF export";
 
     private LegacySpaceResolver legacySpaceResolver = Utils.getComponent(LegacySpaceResolver.class);
 
@@ -103,7 +102,7 @@ public class FileSystemURLFactory extends XWikiServletURLFactory
         try {
             return getURL(wiki, spaces, name, filename, null, context);
         } catch (Exception ex) {
-            LOGGER.warn(SAVE_IMAGE_ERROR, ExceptionUtils.getRootCauseMessage(ex));
+            LOGGER.warn(SAVE_IMAGE_ERROR, ex);
             return super.createAttachmentURL(filename, spaces, name, action, null, wiki, context);
         }
     }
@@ -115,7 +114,7 @@ public class FileSystemURLFactory extends XWikiServletURLFactory
         try {
             return getURL(wiki, spaces, name, filename, revision, context);
         } catch (Exception ex) {
-            LOGGER.warn(SAVE_IMAGE_ERROR, ExceptionUtils.getRootCauseMessage(ex));
+            LOGGER.warn(SAVE_IMAGE_ERROR, ex);
             return super.createAttachmentRevisionURL(filename, spaces, name, revision, wiki, context);
         }
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/PdfExportImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/PdfExportImpl.java
@@ -174,8 +174,7 @@ public class PdfExportImpl implements PdfExport
                 FileUtils.deleteDirectory(tempdir);
             } catch (IOException ex) {
                 // Should not happen, but it's nothing serious, just that temporary files are left on the disk.
-                LOGGER.warn("Failed to cleanup temporary files after a PDF export. Root cause is [{}]",
-                    ExceptionUtils.getRootCauseMessage(ex));
+                LOGGER.warn("Failed to cleanup temporary files after a PDF export", ex);
             }
         }
     }
@@ -378,8 +377,7 @@ public class PdfExportImpl implements PdfExport
             LOGGER.debug("HTML with CSS applied [{}]", result);
             return result;
         } catch (Exception e) {
-            LOGGER.warn("Failed to apply CSS [{}] to HTML [{}]. Root cause is [{}]", css, html,
-                ExceptionUtils.getRootCauseMessage(e));
+            LOGGER.warn("Failed to apply CSS [{}] to HTML [{}]", css, html, e);
             return html;
         }
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/fileupload/FileUploadPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/fileupload/FileUploadPlugin.java
@@ -29,7 +29,6 @@ import java.util.List;
 
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.poi.util.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -169,8 +168,7 @@ public class FileUploadPlugin extends XWikiDefaultPlugin
                 try {
                     item.delete();
                 } catch (Exception ex) {
-                    LOGGER.warn("Failed to clean uploaded file [{}]. Root cause is [{}]", item.getName(),
-                        ExceptionUtils.getRootCauseMessage(ex));
+                    LOGGER.warn("Failed to clean uploaded file [{}]", item.getName(), ex);
                 }
             }
             context.remove(FILE_LIST_KEY);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/rightsmanager/RightsManagerListener.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/rightsmanager/RightsManagerListener.java
@@ -22,7 +22,6 @@ package com.xpn.xwiki.plugin.rightsmanager;
 
 import java.util.List;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.bridge.event.DocumentDeletedEvent;
@@ -118,15 +117,13 @@ public final class RightsManagerListener implements EventListener
                 try {
                     cleanDeletedUserOrGroup(userOrGroupWiki, userOrGroupSpace, userOrGroupName, true, context);
                 } catch (XWikiException e) {
-                    LOGGER.warn("Failed to clean the rights of deleted user [{}]. Root cause is [{}]", userOrGroupName,
-                        ExceptionUtils.getRootCauseMessage(e));
+                    LOGGER.warn("Failed to clean the rights of deleted user [{}]", userOrGroupName, e);
                 }
             } else if (document.getObject("XWiki.XWikiGroups") != null) {
                 try {
                     cleanDeletedUserOrGroup(userOrGroupWiki, userOrGroupSpace, userOrGroupName, false, context);
                 } catch (XWikiException e) {
-                    LOGGER.warn("Failed to clean the rights of deleted group [{}]. Root cause is [{}]",
-                        userOrGroupName, ExceptionUtils.getRootCauseMessage(e));
+                    LOGGER.warn("Failed to clean the rights of deleted group [{}]", userOrGroupName, e);
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/script/display/DisplayScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/script/display/DisplayScriptService.java
@@ -28,7 +28,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.bridge.DocumentModelBridge;
 import org.xwiki.component.annotation.Component;
@@ -180,8 +179,8 @@ public class DisplayScriptService implements ScriptService
         try {
             content = document.getTranslatedContent();
         } catch (XWikiException e) {
-            this.logger.warn("Failed to get the translated content of document [{}]. Root cause is [{}]",
-                document.getPrefixedFullName(), ExceptionUtils.getRootCauseMessage(e));
+            this.logger.warn("Failed to get the translated content of document [{}]",
+                document.getPrefixedFullName(), e);
             return null;
         }
         String renderedContent =

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateAttachmentStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateAttachmentStore.java
@@ -422,8 +422,7 @@ public class XWikiHibernateAttachmentStore extends XWikiHibernateBaseStore imple
             try {
                 return this.componentManager.getInstance(AttachmentVersioningStore.class, storeType);
             } catch (ComponentLookupException e) {
-                this.logger.warn("Can't find attachment versioning store for type [{}]. Root cause is [{}]", storeType,
-                    ExceptionUtils.getRootCauseMessage(e));
+                this.logger.warn("Can't find attachment versioning store for type [{}]", storeType, e);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateRecycleBinStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateRecycleBinStore.java
@@ -33,7 +33,6 @@ import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
@@ -213,8 +212,7 @@ public class XWikiHibernateRecycleBinStore extends XWikiHibernateBaseStore imple
             try {
                 return this.componentManager.getInstance(XWikiRecycleBinContentStoreInterface.class, storeType);
             } catch (ComponentLookupException e) {
-                this.logger.warn("Can't find recycle bin content store for type [{}]. Root cause is [{}]", storeType,
-                    ExceptionUtils.getRootCauseMessage(e));
+                this.logger.warn("Can't find recycle bin content store for type [{}]", storeType, e);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/HibernateAttachmentRecycleBinStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/HibernateAttachmentRecycleBinStore.java
@@ -32,7 +32,6 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.hibernate.Session;
 import org.slf4j.Logger;
@@ -281,8 +280,7 @@ public class HibernateAttachmentRecycleBinStore extends XWikiHibernateBaseStore 
             try {
                 return this.componentManager.getInstance(AttachmentRecycleBinContentStore.class, storeType);
             } catch (ComponentLookupException e) {
-                this.logger.warn("Can't find attachment recycle bin content store for type [{}]. Root cause is [{}]",
-                    storeType, ExceptionUtils.getRootCauseMessage(e));
+                this.logger.warn("Can't find attachment recycle bin content store for type [{}]", storeType, e);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R140600000XWIKI19869DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R140600000XWIKI19869DataMigration.java
@@ -193,8 +193,7 @@ public class R140600000XWIKI19869DataMigration extends AbstractHibernateDataMigr
             // We don't throw an exception because it might be only a problem with the count
             // and this is only used for log purpose.
             // In case of real issue on the query, it will throw an exception when actually getting the users
-            this.logger.warn("Error while trying to count the number of users. Root cause is [{}]",
-                ExceptionUtils.getRootCauseMessage(e));
+            this.logger.warn("Error while trying to count the number of users", e);
         }
         return result;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/UploadAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/UploadAction.java
@@ -139,8 +139,7 @@ public class UploadAction extends XWikiAction
             try {
                 uploadAttachment(file.getValue(), file.getKey(), fileupload, doc, context);
             } catch (Exception ex) {
-                this.logger.warn("Failed to save uploaded file [{}]. Root cause is [{}]", file.getKey(),
-                    ExceptionUtils.getRootCauseMessage(ex));
+                this.logger.warn("Failed to save uploaded file [{}]", file.getKey(), ex);
                 failedFiles.put(file.getKey(), ExceptionUtils.getRootCauseMessage(ex));
             }
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiAction.java
@@ -707,8 +707,7 @@ public abstract class XWikiAction implements LegacyAction
                         if ("IOException: Broken pipe".equals(ExceptionUtils.getRootCauseMessage(e))) {
                             return;
                         }
-                        LOGGER.warn("Uncaught exception. Root cause is [{}]",
-                            ExceptionUtils.getRootCauseMessage(e));
+                        LOGGER.warn("Uncaught exception", e);
                     }
                     // If the request is an AJAX request, we don't return a whole HTML page, but just the exception
                     // inline.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/internal/script/XWikiScriptContextInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/internal/script/XWikiScriptContextInitializer.java
@@ -25,7 +25,6 @@ import javax.inject.Provider;
 import javax.inject.Singleton;
 import javax.script.ScriptContext;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.script.ScriptContextInitializer;
@@ -105,9 +104,8 @@ public class XWikiScriptContextInitializer implements ScriptContextInitializer
                 try {
                     tdoc = doc.getTranslatedDocument(xcontext);
                 } catch (XWikiException e) {
-                    this.logger.warn("Failed to retrieve the translated document for [{}]. "
-                        + "Continue using the default translation. Root cause is [{}]", doc.getDocumentReference(),
-                        ExceptionUtils.getRootCauseMessage(e));
+                    this.logger.warn("Failed to retrieve the translated document for [{}]. Continue using the "
+                        + "default translation", doc.getDocumentReference(), e);
                     tdoc = doc;
                 }
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentTest.java
@@ -877,8 +877,8 @@ class XWikiDocumentTest
 
         assertEquals("Page", this.document.getRenderedTitle(this.oldcore.getXWikiContext()));
 
-        assertEquals("Failed to interpret title of document [Wiki:Space.Page]. Root cause is "
-            + "[XWikiVelocityException: message]", this.logCapture.getLogEvent(0).getFormattedMessage());
+        assertEquals("Failed to interpret title of document [Wiki:Space.Page]",
+            this.logCapture.getLogEvent(0).getFormattedMessage());
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultModelBridge.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultModelBridge.java
@@ -238,8 +238,7 @@ public class DefaultModelBridge implements ModelBridge
             return true;
         } catch (Exception e) {
             // Just warn, since it's a recoverable situation.
-            this.logger.warn("Failed to unlock document [{}]. Root cause is [{}]", reference,
-                ExceptionUtils.getRootCauseMessage(e));
+            this.logger.warn("Failed to unlock document [{}]", reference, e);
             return false;
         }
     }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultModelBridgeTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultModelBridgeTest.java
@@ -101,13 +101,6 @@ import static org.mockito.Mockito.when;
 @ComponentTest
 class DefaultModelBridgeTest
 {
-    /**
-     * The root cause reported when the recycle bin rights check fails, because this test doesn't load all the oldcore
-     * components that check needs.
-     */
-    private static final String RIGHTS_CHECK_CAUSE = "ComponentLookupException: Can't find descriptor for the component "
-        + "with type [javax.inject.Provider<org.xwiki.model.reference.DocumentReference>] and hint [default]";
-
     @RegisterExtension
     private LogCaptureExtension logCapture = new LogCaptureExtension();
 
@@ -685,8 +678,7 @@ class DefaultModelBridgeTest
         // this could be improved later: right now we don't get the rights in the test because the components are not
         // all properly loaded from oldcore.
         assertLog(0, Level.WARN,
-            "Failed to check if entry [{}] can be removed from the recycle bin. Root cause is [{}]", deletedDocumentId,
-            RIGHTS_CHECK_CAUSE);
+            "Failed to check if entry [{}] can be removed from the recycle bin", deletedDocumentId);
     }
 
     @Test
@@ -885,8 +877,7 @@ class DefaultModelBridgeTest
         assertFalse(this.modelBridge.permanentlyDeleteDocument(deletedDocumentId, request));
 
         assertLog(0, Level.WARN,
-            "Failed to check if entry [{}] can be removed from the recycle bin. Root cause is [{}]", deletedDocumentId,
-            RIGHTS_CHECK_CAUSE);
+            "Failed to check if entry [{}] can be removed from the recycle bin", deletedDocumentId);
         assertLog(1, Level.ERROR, "You are not allowed to permanently delete document [{}] with ID [{}]",
             documentReference, deletedDocumentId);
         verify(recycleBin, never()).deleteFromRecycleBin(anyLong(), any(), anyBoolean());

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/RegisterMacrosOnImportListener.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/RegisterMacrosOnImportListener.java
@@ -27,7 +27,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.context.Execution;
@@ -103,8 +102,7 @@ public class RegisterMacrosOnImportListener implements EventListener
             String currentWiki = xcontext.getWikiId();
             macroInitializer.registerExistingWikiMacros(currentWiki);
         } catch (Exception e) {
-            this.logger.warn("Could not register existing macros on import. Root cause is [{}]",
-                ExceptionUtils.getRootCauseMessage(e));
+            this.logger.warn("Could not register existing macros on import", e);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrIndexer.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrIndexer.java
@@ -35,7 +35,6 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.solr.common.SolrInputDocument;
 import org.slf4j.Logger;
 import org.xwiki.bridge.internal.DocumentContextExecutor;
@@ -242,8 +241,8 @@ public class DefaultSolrIndexer implements SolrIndexer, Initializable, Disposabl
                 try {
                     dispatchQueueEntry(queueEntry);
                 } catch (Throwable e) {
-                    logger.warn("Failed to apply operation [{}] on root reference [{}]. Root cause is [{}]",
-                        queueEntry.operation, queueEntry.reference, ExceptionUtils.getRootCauseMessage(e));
+                    logger.warn("Failed to apply operation [{}] on root reference [{}]",
+                        queueEntry.operation, queueEntry.reference, e);
                 } finally {
                     // Decrement only for entries submitted via addToQueue(); READY_MARKER entries come from
                     // waitReady() which does not increment pendingResolveItems.
@@ -303,8 +302,7 @@ public class DefaultSolrIndexer implements SolrIndexer, Initializable, Disposabl
                 queueEntry = resolveQueue.take();
                 DefaultSolrIndexer.this.resolveQueueRemovalCounter.incrementAndGet();
             } catch (InterruptedException e) {
-                logger.warn("The SOLR resolve thread has been interrupted. Root cause is [{}]",
-                    ExceptionUtils.getRootCauseMessage(e));
+                logger.warn("The SOLR resolve thread has been interrupted", e);
                 queueEntry = RESOLVE_QUEUE_ENTRY_STOP;
             }
             return queueEntry;
@@ -524,8 +522,7 @@ public class DefaultSolrIndexer implements SolrIndexer, Initializable, Disposabl
             try {
                 queueEntry = this.indexQueue.take();
             } catch (InterruptedException e) {
-                this.logger.warn("The SOLR index thread has been interrupted. Root cause is [{}]",
-                    ExceptionUtils.getRootCauseMessage(e));
+                this.logger.warn("The SOLR index thread has been interrupted", e);
 
                 queueEntry = INDEX_QUEUE_ENTRY_STOP;
             }
@@ -759,8 +756,7 @@ public class DefaultSolrIndexer implements SolrIndexer, Initializable, Disposabl
         try {
             result = this.componentManager.getInstance(SolrMetadataExtractor.class, entityType.name().toLowerCase());
         } catch (ComponentLookupException e) {
-            this.logger.warn("Unsupported entity type: [{}]. Root cause is [{}]", entityType,
-                ExceptionUtils.getRootCauseMessage(e));
+            this.logger.warn("Unsupported entity type: [{}]", entityType, e);
         }
 
         return result;

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-query/src/main/java/org/xwiki/query/solr/internal/SolrQueryExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-query/src/main/java/org/xwiki/query/solr/internal/SolrQueryExecutor.java
@@ -30,7 +30,6 @@ import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
@@ -244,8 +243,7 @@ public class SolrQueryExecutor extends AbstractQueryExecutor
             } catch (Exception e) {
                 // Don't take any risk of including a result for which we cannot determine the document reference and
                 // thus cannot determine if the given users have access to it or not.
-                this.logger.warn("Removing bad result: [{}]. Root cause is [{}]", result,
-                    ExceptionUtils.getRootCauseMessage(e));
+                this.logger.warn("Removing bad result: [{}]", result, e);
             }
 
             // FIXME: We should update maxScore as well when removing the top scored item. How do we do that?

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-query/src/test/java/org/xwiki/query/solr/internal/SolrQueryExecutorTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-query/src/test/java/org/xwiki/query/solr/internal/SolrQueryExecutorTest.java
@@ -275,11 +275,11 @@ class SolrQueryExecutorTest
         assertEquals(0, results.getNumFound());
 
         // One warning for Alice in the previous execution, two for Alice and Bob in this one.
-        assertEquals("Removing bad result: [SolrDocument{}]. Root cause is [RuntimeException: Alice]",
+        assertEquals("Removing bad result: [SolrDocument{}]",
             this.logCapture.getMessage(0));
-        assertEquals("Removing bad result: [SolrDocument{}]. Root cause is [RuntimeException: Alice]",
+        assertEquals("Removing bad result: [SolrDocument{}]",
             this.logCapture.getMessage(1));
-        assertEquals("Removing bad result: [SolrDocument{}]. Root cause is [RuntimeException: Bob]",
+        assertEquals("Removing bad result: [SolrDocument{}]",
             this.logCapture.getMessage(2));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-sheet/xwiki-platform-sheet-api/src/main/java/org/xwiki/sheet/internal/SheetDocumentDisplayer.java
+++ b/xwiki-platform-core/xwiki-platform-sheet/xwiki-platform-sheet-api/src/main/java/org/xwiki/sheet/internal/SheetDocumentDisplayer.java
@@ -27,7 +27,6 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.bridge.DocumentAccessBridge;
 import org.xwiki.bridge.DocumentModelBridge;
@@ -181,8 +180,7 @@ public class SheetDocumentDisplayer implements DocumentDisplayer
                     return applySheet(document, sheetReference, parameters);
                 } catch (Exception e) {
                     String sheetStringReference = defaultEntityReferenceSerializer.serialize(sheetReference);
-                    logger.warn("Failed to apply sheet [{}]. Root cause is [{}]", sheetStringReference,
-                        ExceptionUtils.getRootCauseMessage(e));
+                    logger.warn("Failed to apply sheet [{}]", sheetStringReference, e);
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-sheet/xwiki-platform-sheet-api/src/test/java/org/xwiki/sheet/internal/SheetDocumentDisplayerTest.java
+++ b/xwiki-platform-core/xwiki-platform-sheet/xwiki-platform-sheet-api/src/test/java/org/xwiki/sheet/internal/SheetDocumentDisplayerTest.java
@@ -272,7 +272,7 @@ class SheetDocumentDisplayerTest
 
         assertSame(output, this.displayer.display(document, parameters));
 
-        assertEquals("Failed to apply sheet [wiki2:Code.Sheet]. Root cause is [Exception: Database is down]",
+        assertEquals("Failed to apply sheet [wiki2:Code.Sheet]",
             this.logCapture.getMessage(0));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/sx/CssExtension.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/sx/CssExtension.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,8 +61,7 @@ public class CssExtension implements Extension
                 compressor.compress(out, -1);
                 return out.toString();
             } catch (IOException ex) {
-                LOGGER.warn("Failed to compress the SSX code. Root cause is [{}]",
-                    ExceptionUtils.getRootCauseMessage(ex));
+                LOGGER.warn("Failed to compress the SSX code", ex);
             }
             return source;
         };

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentStore.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentStore.java
@@ -26,7 +26,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hibernate.Session;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
@@ -532,8 +531,7 @@ public class FilesystemAttachmentStore implements XWikiAttachmentStoreInterface
             try {
                 return this.componentManager.getInstance(AttachmentVersioningStore.class, storeType);
             } catch (ComponentLookupException e) {
-                this.logger.warn("Can't find attachment versioning store for type [{}]. Root cause is [{}]", storeType,
-                    ExceptionUtils.getRootCauseMessage(e));
+                this.logger.warn("Can't find attachment versioning store for type [{}]", storeType, e);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/DockerTestUtils.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/DockerTestUtils.java
@@ -339,7 +339,7 @@ public final class DockerTestUtils
             InetAddress ip = InetAddress.getLocalHost();
             hostname = ip.getHostName();
         } catch (Exception e) {
-            LOGGER.warn("Failed to get hostname. Root cause is [{}]", ExceptionUtils.getRootCauseMessage(e));
+            LOGGER.warn("Failed to get hostname", e);
             hostname = "Unknown";
         }
         return hostname;

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/StopFileWatcher.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/StopFileWatcher.java
@@ -28,7 +28,6 @@ import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,8 +78,7 @@ final class StopFileWatcher
                     LOGGER.warn("Not deleting non-empty file [{}], please delete it manually.", target);
                 }
             } catch (IOException e) {
-                LOGGER.warn("Could not delete existing file [{}]. Root cause is [{}]", target,
-                    ExceptionUtils.getRootCauseMessage(e));
+                LOGGER.warn("Could not delete existing file [{}]", target, e);
             }
         }
 
@@ -111,8 +109,7 @@ final class StopFileWatcher
                 }
             }
         } catch (IOException e) {
-            LOGGER.warn("WatchService failed, falling back to blocking wait for [{}]. Root cause is [{}]",
-                target.getFileName(), ExceptionUtils.getRootCauseMessage(e));
+            LOGGER.warn("WatchService failed, falling back to blocking wait for [{}]", target.getFileName(), e);
             return false;
         } catch (InterruptedException e) {
             LOGGER.error(WAIT_FAILED_MESSAGE, target.getFileName(), e);

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-script/src/main/java/org/xwiki/user/script/GroupScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-script/src/main/java/org/xwiki/user/script/GroupScriptService.java
@@ -25,7 +25,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
@@ -174,14 +173,12 @@ public class GroupScriptService implements ScriptService
                     try {
                         ret = !getMembers(candidate, true).contains(target);
                     } catch (GroupException e) {
-                        this.logger.warn("Failed to access the members of the candidate group [{}]. "
-                            + "Root cause is [{}]", candidate, ExceptionUtils.getRootCauseMessage(e));
+                        this.logger.warn("Failed to access the members of the candidate group [{}]", candidate, e);
                         ret = false;
                     }
                 }
             } catch (GroupException e) {
-                this.logger.warn("Failed to access the members of the target group [{}]. Root cause is [{}]", target,
-                    ExceptionUtils.getRootCauseMessage(e));
+                this.logger.warn("Failed to access the members of the target group [{}]", target, e);
                 ret = false;
             }
         }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-script/src/test/java/org/xwiki/user/script/GroupScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-script/src/test/java/org/xwiki/user/script/GroupScriptServiceTest.java
@@ -199,8 +199,8 @@ class GroupScriptServiceTest
         verify(this.groupManager, never()).getMembers(CANDIDATE_GROUP, true);
         assertEquals(1, this.logCapture.size());
         assertEquals(Level.WARN, this.logCapture.getLogEvent(0).getLevel());
-        assertEquals("Failed to access the members of the target group [xwiki:XWiki.Target]. Root cause is "
-            + "[GroupException: target failure]", this.logCapture.getMessage(0));
+        assertEquals("Failed to access the members of the target group [xwiki:XWiki.Target]",
+            this.logCapture.getMessage(0));
     }
 
     @Test
@@ -214,7 +214,7 @@ class GroupScriptServiceTest
         assertFalse(actual);
         assertEquals(1, this.logCapture.size());
         assertEquals(Level.WARN, this.logCapture.getLogEvent(0).getLevel());
-        assertEquals("Failed to access the members of the candidate group [xwiki:XWiki.Added]. Root cause is "
-            + "[GroupException: candidate failure]", this.logCapture.getMessage(0));
+        assertEquals("Failed to access the members of the candidate group [xwiki:XWiki.Added]",
+            this.logCapture.getMessage(0));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-websocket/src/main/java/org/xwiki/websocket/AbstractXWikiEndpoint.java
+++ b/xwiki-platform-core/xwiki-platform-websocket/src/main/java/org/xwiki/websocket/AbstractXWikiEndpoint.java
@@ -144,8 +144,7 @@ public abstract class AbstractXWikiEndpoint extends Endpoint implements Endpoint
         try {
             session.close(new CloseReason(closeCode, reasonPhrase));
         } catch (IOException e) {
-            this.logger.warn("Failed to close the session. Root cause is [{}]",
-                ExceptionUtils.getRootCauseMessage(e));
+            this.logger.warn("Failed to close the session", e);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-websocket/src/main/java/org/xwiki/websocket/internal/DefaultWebSocketContext.java
+++ b/xwiki-platform-core/xwiki-platform-websocket/src/main/java/org/xwiki/websocket/internal/DefaultWebSocketContext.java
@@ -30,7 +30,6 @@ import jakarta.websocket.Session;
 import jakarta.websocket.server.HandshakeRequest;
 import jakarta.websocket.server.ServerEndpointConfig;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.container.Container;
@@ -216,8 +215,7 @@ public class DefaultWebSocketContext implements WebSocketContext
                     xcontext.setUserReference(xwikiUser.getUserReference());
                 }
             } catch (Exception e) {
-                this.logger.warn("Failed to authenticate the user for [{}]. Root cause is [{}]",
-                    request.getRequestURI(), ExceptionUtils.getRootCauseMessage(e));
+                this.logger.warn("Failed to authenticate the user for [{}]", request.getRequestURI(), e);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-websocket/src/main/java/org/xwiki/websocket/internal/StaticEchoEndpoint.java
+++ b/xwiki-platform-core/xwiki-platform-websocket/src/main/java/org/xwiki/websocket/internal/StaticEchoEndpoint.java
@@ -30,7 +30,6 @@ import jakarta.websocket.OnOpen;
 import jakarta.websocket.Session;
 import jakarta.websocket.server.ServerEndpoint;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.bridge.DocumentAccessBridge;
 import org.xwiki.component.annotation.Component;
@@ -77,8 +76,7 @@ public class StaticEchoEndpoint implements EndpointComponent
                     session.close(new CloseReason(CloseReason.CloseCodes.CANNOT_ACCEPT,
                         "We don't accept connections from guest users. Please login first."));
                 } catch (IOException e) {
-                    this.logger.warn("Failed to close the session. Root cause is [{}]",
-                        ExceptionUtils.getRootCauseMessage(e));
+                    this.logger.warn("Failed to close the session", e);
                 }
             }
         });

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/descriptor/properties/DefaultWikiPropertyGroupManager.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/descriptor/properties/DefaultWikiPropertyGroupManager.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.wiki.descriptor.WikiDescriptor;
@@ -58,8 +57,7 @@ public class DefaultWikiPropertyGroupManager implements WikiPropertyGroupManager
             try {
                 descriptor.addPropertyGroup(provider.get(wikiId));
             } catch (WikiPropertyGroupException e) {
-                logger.warn("Unable to load property groups [{}]. Root cause is [{}]", propertyGroupName,
-                    ExceptionUtils.getRootCauseMessage(e));
+                logger.warn("Unable to load property groups [{}]", propertyGroupName, e);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-xml/xwiki-platform-xml-script/src/main/java/org/xwiki/xml/script/XMLScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-xml/xwiki-platform-xml-script/src/main/java/org/xwiki/xml/script/XMLScriptService.java
@@ -31,7 +31,6 @@ import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamSource;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.w3c.dom.Document;
@@ -70,8 +69,7 @@ public class XMLScriptService implements ScriptService, Initializable
         try {
             this.lsImpl = (DOMImplementationLS) DOMImplementationRegistry.newInstance().getDOMImplementation("LS 3.0");
         } catch (Exception ex) {
-            this.logger.warn("Cannot initialize the XML Script Service. Root cause is [{}]",
-                ExceptionUtils.getRootCauseMessage(ex));
+            this.logger.warn("Cannot initialize the XML Script Service", ex);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-xml/xwiki-platform-xml-script/src/test/java/org/xwiki/xml/script/XMLScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-xml/xwiki-platform-xml-script/src/test/java/org/xwiki/xml/script/XMLScriptServiceTest.java
@@ -38,6 +38,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -78,8 +80,7 @@ class XMLScriptServiceTest
             }
         }
 
-        verify(logger).warn("Cannot initialize the XML Script Service. Root cause is [{}]",
-            "ClassNotFoundException: does.not.exist.DOMImplementationSource");
+        verify(logger).warn(eq("Cannot initialize the XML Script Service"), any(ClassNotFoundException.class));
     }
 
     @Test


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24665

# Changes

## Description

* Restores the throwable as the trailing SLF4J argument in the **106 `warn()` calls** where the
  logging sweep had dropped it in favour of `ExceptionUtils.getRootCauseMessage(e)` formatted into
  the message. 72 main files, 37 modules.
* The root-cause clause (`. Root cause is [{}]` and its variants) is removed from the message, since
  the throwable now carries the cause.
* **This is not a plain revert of those hunks.** The message improvements the sweep made in the same
  hunks are kept: `{}` placeholders instead of `%s` or `{0}`, values in brackets, and placeholders
  that were missing altogether. Reverting literally would have put back messages such as
  `"Failed to register channel [] against the JMX Server"`,
  `"Failed to display field [] in [] mode for Object of Class []"` and
  `"Failed to retrieve content from []"` — 42 of the sites had a genuine message fix bundled in.
* `FileSystemURLFactory`: the clause is also removed from the shared `SAVE_IMAGE_ERROR` constant, so
  both of its call sites log the throwable.
* Five tests that asserted a removed clause are updated, and the `ExceptionUtils` imports left
  unused are dropped (50 of them).

## Clarifications

* **Why the throwable must stay a throwable.** Passed as SLF4J's trailing argument it reaches a
  structured field — `ILoggingEvent#getThrowableProxy()`, XWiki's own `LogEvent#getThrowable()`, and
  the `error.stack_trace` / `exception.stacktrace` fields of the ECS, OpenTelemetry and Datadog
  encoders. The decision to *display* a trace then belongs to whoever renders it, and a renderer can
  hide it while keeping it one click away — which is exactly what the job log displayer does
  (`logging_macros.vm`, `#printLog`) when `$log.throwable` is set. A cause formatted into the message
  destroys that information for every consumer, permanently.
* **The rule this implies.** The logging rule "a warn must not print a stack trace" is
  under-specified: it should say a warn must not **display** a stack trace by default, enforced by
  the appender or the displayer, not by destroying the throwable at the call site. That amendment
  will be proposed on the forum, in the existing
  [logging warning stacktraces in debug mode](https://forum.xwiki.org/t/logging-warning-stacktraces-in-debug-mode/18728)
  thread. **Please do not merge this PR before that discussion has happened** — the code change is
  posted first so the discussion has something concrete to look at.
* After the amendment, the only question left per site is "is this a `warn` or an `error`?", which is
  a genuine per-site judgement to be made when the code is next touched, rather than in a sweep.
* Two of the 108 sites in this class are not in this PR: `DocumentEventListener` and
  `WikiCreationJobScriptServices` already became `error(msg, e)` under this same issue, which is the
  same target form. One equivalent site in `xwiki-rendering`
  (`RenderingContextStore`) will get its own one-line PR in that repo.
* The change is mechanical and uniform: it was applied by a script that parses each statement into
  message plus arguments and re-emits it, with a check that the number of `{}` placeholders still
  matches the number of value arguments at every site.

# Screenshots & Video

No UI change. The visible effect is in the log output: a warning now shows its root cause on the
first line and its stack trace wherever the appender or displayer chooses to show it, instead of the
cause being embedded in the message text.

# Executed Tests

`mvn clean install -Plegacy,quality -DskipITs --fail-at-end` over the 46 reactor modules covering
every touched module (checkstyle, revapi and the unit tests of oldcore, notifications, refactoring,
solr, sheet, eventstream, xar, export-pdf, xml-script and the rest).

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * none — this only restores information in log output on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
