### PR TITLE
XWIKI-16742: (Simple) user type is not displayed by default in User Directory's Livetable when the respective column is added

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -235,6 +235,7 @@ import com.xpn.xwiki.job.JobRequestContext;
 import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.objects.PropertyInterface;
 import com.xpn.xwiki.objects.classes.BaseClass;
+import com.xpn.xwiki.objects.classes.ListClass;
 import com.xpn.xwiki.objects.classes.PasswordClass;
 import com.xpn.xwiki.objects.classes.PropertyClass;
 import com.xpn.xwiki.objects.meta.MetaClass;
@@ -4270,6 +4271,23 @@ public class XWiki implements EventListener
             BaseObject userObject =
                 doc.newXObject(userClassReference.removeParent(userClassReference.getWikiReference()), context);
             userClass.fromMap(map, userObject);
+
+            // Make sure the user type property has an explicit value even when it's not part of the submitted
+            // data (e.g. the registration and the "create user" forms don't have a field for it), so that it's
+            // consistently stored and can be reliably filtered, sorted and displayed (e.g. in the User Directory).
+            // Note: fromMap() only leaves the property unset when the map has no entry for it at all, so this
+            // doesn't override a value that was actually submitted (even if that value is an empty string).
+            if (userObject.safeget(XWikiUsersDocumentInitializer.USERTYPE_FIELD) == null) {
+                PropertyClass userTypeProperty =
+                    (PropertyClass) userClass.get(XWikiUsersDocumentInitializer.USERTYPE_FIELD);
+                if (userTypeProperty instanceof ListClass listUserTypeProperty) {
+                    // Go through the property class's own factory rather than setStringValue() so that the
+                    // property is created with the storage type the class is actually configured for (e.g. a
+                    // StringListProperty/DBStringListProperty if the field has been customized to be multiSelect).
+                    userObject.safeput(XWikiUsersDocumentInitializer.USERTYPE_FIELD,
+                        listUserTypeProperty.fromString(listUserTypeProperty.getDefaultValue()));
+                }
+            }
 
             doc.setParentReference(parentReference);
             doc.setContent(content);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -4241,18 +4241,11 @@ public class XWiki implements EventListener
                 doc.newXObject(userClassReference.removeParent(userClassReference.getWikiReference()), context);
             userClass.fromMap(map, userObject);
 
-            // Make sure the user type property has an explicit value even when it's not part of the submitted
-            // data (e.g. the registration and the "create user" forms don't have a field for it), so that it's
-            // consistently stored and can be reliably filtered, sorted and displayed (e.g. in the User Directory).
-            // Note: fromMap() only leaves the property unset when the map has no entry for it at all, so this
-            // doesn't override a value that was actually submitted (even if that value is an empty string).
+            // Make sure the user type property has an explicit value even when it's not part of the submitted data
             if (userObject.safeget(XWikiUsersDocumentInitializer.USERTYPE_FIELD) == null) {
                 PropertyClass userTypeProperty =
                     (PropertyClass) userClass.get(XWikiUsersDocumentInitializer.USERTYPE_FIELD);
                 if (userTypeProperty instanceof ListClass listUserTypeProperty) {
-                    // Go through the property class's own factory rather than setStringValue() so that the
-                    // property is created with the storage type the class is actually configured for (e.g. a
-                    // StringListProperty/DBStringListProperty if the field has been customized to be multiSelect).
                     userObject.safeput(XWikiUsersDocumentInitializer.USERTYPE_FIELD,
                         listUserTypeProperty.fromString(listUserTypeProperty.getDefaultValue()));
                 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -235,6 +235,7 @@ import com.xpn.xwiki.job.JobRequestContext;
 import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.objects.PropertyInterface;
 import com.xpn.xwiki.objects.classes.BaseClass;
+import com.xpn.xwiki.objects.classes.ListClass;
 import com.xpn.xwiki.objects.classes.PasswordClass;
 import com.xpn.xwiki.objects.classes.PropertyClass;
 import com.xpn.xwiki.objects.meta.MetaClass;
@@ -4239,6 +4240,23 @@ public class XWiki implements EventListener
             BaseObject userObject =
                 doc.newXObject(userClassReference.removeParent(userClassReference.getWikiReference()), context);
             userClass.fromMap(map, userObject);
+
+            // Make sure the user type property has an explicit value even when it's not part of the submitted
+            // data (e.g. the registration and the "create user" forms don't have a field for it), so that it's
+            // consistently stored and can be reliably filtered, sorted and displayed (e.g. in the User Directory).
+            // Note: fromMap() only leaves the property unset when the map has no entry for it at all, so this
+            // doesn't override a value that was actually submitted (even if that value is an empty string).
+            if (userObject.safeget(XWikiUsersDocumentInitializer.USERTYPE_FIELD) == null) {
+                PropertyClass userTypeProperty =
+                    (PropertyClass) userClass.get(XWikiUsersDocumentInitializer.USERTYPE_FIELD);
+                if (userTypeProperty instanceof ListClass listUserTypeProperty) {
+                    // Go through the property class's own factory rather than setStringValue() so that the
+                    // property is created with the storage type the class is actually configured for (e.g. a
+                    // StringListProperty/DBStringListProperty if the field has been customized to be multiSelect).
+                    userObject.safeput(XWikiUsersDocumentInitializer.USERTYPE_FIELD,
+                        listUserTypeProperty.fromString(listUserTypeProperty.getDefaultValue()));
+                }
+            }
 
             doc.setParentReference(parentReference);
             doc.setContent(content);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -4272,18 +4272,11 @@ public class XWiki implements EventListener
                 doc.newXObject(userClassReference.removeParent(userClassReference.getWikiReference()), context);
             userClass.fromMap(map, userObject);
 
-            // Make sure the user type property has an explicit value even when it's not part of the submitted
-            // data (e.g. the registration and the "create user" forms don't have a field for it), so that it's
-            // consistently stored and can be reliably filtered, sorted and displayed (e.g. in the User Directory).
-            // Note: fromMap() only leaves the property unset when the map has no entry for it at all, so this
-            // doesn't override a value that was actually submitted (even if that value is an empty string).
+            // Make sure the user type property has an explicit value even when it's not part of the submitted data
             if (userObject.safeget(XWikiUsersDocumentInitializer.USERTYPE_FIELD) == null) {
                 PropertyClass userTypeProperty =
                     (PropertyClass) userClass.get(XWikiUsersDocumentInitializer.USERTYPE_FIELD);
                 if (userTypeProperty instanceof ListClass listUserTypeProperty) {
-                    // Go through the property class's own factory rather than setStringValue() so that the
-                    // property is created with the storage type the class is actually configured for (e.g. a
-                    // StringListProperty/DBStringListProperty if the field has been customized to be multiSelect).
                     userObject.safeput(XWikiUsersDocumentInitializer.USERTYPE_FIELD,
                         listUserTypeProperty.fromString(listUserTypeProperty.getDefaultValue()));
                 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiUsersDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiUsersDocumentInitializer.java
@@ -100,6 +100,20 @@ public class XWikiUsersDocumentInitializer extends AbstractMandatoryClassInitial
     private static final String TIMEZONE_FIELD = "timezone";
 
     /**
+     * The name of the field containing the user type.
+     *
+     * @since 18.7.0RC1
+     */
+    public static final String USERTYPE_FIELD = "usertype";
+
+    /**
+     * The default value of the {@link #USERTYPE_FIELD} field.
+     *
+     * @since 18.7.0RC1
+     */
+    public static final String USERTYPE_DEFAULT_VALUE = "Simple";
+
+    /**
      * Used to bind a class to a document sheet.
      */
     @Inject
@@ -130,7 +144,7 @@ public class XWikiUsersDocumentInitializer extends AbstractMandatoryClassInitial
         xclass.addStaticListField("imtype", "IM Type", "AIM|Yahoo|Jabber|MSN|Skype|ICQ");
         xclass.addTextField("imaccount", "imaccount", 30);
         xclass.addStaticListField("editor", "Default Editor", "Text|Wysiwyg");
-        xclass.addStaticListField("usertype", "User type", "Simple|Advanced", "Simple");
+        xclass.addStaticListField(USERTYPE_FIELD, "User type", "Simple|Advanced", USERTYPE_DEFAULT_VALUE);
         xclass.addStaticListField("underline", "Underline links", "OnlyInlineLinks|Yes|No", "OnlyInlineLinks");
         xclass.addBooleanField("displayHiddenDocuments", "Display Hidden Documents", "yesno");
         xclass.addTimezoneField(TIMEZONE_FIELD, "Time Zone", 30);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiUsersDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiUsersDocumentInitializer.java
@@ -108,10 +108,8 @@ public class XWikiUsersDocumentInitializer extends AbstractMandatoryClassInitial
 
     /**
      * The default value of the {@link #USERTYPE_FIELD} field.
-     *
-     * @since 18.8.0RC1
      */
-    public static final String USERTYPE_DEFAULT_VALUE = "Simple";
+    private static final String USERTYPE_DEFAULT_VALUE = "Simple";
 
     /**
      * Used to bind a class to a document sheet.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiUsersDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiUsersDocumentInitializer.java
@@ -102,14 +102,14 @@ public class XWikiUsersDocumentInitializer extends AbstractMandatoryClassInitial
     /**
      * The name of the field containing the user type.
      *
-     * @since 18.7.0RC1
+     * @since 18.8.0RC1
      */
     public static final String USERTYPE_FIELD = "usertype";
 
     /**
      * The default value of the {@link #USERTYPE_FIELD} field.
      *
-     * @since 18.7.0RC1
+     * @since 18.8.0RC1
      */
     public static final String USERTYPE_DEFAULT_VALUE = "Simple";
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R180700000XWIKI16742DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R180700000XWIKI16742DataMigration.java
@@ -55,7 +55,7 @@ import com.xpn.xwiki.store.migration.XWikiDBVersion;
  * doesn't have it set yet.
  *
  * @version $Id$
- * @since 18.7.0RC1
+ * @since 18.8.0RC1
  */
 @Component
 @Named("R180700000XWIKI16742")

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R180700000XWIKI16742DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R180700000XWIKI16742DataMigration.java
@@ -158,9 +158,6 @@ public class R180700000XWIKI16742DataMigration extends AbstractHibernateDataMigr
         // This condition should never happen normally, but we might imagine so DB with stale objects for some
         // reasons, so we won't take the chance.
         if (userObject != null) {
-            // Go through the property class's own factory rather than setStringValue() so that the property is
-            // created with the storage type the class is actually configured for (e.g. a
-            // StringListProperty/DBStringListProperty if the field has been customized to be multiSelect).
             userObject.safeput(XWikiUsersDocumentInitializer.USERTYPE_FIELD,
                 userTypeProperty.fromString(userTypeProperty.getDefaultValue()));
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R180700000XWIKI16742DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R180700000XWIKI16742DataMigration.java
@@ -1,0 +1,170 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.store.migration.hibernate;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.hibernate.query.Query;
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.internal.mandatory.XWikiUsersDocumentInitializer;
+import com.xpn.xwiki.objects.BaseObject;
+import com.xpn.xwiki.objects.classes.BaseClass;
+import com.xpn.xwiki.objects.classes.ListClass;
+import com.xpn.xwiki.objects.classes.PropertyClass;
+import com.xpn.xwiki.store.migration.DataMigrationException;
+import com.xpn.xwiki.store.migration.XWikiDBVersion;
+
+/**
+ * Migration for XWIKI-16742: the user type property was not consistently stored on user profiles created before the
+ * fix in {@link XWiki#createUser}, which means that it's not properly displayed, filtered or sorted (e.g. in the
+ * User Directory live table) until the user explicitly saves their profile preferences at least once.
+ * <p>
+ * This migration sets the user type property to the wiki's current default value for that property (as configured
+ * on the {@code XWiki.XWikiUsers} class, in case it was customized) for every {@code XWiki.XWikiUsers} object that
+ * doesn't have it set yet.
+ *
+ * @version $Id$
+ * @since 18.7.0RC1
+ */
+@Component
+@Named("R180700000XWIKI16742")
+@Singleton
+public class R180700000XWIKI16742DataMigration extends AbstractHibernateDataMigration
+{
+    @Inject
+    @Named("current")
+    private DocumentReferenceResolver<String> documentReferenceResolver;
+
+    @Inject
+    private Logger logger;
+
+    @Override
+    public String getDescription()
+    {
+        return "Set the user type property to its default value for user profiles that don't have it set yet.";
+    }
+
+    @Override
+    public XWikiDBVersion getVersion()
+    {
+        return new XWikiDBVersion(180700000);
+    }
+
+    @Override
+    protected void hibernateMigrate() throws DataMigrationException, XWikiException
+    {
+        // Get all the users that don't have the user type property set yet.
+        List<String> allUsers = getStore().executeRead(getXWikiContext(), this::getUsersWithoutUserType);
+
+        this.logger.info("Migration needed for [{}] users on database [{}].",
+            allUsers.size(), getXWikiContext().getWikiId());
+
+        DocumentReference wikiUserClassReference =
+            new DocumentReference(XWikiUsersDocumentInitializer.XWIKI_USERS_DOCUMENT_REFERENCE,
+                getXWikiContext().getWikiReference());
+        BaseClass xwikiUserClass = getXWikiContext().getWiki().getXClass(wikiUserClassReference, getXWikiContext());
+        ListClass userTypeProperty = getUserTypeProperty(xwikiUserClass, wikiUserClassReference);
+
+        int i = 0;
+        int failures = 0;
+        for (String user : allUsers) {
+            try {
+                applyMigrationOnUser(user, xwikiUserClass, userTypeProperty);
+            } catch (Exception e) {
+                this.logger.error("Error while migrating the user type for user [{}] on database [{}]", user,
+                    getXWikiContext().getWikiId(), e);
+                failures++;
+            }
+            if (++i % 100 == 0) {
+                this.logger.info("[{}] users on [{}] have been migrated on database [{}]...", i - failures,
+                    allUsers.size(), getXWikiContext().getWikiId());
+            }
+        }
+        this.logger.info("[{}] users on [{}] have been migrated on database [{}].", allUsers.size() - failures,
+            allUsers.size(), getXWikiContext().getWikiId());
+        if (failures > 0) {
+            this.logger.warn("[{}] users have not been properly migrated, please check the logs above.", failures);
+        }
+    }
+
+    private List<String> getUsersWithoutUserType(Session session) throws HibernateException, XWikiException
+    {
+        Query<String> query = session.createQuery("select obj.name from BaseObject obj"
+            + " where obj.className = '" + XWikiUsersDocumentInitializer.CLASS_REFERENCE_STRING + "'"
+            + " and obj.id not in (select prop.id.id from StringProperty prop where prop.id.name='"
+            + XWikiUsersDocumentInitializer.USERTYPE_FIELD + "')",
+            String.class);
+
+        return query.list();
+    }
+
+    private ListClass getUserTypeProperty(BaseClass xwikiUserClass, DocumentReference wikiUserClassReference)
+        throws XWikiException
+    {
+        PropertyClass userTypeProperty =
+            (PropertyClass) xwikiUserClass.get(XWikiUsersDocumentInitializer.USERTYPE_FIELD);
+        if (userTypeProperty instanceof ListClass listUserTypeProperty) {
+            return listUserTypeProperty;
+        }
+
+        throw new XWikiException(XWikiException.MODULE_XWIKI_STORE, XWikiException.ERROR_XWIKI_STORE_MIGRATION,
+            String.format("The [%s] property of the XWikiUsers XClass with reference [%s] has not been found or is "
+                + "not a list property, the migration [%s] cannot be performed.",
+                XWikiUsersDocumentInitializer.USERTYPE_FIELD, wikiUserClassReference, getName()));
+    }
+
+    private void applyMigrationOnUser(String docUser, BaseClass xwikiUserXClass, ListClass userTypeProperty)
+        throws XWikiException
+    {
+        XWikiContext context = getXWikiContext();
+        XWiki xwiki = context.getWiki();
+        DocumentReference userDocReference = this.documentReferenceResolver.resolve(docUser);
+        XWikiDocument userDocument = xwiki.getDocument(userDocReference, context);
+        // Avoid modifying the cached document.
+        userDocument = userDocument.clone();
+        BaseObject userObject = userDocument.getXObject(xwikiUserXClass.getReference());
+
+        // This condition should never happen normally, but we might imagine so DB with stale objects for some
+        // reasons, so we won't take the chance.
+        if (userObject != null) {
+            // Go through the property class's own factory rather than setStringValue() so that the property is
+            // created with the storage type the class is actually configured for (e.g. a
+            // StringListProperty/DBStringListProperty if the field has been customized to be multiSelect).
+            userObject.safeput(XWikiUsersDocumentInitializer.USERTYPE_FIELD,
+                userTypeProperty.fromString(userTypeProperty.getDefaultValue()));
+
+            xwiki.saveDocument(userDocument, "Set the user type to its default value (XWIKI-16742)", true, context);
+        }
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R180800000XWIKI16742DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R180800000XWIKI16742DataMigration.java
@@ -58,9 +58,9 @@ import com.xpn.xwiki.store.migration.XWikiDBVersion;
  * @since 18.8.0RC1
  */
 @Component
-@Named("R180700000XWIKI16742")
+@Named("R180800000XWIKI16742")
 @Singleton
-public class R180700000XWIKI16742DataMigration extends AbstractHibernateDataMigration
+public class R180800000XWIKI16742DataMigration extends AbstractHibernateDataMigration
 {
     @Inject
     @Named("current")
@@ -78,7 +78,7 @@ public class R180700000XWIKI16742DataMigration extends AbstractHibernateDataMigr
     @Override
     public XWikiDBVersion getVersion()
     {
-        return new XWikiDBVersion(180700000);
+        return new XWikiDBVersion(180800000);
     }
 
     @Override
@@ -121,10 +121,11 @@ public class R180700000XWIKI16742DataMigration extends AbstractHibernateDataMigr
     private List<String> getUsersWithoutUserType(Session session) throws HibernateException, XWikiException
     {
         Query<String> query = session.createQuery("select obj.name from BaseObject obj"
-            + " where obj.className = '" + XWikiUsersDocumentInitializer.CLASS_REFERENCE_STRING + "'"
-            + " and obj.id not in (select prop.id.id from StringProperty prop where prop.id.name='"
-            + XWikiUsersDocumentInitializer.USERTYPE_FIELD + "')",
+            + " where obj.className = :className"
+            + " and obj.id not in (select prop.id.id from StringProperty prop where prop.id.name = :propertyName)",
             String.class);
+        query.setParameter("className", XWikiUsersDocumentInitializer.CLASS_REFERENCE_STRING);
+        query.setParameter("propertyName", XWikiUsersDocumentInitializer.USERTYPE_FIELD);
 
         return query.list();
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
@@ -216,7 +216,7 @@ com.xpn.xwiki.store.migration.hibernate.R140000000XWIKI19125DataMigration
 com.xpn.xwiki.store.migration.hibernate.R140200010XWIKI19207DataMigration
 com.xpn.xwiki.store.migration.hibernate.R140200000XWIKI19352DataMigration
 com.xpn.xwiki.store.migration.hibernate.R140600000XWIKI19869DataMigration
-com.xpn.xwiki.store.migration.hibernate.R180700000XWIKI16742DataMigration
+com.xpn.xwiki.store.migration.hibernate.R180800000XWIKI16742DataMigration
 com.xpn.xwiki.store.VoidAttachmentVersioningStore
 com.xpn.xwiki.store.XWikiHibernateStore
 com.xpn.xwiki.store.XWikiHibernateVersioningStore

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
@@ -216,6 +216,7 @@ com.xpn.xwiki.store.migration.hibernate.R140000000XWIKI19125DataMigration
 com.xpn.xwiki.store.migration.hibernate.R140200010XWIKI19207DataMigration
 com.xpn.xwiki.store.migration.hibernate.R140200000XWIKI19352DataMigration
 com.xpn.xwiki.store.migration.hibernate.R140600000XWIKI19869DataMigration
+com.xpn.xwiki.store.migration.hibernate.R180700000XWIKI16742DataMigration
 com.xpn.xwiki.store.VoidAttachmentVersioningStore
 com.xpn.xwiki.store.XWikiHibernateStore
 com.xpn.xwiki.store.XWikiHibernateVersioningStore


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-16742

# Changes

## Description

* Set the "usertype" property to its class-configured default value when creating a user, if not already submitted.
* Add a data migration backfilling the "usertype" property for existing users missing it.

## Clarifications

* The "usertype" static list field defaults to "Simple" at the class level, but that default was never actually persisted on the user's object unless the user explicitly saved their profile preferences at least once. This meant the User Directory live table's "User Type" column (and its filtering/sorting) was inconsistent for users who never touched that setting.
* The default value is read from the live `XWiki.XWikiUsers` class definition (not hardcoded), so a wiki that customized the class's default is respected.
* The property is built through the property class's own factory (`ListClass#fromString`) rather than forcing a plain string value, so a customized multiSelect field would still get the correct storage type.

# Screenshots & Video
<img width="2120" height="611" alt="comparison-trimmed" src="https://github.com/user-attachments/assets/81b8590c-5b20-4709-bd3a-95ac6d3d5a84" />


<img width="1880" height="433" alt="release-notes-comparison-trimmed" src="https://github.com/user-attachments/assets/4eac0dcc-dff8-49b8-bc74-61f5e18ca864" />

# Executed Tests

* `mvn checkstyle:check` on `xwiki-platform-oldcore`
* `mvn test -Dtest=XWikiTest` on `xwiki-platform-oldcore`
* `mvn compile` / `mvn test-compile` on `xwiki-platform-oldcore`

Tests of the patch on a live instance to make the screenshots above.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None