### PR TITLE
XWIKI-24665: Apply the logging best practices across commons, rendering and platform

### DIFF
--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/store/StoreConstructorsCompatibilityAspect.aj
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/store/StoreConstructorsCompatibilityAspect.aj
@@ -82,7 +82,8 @@ public privileged aspect StoreConstructorsCompatibilityAspect
      *
      * @param xwiki the XWiki object holding the configuration
      * @param context the current context, unused
-     * @deprecated 1.6M1. Use ComponentManager.lookup(String) instead.
+     * @deprecated 1.6M1. Use the concrete store component instead, for example {@link XWikiStoreInterface} with
+     *             hint {@code hibernate}.
      */
     @Deprecated
     public XWikiHibernateBaseStore.new(XWiki xwiki, XWikiContext context)
@@ -100,7 +101,8 @@ public privileged aspect StoreConstructorsCompatibilityAspect
      * Look up the component instead.
      *
      * @param hibpath the path to the Hibernate configuration file
-     * @deprecated 1.6M1. Use ComponentManager.lookup(String) instead.
+     * @deprecated 1.6M1. Use the concrete store component instead, for example {@link XWikiStoreInterface} with
+     *             hint {@code hibernate}.
      */
     @Deprecated
     public XWikiHibernateBaseStore.new(String hibpath)
@@ -119,7 +121,7 @@ public privileged aspect StoreConstructorsCompatibilityAspect
      *
      * @param xwiki the XWiki object holding the configuration
      * @param context the current context, unused
-     * @deprecated 1.6M1. Use ComponentManager.lookup(XWikiStoreInterface.class) instead.
+     * @deprecated 1.6M1. Use the {@link XWikiStoreInterface} component with hint {@code hibernate} instead.
      */
     @Deprecated
     public XWikiHibernateStore.new(XWiki xwiki, XWikiContext context)
@@ -137,7 +139,7 @@ public privileged aspect StoreConstructorsCompatibilityAspect
      * Look up the component instead.
      *
      * @param hibpath the path to the Hibernate configuration file
-     * @deprecated 1.6M1. Use ComponentManager.lookup(XWikiStoreInterface.class) instead.
+     * @deprecated 1.6M1. Use the {@link XWikiStoreInterface} component with hint {@code hibernate} instead.
      */
     @Deprecated
     public XWikiHibernateStore.new(String hibpath)
@@ -155,7 +157,7 @@ public privileged aspect StoreConstructorsCompatibilityAspect
      * Look up the component instead.
      *
      * @param context the current context, used to reach the XWiki object
-     * @deprecated 1.6M1. Use ComponentManager.lookup(XWikiStoreInterface.class) instead.
+     * @deprecated 1.6M1. Use the {@link XWikiStoreInterface} component with hint {@code hibernate} instead.
      */
     @Deprecated
     public XWikiHibernateStore.new(XWikiContext context)
@@ -174,7 +176,8 @@ public privileged aspect StoreConstructorsCompatibilityAspect
      *
      * @param xwiki the XWiki object holding the configuration
      * @param context the current context, unused
-     * @deprecated 1.6M1. Use ComponentManager.lookup(XWikiAttachmentStoreInterface.class) instead.
+     * @deprecated 1.6M1. Use the {@link XWikiAttachmentStoreInterface} component with hint {@code hibernate}
+     *             instead.
      */
     @Deprecated
     public XWikiHibernateAttachmentStore.new(XWiki xwiki, XWikiContext context)
@@ -192,7 +195,8 @@ public privileged aspect StoreConstructorsCompatibilityAspect
      * Look up the component instead.
      *
      * @param context the current context, used to reach the XWiki object
-     * @deprecated 1.6M1. Use ComponentManager.lookup(XWikiAttachmentStoreInterface.class) instead.
+     * @deprecated 1.6M1. Use the {@link XWikiAttachmentStoreInterface} component with hint {@code hibernate}
+     *             instead.
      */
     @Deprecated
     public XWikiHibernateAttachmentStore.new(XWikiContext context)
@@ -210,7 +214,8 @@ public privileged aspect StoreConstructorsCompatibilityAspect
      * Look up the component instead.
      *
      * @param hibpath the path to the Hibernate configuration file
-     * @deprecated 1.6M1. Use ComponentManager.lookup(XWikiAttachmentStoreInterface.class) instead.
+     * @deprecated 1.6M1. Use the {@link XWikiAttachmentStoreInterface} component with hint {@code hibernate}
+     *             instead.
      */
     @Deprecated
     public XWikiHibernateAttachmentStore.new(String hibpath)
@@ -229,7 +234,8 @@ public privileged aspect StoreConstructorsCompatibilityAspect
      *
      * @param xwiki the XWiki object holding the configuration
      * @param context the current context, unused
-     * @deprecated 1.6M1. use ComponentManager.lookup(XWikiVersioningStoreInterface.class) instead.
+     * @deprecated 1.6M1. Use the {@link XWikiVersioningStoreInterface} component with hint {@code hibernate}
+     *             instead.
      */
     @Deprecated
     public XWikiHibernateVersioningStore.new(XWiki xwiki, XWikiContext context)
@@ -247,7 +253,8 @@ public privileged aspect StoreConstructorsCompatibilityAspect
      * Look up the component instead.
      *
      * @param hibpath the path to the Hibernate configuration file
-     * @deprecated 1.6M1. use ComponentManager.lookup(XWikiVersioningStoreInterface.class) instead.
+     * @deprecated 1.6M1. Use the {@link XWikiVersioningStoreInterface} component with hint {@code hibernate}
+     *             instead.
      */
     @Deprecated
     public XWikiHibernateVersioningStore.new(String hibpath)
@@ -265,7 +272,8 @@ public privileged aspect StoreConstructorsCompatibilityAspect
      * Look up the component instead.
      *
      * @param context the current context, used to reach the XWiki object
-     * @deprecated 1.6M1. use ComponentManager.lookup(XWikiVersioningStoreInterface.class) instead.
+     * @deprecated 1.6M1. Use the {@link XWikiVersioningStoreInterface} component with hint {@code hibernate}
+     *             instead.
      */
     @Deprecated
     public XWikiHibernateVersioningStore.new(XWikiContext context)
@@ -283,7 +291,8 @@ public privileged aspect StoreConstructorsCompatibilityAspect
      * Look up the component instead.
      *
      * @param context the current context, used to reach the XWiki object
-     * @deprecated 1.6M1. Use ComponentManager#getInstance(XWikiRecycleBinStoreInterface.class) instead.
+     * @deprecated 1.6M1. Use the {@link XWikiRecycleBinStoreInterface} component with hint {@code hibernate}
+     *             instead.
      */
     @Deprecated
     public XWikiHibernateRecycleBinStore.new(XWikiContext context)
@@ -301,7 +310,7 @@ public privileged aspect StoreConstructorsCompatibilityAspect
      * Look up the component instead.
      *
      * @param context the current context, used to reach the XWiki object
-     * @deprecated 1.6M1. Use ComponentManager.lookup(AttachmentRecycleBinStore.class) instead.
+     * @deprecated 1.6M1. Use the {@link AttachmentRecycleBinStore} component with hint {@code hibernate} instead.
      */
     @Deprecated
     public HibernateAttachmentRecycleBinStore.new(XWikiContext context)
@@ -319,7 +328,7 @@ public privileged aspect StoreConstructorsCompatibilityAspect
      * Look up the component instead.
      *
      * @param context the current context, used to reach the XWiki object
-     * @deprecated 1.6M1. Use ComponentManager.lookup(AttachmentVersioningStore.class) instead.
+     * @deprecated 1.6M1. Use the {@link AttachmentVersioningStore} component with hint {@code hibernate} instead.
      */
     @Deprecated
     public HibernateAttachmentVersioningStore.new(XWikiContext context)
@@ -336,7 +345,7 @@ public privileged aspect StoreConstructorsCompatibilityAspect
      * exactly like one built with the no-argument constructor. The context is ignored.
      *
      * @param context the current context, unused
-     * @deprecated 1.6M1. Use ComponentManager.lookup(AttachmentVersioningStore.class) instead.
+     * @deprecated 1.6M1. Use the {@link AttachmentVersioningStore} component with hint {@code void} instead.
      */
     @Deprecated
     public VoidAttachmentVersioningStore.new(XWikiContext context)

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/store/StoreConstructorsCompatibilityAspect.aj
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/store/StoreConstructorsCompatibilityAspect.aj
@@ -1,0 +1,346 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.store;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.internal.store.hibernate.HibernateConfiguration;
+import com.xpn.xwiki.store.hibernate.HibernateAttachmentRecycleBinStore;
+import com.xpn.xwiki.store.hibernate.HibernateAttachmentVersioningStore;
+
+/**
+ * Add a backward compatibility layer for the deprecated public constructors of the store classes.
+ * <p>
+ * All of these constructors are declared in a single aspect because they form one hierarchy: the subclass constructors
+ * need the initialization performed by {@link XWikiHibernateBaseStore}'s, which an inter-type constructor cannot reach
+ * through a {@code super(...)} call.
+ *
+ * @version $Id$
+ * @since 18.7.0RC1
+ */
+public privileged aspect StoreConstructorsCompatibilityAspect
+{
+    private static final String HIBERNATE_PATH_PROPERTY = "xwiki.store.hibernate.path";
+
+    private static final String DEFAULT_HIBERNATE_PATH = "/WEB-INF/hibernate.cfg.xml";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(XWikiHibernateBaseStore.class);
+
+    /**
+     * Set the Hibernate configuration path from the {@code xwiki.store.hibernate.path} configuration property.
+     *
+     * @param store the store to initialize
+     * @param xwiki the XWiki object holding the configuration
+     */
+    private static void initializeHibernatePath(XWikiHibernateBaseStore store, XWiki xwiki)
+    {
+        String path = xwiki.Param(HIBERNATE_PATH_PROPERTY, DEFAULT_HIBERNATE_PATH);
+        LOGGER.debug("Hibernate configuration file: [{}]", path);
+
+        initializeHibernatePath(store, path);
+    }
+
+    /**
+     * Set the Hibernate configuration path explicitly.
+     *
+     * @param store the store to initialize
+     * @param hibpath the path to the Hibernate configuration file
+     */
+    private static void initializeHibernatePath(XWikiHibernateBaseStore store, String hibpath)
+    {
+        store.hibernateConfiguration = new HibernateConfiguration();
+
+        store.setPath(hibpath);
+    }
+
+    /**
+     * Build a store directly instead of looking it up as a component.
+     * <p>
+     * The resulting store is not usable: this class obtains all its collaborators through component injection, and an
+     * instance built with this constructor leaves every one of them {@code null}, so the first store operation fails.
+     * Look up the component instead.
+     *
+     * @param xwiki the XWiki object holding the configuration
+     * @param context the current context, unused
+     * @deprecated 1.6M1. Use ComponentManager.lookup(String) instead.
+     */
+    @Deprecated
+    public XWikiHibernateBaseStore.new(XWiki xwiki, XWikiContext context)
+    {
+        this();
+
+        initializeHibernatePath(this, xwiki);
+    }
+
+    /**
+     * Build a store directly instead of looking it up as a component.
+     * <p>
+     * The resulting store is not usable: this class obtains all its collaborators through component injection, and an
+     * instance built with this constructor leaves every one of them {@code null}, so the first store operation fails.
+     * Look up the component instead.
+     *
+     * @param hibpath the path to the Hibernate configuration file
+     * @deprecated 1.6M1. Use ComponentManager.lookup(String) instead.
+     */
+    @Deprecated
+    public XWikiHibernateBaseStore.new(String hibpath)
+    {
+        this();
+
+        initializeHibernatePath(this, hibpath);
+    }
+
+    /**
+     * Build a store directly instead of looking it up as a component.
+     * <p>
+     * The resulting store is not usable: this class obtains all its collaborators through component injection, and an
+     * instance built with this constructor leaves every one of them {@code null}, so the first store operation fails.
+     * Look up the component instead.
+     *
+     * @param xwiki the XWiki object holding the configuration
+     * @param context the current context, unused
+     * @deprecated 1.6M1. Use ComponentManager.lookup(XWikiStoreInterface.class) instead.
+     */
+    @Deprecated
+    public XWikiHibernateStore.new(XWiki xwiki, XWikiContext context)
+    {
+        this();
+
+        initializeHibernatePath(this, xwiki);
+    }
+
+    /**
+     * Build a store directly instead of looking it up as a component.
+     * <p>
+     * The resulting store is not usable: this class obtains all its collaborators through component injection, and an
+     * instance built with this constructor leaves every one of them {@code null}, so the first store operation fails.
+     * Look up the component instead.
+     *
+     * @param hibpath the path to the Hibernate configuration file
+     * @deprecated 1.6M1. Use ComponentManager.lookup(XWikiStoreInterface.class) instead.
+     */
+    @Deprecated
+    public XWikiHibernateStore.new(String hibpath)
+    {
+        this();
+
+        initializeHibernatePath(this, hibpath);
+    }
+
+    /**
+     * Build a store directly instead of looking it up as a component.
+     * <p>
+     * The resulting store is not usable: this class obtains all its collaborators through component injection, and an
+     * instance built with this constructor leaves every one of them {@code null}, so the first store operation fails.
+     * Look up the component instead.
+     *
+     * @param context the current context, used to reach the XWiki object
+     * @deprecated 1.6M1. Use ComponentManager.lookup(XWikiStoreInterface.class) instead.
+     */
+    @Deprecated
+    public XWikiHibernateStore.new(XWikiContext context)
+    {
+        this();
+
+        initializeHibernatePath(this, context.getWiki());
+    }
+
+    /**
+     * Build a store directly instead of looking it up as a component.
+     * <p>
+     * The resulting store is not usable: this class obtains all its collaborators through component injection, and an
+     * instance built with this constructor leaves every one of them {@code null}, so the first store operation fails.
+     * Look up the component instead.
+     *
+     * @param xwiki the XWiki object holding the configuration
+     * @param context the current context, unused
+     * @deprecated 1.6M1. Use ComponentManager.lookup(XWikiAttachmentStoreInterface.class) instead.
+     */
+    @Deprecated
+    public XWikiHibernateAttachmentStore.new(XWiki xwiki, XWikiContext context)
+    {
+        this();
+
+        initializeHibernatePath(this, xwiki);
+    }
+
+    /**
+     * Build a store directly instead of looking it up as a component.
+     * <p>
+     * The resulting store is not usable: this class obtains all its collaborators through component injection, and an
+     * instance built with this constructor leaves every one of them {@code null}, so the first store operation fails.
+     * Look up the component instead.
+     *
+     * @param context the current context, used to reach the XWiki object
+     * @deprecated 1.6M1. Use ComponentManager.lookup(XWikiAttachmentStoreInterface.class) instead.
+     */
+    @Deprecated
+    public XWikiHibernateAttachmentStore.new(XWikiContext context)
+    {
+        this();
+
+        initializeHibernatePath(this, context.getWiki());
+    }
+
+    /**
+     * Build a store directly instead of looking it up as a component.
+     * <p>
+     * The resulting store is not usable: this class obtains all its collaborators through component injection, and an
+     * instance built with this constructor leaves every one of them {@code null}, so the first store operation fails.
+     * Look up the component instead.
+     *
+     * @param hibpath the path to the Hibernate configuration file
+     * @deprecated 1.6M1. Use ComponentManager.lookup(XWikiAttachmentStoreInterface.class) instead.
+     */
+    @Deprecated
+    public XWikiHibernateAttachmentStore.new(String hibpath)
+    {
+        this();
+
+        initializeHibernatePath(this, hibpath);
+    }
+
+    /**
+     * Build a store directly instead of looking it up as a component.
+     * <p>
+     * The resulting store is not usable: this class obtains all its collaborators through component injection, and an
+     * instance built with this constructor leaves every one of them {@code null}, so the first store operation fails.
+     * Look up the component instead.
+     *
+     * @param xwiki the XWiki object holding the configuration
+     * @param context the current context, unused
+     * @deprecated 1.6M1. use ComponentManager.lookup(XWikiVersioningStoreInterface.class) instead.
+     */
+    @Deprecated
+    public XWikiHibernateVersioningStore.new(XWiki xwiki, XWikiContext context)
+    {
+        this();
+
+        initializeHibernatePath(this, xwiki);
+    }
+
+    /**
+     * Build a store directly instead of looking it up as a component.
+     * <p>
+     * The resulting store is not usable: this class obtains all its collaborators through component injection, and an
+     * instance built with this constructor leaves every one of them {@code null}, so the first store operation fails.
+     * Look up the component instead.
+     *
+     * @param hibpath the path to the Hibernate configuration file
+     * @deprecated 1.6M1. use ComponentManager.lookup(XWikiVersioningStoreInterface.class) instead.
+     */
+    @Deprecated
+    public XWikiHibernateVersioningStore.new(String hibpath)
+    {
+        this();
+
+        initializeHibernatePath(this, hibpath);
+    }
+
+    /**
+     * Build a store directly instead of looking it up as a component.
+     * <p>
+     * The resulting store is not usable: this class obtains all its collaborators through component injection, and an
+     * instance built with this constructor leaves every one of them {@code null}, so the first store operation fails.
+     * Look up the component instead.
+     *
+     * @param context the current context, used to reach the XWiki object
+     * @deprecated 1.6M1. use ComponentManager.lookup(XWikiVersioningStoreInterface.class) instead.
+     */
+    @Deprecated
+    public XWikiHibernateVersioningStore.new(XWikiContext context)
+    {
+        this();
+
+        initializeHibernatePath(this, context.getWiki());
+    }
+
+    /**
+     * Build a store directly instead of looking it up as a component.
+     * <p>
+     * The resulting store is not usable: this class obtains all its collaborators through component injection, and an
+     * instance built with this constructor leaves every one of them {@code null}, so the first store operation fails.
+     * Look up the component instead.
+     *
+     * @param context the current context, used to reach the XWiki object
+     * @deprecated 1.6M1. Use ComponentManager#getInstance(XWikiRecycleBinStoreInterface.class) instead.
+     */
+    @Deprecated
+    public XWikiHibernateRecycleBinStore.new(XWikiContext context)
+    {
+        this();
+
+        initializeHibernatePath(this, context.getWiki());
+    }
+
+    /**
+     * Build a store directly instead of looking it up as a component.
+     * <p>
+     * The resulting store is not usable: this class obtains all its collaborators through component injection, and an
+     * instance built with this constructor leaves every one of them {@code null}, so the first store operation fails.
+     * Look up the component instead.
+     *
+     * @param context the current context, used to reach the XWiki object
+     * @deprecated 1.6M1. Use ComponentManager.lookup(AttachmentRecycleBinStore.class) instead.
+     */
+    @Deprecated
+    public HibernateAttachmentRecycleBinStore.new(XWikiContext context)
+    {
+        this();
+
+        initializeHibernatePath(this, context.getWiki());
+    }
+
+    /**
+     * Build a store directly instead of looking it up as a component.
+     * <p>
+     * The resulting store is not usable: this class obtains all its collaborators through component injection, and an
+     * instance built with this constructor leaves every one of them {@code null}, so the first store operation fails.
+     * Look up the component instead.
+     *
+     * @param context the current context, used to reach the XWiki object
+     * @deprecated 1.6M1. Use ComponentManager.lookup(AttachmentVersioningStore.class) instead.
+     */
+    @Deprecated
+    public HibernateAttachmentVersioningStore.new(XWikiContext context)
+    {
+        this();
+
+        initializeHibernatePath(this, context.getWiki());
+    }
+
+    /**
+     * Build a store directly instead of looking it up as a component.
+     * <p>
+     * Unlike the other stores, this one holds no state and no injected collaborator, so the instance it returns behaves
+     * exactly like one built with the no-argument constructor. The context is ignored.
+     *
+     * @param context the current context, unused
+     * @deprecated 1.6M1. Use ComponentManager.lookup(AttachmentVersioningStore.class) instead.
+     */
+    @Deprecated
+    public VoidAttachmentVersioningStore.new(XWikiContext context)
+    {
+        this();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/store/StoreConstructorsCompatibilityTest.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/store/StoreConstructorsCompatibilityTest.java
@@ -1,0 +1,118 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.store;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.store.hibernate.HibernateAttachmentRecycleBinStore;
+import com.xpn.xwiki.store.hibernate.HibernateAttachmentVersioningStore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the deprecated store constructors re-added by
+ * {@code StoreConstructorsCompatibilityAspect}.
+ *
+ * @version $Id$
+ * @since 18.7.0RC1
+ */
+@SuppressWarnings("deprecation")
+class StoreConstructorsCompatibilityTest
+{
+    private static final String CONFIGURED_PATH = "/WEB-INF/custom-hibernate.cfg.xml";
+
+    private static final String EXPLICIT_PATH = "/explicit/hibernate.cfg.xml";
+
+    private XWiki xwiki;
+
+    private XWikiContext context;
+
+    @BeforeEach
+    void setUp()
+    {
+        this.xwiki = mock(XWiki.class);
+        when(this.xwiki.Param("xwiki.store.hibernate.path", "/WEB-INF/hibernate.cfg.xml"))
+            .thenReturn(CONFIGURED_PATH);
+
+        this.context = mock(XWikiContext.class);
+        when(this.context.getWiki()).thenReturn(this.xwiki);
+    }
+
+    @Test
+    void baseStoreTakesThePathFromTheConfiguration()
+    {
+        assertEquals(CONFIGURED_PATH, new XWikiHibernateBaseStore(this.xwiki, this.context).getPath());
+    }
+
+    @Test
+    void baseStoreTakesTheExplicitPath()
+    {
+        assertEquals(EXPLICIT_PATH, new XWikiHibernateBaseStore(EXPLICIT_PATH).getPath());
+    }
+
+    @Test
+    void storeTakesThePathFromTheConfiguration()
+    {
+        assertEquals(CONFIGURED_PATH, new XWikiHibernateStore(this.xwiki, this.context).getPath());
+        assertEquals(CONFIGURED_PATH, new XWikiHibernateStore(this.context).getPath());
+        assertEquals(EXPLICIT_PATH, new XWikiHibernateStore(EXPLICIT_PATH).getPath());
+    }
+
+    @Test
+    void attachmentStoreTakesThePathFromTheConfiguration()
+    {
+        assertEquals(CONFIGURED_PATH, new XWikiHibernateAttachmentStore(this.xwiki, this.context).getPath());
+        assertEquals(CONFIGURED_PATH, new XWikiHibernateAttachmentStore(this.context).getPath());
+        assertEquals(EXPLICIT_PATH, new XWikiHibernateAttachmentStore(EXPLICIT_PATH).getPath());
+    }
+
+    @Test
+    void versioningStoreTakesThePathFromTheConfiguration()
+    {
+        assertEquals(CONFIGURED_PATH, new XWikiHibernateVersioningStore(this.xwiki, this.context).getPath());
+        assertEquals(CONFIGURED_PATH, new XWikiHibernateVersioningStore(this.context).getPath());
+        assertEquals(EXPLICIT_PATH, new XWikiHibernateVersioningStore(EXPLICIT_PATH).getPath());
+    }
+
+    @Test
+    void recycleBinStoresTakeThePathFromTheConfiguration()
+    {
+        assertEquals(CONFIGURED_PATH, new XWikiHibernateRecycleBinStore(this.context).getPath());
+        assertEquals(CONFIGURED_PATH, new HibernateAttachmentRecycleBinStore(this.context).getPath());
+    }
+
+    @Test
+    void attachmentVersioningStoreTakesThePathFromTheConfiguration()
+    {
+        assertEquals(CONFIGURED_PATH, new HibernateAttachmentVersioningStore(this.context).getPath());
+    }
+
+    @Test
+    void voidAttachmentVersioningStoreIgnoresTheContext()
+    {
+        assertNotNull(new VoidAttachmentVersioningStore(this.context));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/VoidAttachmentVersioningStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/VoidAttachmentVersioningStore.java
@@ -47,17 +47,6 @@ import com.xpn.xwiki.doc.XWikiAttachmentArchive;
 public class VoidAttachmentVersioningStore implements AttachmentVersioningStore
 {
     /**
-     * Constructor used by {@link com.xpn.xwiki.XWiki} during storage initialization.
-     *
-     * @param context The current context.
-     * @deprecated 1.6M1. Use ComponentManager.lookup(AttachmentVersioningStore.class) instead.
-     */
-    @Deprecated
-    public VoidAttachmentVersioningStore(XWikiContext context)
-    {
-    }
-
-    /**
      * Empty constructor needed for component manager.
      */
     public VoidAttachmentVersioningStore()

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateAttachmentStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateAttachmentStore.java
@@ -57,42 +57,6 @@ public class XWikiHibernateAttachmentStore extends XWikiHibernateBaseStore imple
     private AttachmentVersioningStore attachmentVersioningStore;
 
     /**
-     * This allows to initialize our storage engine. The hibernate config file path is taken from xwiki.cfg or directly
-     * in the WEB-INF directory.
-     *
-     * @param xwiki
-     * @param context
-     * @deprecated 1.6M1. Use ComponentManager.lookup(XWikiAttachmentStoreInterface.class) instead.
-     */
-    @Deprecated
-    public XWikiHibernateAttachmentStore(XWiki xwiki, XWikiContext context)
-    {
-        super(xwiki, context);
-    }
-
-    /**
-     * @see #XWikiHibernateAttachmentStore(XWiki, XWikiContext)
-     * @deprecated 1.6M1. Use ComponentManager.lookup(XWikiAttachmentStoreInterface.class) instead.
-     */
-    @Deprecated
-    public XWikiHibernateAttachmentStore(XWikiContext context)
-    {
-        this(context.getWiki(), context);
-    }
-
-    /**
-     * Initialize the storage engine with a specific path This is used for tests.
-     *
-     * @param hibpath
-     * @deprecated 1.6M1. Use ComponentManager.lookup(XWikiAttachmentStoreInterface.class) instead.
-     */
-    @Deprecated
-    public XWikiHibernateAttachmentStore(String hibpath)
-    {
-        super(hibpath);
-    }
-
-    /**
      * Empty constructor needed for component manager.
      */
     public XWikiHibernateAttachmentStore()

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateBaseStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateBaseStore.java
@@ -85,39 +85,6 @@ public class XWikiHibernateBaseStore extends AbstractXWikiStore
     private Execution execution;
 
     /**
-     * THis allows to initialize our storage engine. The hibernate config file path is taken from xwiki.cfg or directly
-     * in the WEB-INF directory.
-     *
-     * @param xwiki
-     * @param context
-     * @deprecated 1.6M1. Use ComponentManager.lookup(String) instead.
-     */
-    @Deprecated
-    public XWikiHibernateBaseStore(XWiki xwiki, XWikiContext context)
-    {
-        String path = xwiki.Param("xwiki.store.hibernate.path", "/WEB-INF/hibernate.cfg.xml");
-        LOGGER.debug("Hibernate configuration file: [{}]", path);
-
-        this.hibernateConfiguration = new HibernateConfiguration();
-
-        setPath(path);
-    }
-
-    /**
-     * Initialize the storage engine with a specific path This is used for tests.
-     *
-     * @param hibpath
-     * @deprecated 1.6M1. Use ComponentManager.lookup(String) instead.
-     */
-    @Deprecated
-    public XWikiHibernateBaseStore(String hibpath)
-    {
-        this.hibernateConfiguration = new HibernateConfiguration();
-
-        setPath(hibpath);
-    }
-
-    /**
      * Empty constructor needed for component manager.
      */
     public XWikiHibernateBaseStore()

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateRecycleBinStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateRecycleBinStore.java
@@ -180,16 +180,6 @@ public class XWikiHibernateRecycleBinStore extends XWikiHibernateBaseStore imple
     private Logger logger;
 
     /**
-     * @param context used for environment
-     * @deprecated 1.6M1. Use ComponentManager#getInstance(XWikiRecycleBinStoreInterface.class) instead.
-     */
-    @Deprecated
-    public XWikiHibernateRecycleBinStore(XWikiContext context)
-    {
-        super(context.getWiki(), context);
-    }
-
-    /**
      * Empty constructor needed for component manager.
      */
     public XWikiHibernateRecycleBinStore()

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
@@ -215,44 +215,6 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
     private Optional<Set<EntityReference>> optimizedObjectClasses;
 
     /**
-     * This allows to initialize our storage engine. The hibernate config file path is taken from xwiki.cfg or directly
-     * in the WEB-INF directory.
-     *
-     * @param xwiki
-     * @param context
-     * @deprecated 1.6M1. Use ComponentManager.lookup(XWikiStoreInterface.class) instead.
-     */
-    @Deprecated
-    public XWikiHibernateStore(XWiki xwiki, XWikiContext context)
-    {
-        super(xwiki, context);
-        initValidColumTypes();
-    }
-
-    /**
-     * Initialize the storage engine with a specific path. This is used for tests.
-     *
-     * @param hibpath
-     * @deprecated 1.6M1. Use ComponentManager.lookup(XWikiStoreInterface.class) instead.
-     */
-    @Deprecated
-    public XWikiHibernateStore(String hibpath)
-    {
-        super(hibpath);
-        initValidColumTypes();
-    }
-
-    /**
-     * @see #XWikiHibernateStore(XWiki, XWikiContext)
-     * @deprecated 1.6M1. Use ComponentManager.lookup(XWikiStoreInterface.class) instead.
-     */
-    @Deprecated
-    public XWikiHibernateStore(XWikiContext context)
-    {
-        this(context.getWiki(), context);
-    }
-
-    /**
      * Empty constructor needed for component manager.
      */
     public XWikiHibernateStore()

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateVersioningStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateVersioningStore.java
@@ -33,7 +33,6 @@ import org.xwiki.component.util.DefaultParameterizedType;
 import org.xwiki.model.reference.WikiReference;
 import org.xwiki.user.UserReferenceSerializer;
 
-import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.criteria.impl.RevisionCriteria;
@@ -57,43 +56,6 @@ import com.xpn.xwiki.web.Utils;
 @Singleton
 public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore implements XWikiVersioningStoreInterface
 {
-    /**
-     * This allows to initialize our storage engine. The hibernate config file path is taken from xwiki.cfg or directly
-     * in the WEB-INF directory.
-     *
-     * @param xwiki The xwiki object
-     * @param context The current context
-     * @deprecated 1.6M1. use ComponentManager.lookup(XWikiVersioningStoreInterface.class) instead.
-     */
-    @Deprecated
-    public XWikiHibernateVersioningStore(XWiki xwiki, XWikiContext context)
-    {
-        super(xwiki, context);
-    }
-
-    /**
-     * Initialize the storage engine with a specific path This is used for tests.
-     *
-     * @param hibpath path to hibernate.hbm.xml file
-     * @deprecated 1.6M1. use ComponentManager.lookup(XWikiVersioningStoreInterface.class) instead.
-     */
-    @Deprecated
-    public XWikiHibernateVersioningStore(String hibpath)
-    {
-        super(hibpath);
-    }
-
-    /**
-     * @see #XWikiHibernateVersioningStore(XWiki, XWikiContext)
-     * @param context The current context
-     * @deprecated 1.6M1. use ComponentManager.lookup(XWikiVersioningStoreInterface.class) instead.
-     */
-    @Deprecated
-    public XWikiHibernateVersioningStore(XWikiContext context)
-    {
-        this(context.getWiki(), context);
-    }
-
     /**
      * Empty constructor needed for component manager.
      */

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/HibernateAttachmentRecycleBinStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/HibernateAttachmentRecycleBinStore.java
@@ -79,18 +79,6 @@ public class HibernateAttachmentRecycleBinStore extends XWikiHibernateBaseStore 
     private Logger logger;
 
     /**
-     * Constructor used by {@link com.xpn.xwiki.XWiki} during storage initialization.
-     *
-     * @param context The current context.
-     * @deprecated 1.6M1. Use ComponentManager.lookup(AttachmentRecycleBinStore.class) instead.
-     */
-    @Deprecated
-    public HibernateAttachmentRecycleBinStore(XWikiContext context)
-    {
-        super(context.getWiki(), context);
-    }
-
-    /**
      * Empty constructor needed for component manager.
      */
     public HibernateAttachmentRecycleBinStore()

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/HibernateAttachmentVersioningStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/HibernateAttachmentVersioningStore.java
@@ -52,16 +52,6 @@ public class HibernateAttachmentVersioningStore extends XWikiHibernateBaseStore 
     private Logger logger;
 
     /**
-     * @param context the current context.
-     * @deprecated 1.6M1. Use ComponentManager.lookup(AttachmentVersioningStore.class) instead.
-     */
-    @Deprecated
-    public HibernateAttachmentVersioningStore(XWikiContext context)
-    {
-        super(context.getWiki(), context);
-    }
-
-    /**
      * Empty constructor needed for component manager.
      */
     public HibernateAttachmentVersioningStore()


### PR DESCRIPTION
Follow-up to @tmortagne's review comment on #6070:

> Yeah, I'm afraid the days when that constructor was fully working is long gone. We added a lot of injection since then. I would not completely delete it, but the javadoc should definitely be updated (same for all \*Store constructors) and +1 to move it to legacy/

## What this does

The 15 deprecated public constructors of the 8 `*Store` classes leave `xwiki-platform-oldcore` and are re-added by `xwiki-platform-legacy-oldcore`, which already weaves oldcore. Their javadoc now says what they actually produce.

| Class | Constructors moved |
|---|---|
| `XWikiHibernateBaseStore` | `(XWiki, XWikiContext)`, `(String)` |
| `XWikiHibernateStore` | `(XWiki, XWikiContext)`, `(String)`, `(XWikiContext)` |
| `XWikiHibernateAttachmentStore` | `(XWiki, XWikiContext)`, `(String)`, `(XWikiContext)` |
| `XWikiHibernateVersioningStore` | `(XWiki, XWikiContext)`, `(String)`, `(XWikiContext)` |
| `XWikiHibernateRecycleBinStore` | `(XWikiContext)` |
| `HibernateAttachmentRecycleBinStore` | `(XWikiContext)` |
| `HibernateAttachmentVersioningStore` | `(XWikiContext)` |
| `VoidAttachmentVersioningStore` | `(XWikiContext)` |

The no-argument constructors used by the component manager stay in oldcore. Behaviour is unchanged: an existing extension calling one of these still links and still gets the same Hibernate configuration path.

## Notes for the reviewer

**Why one aspect instead of one per class.** The subclass constructors used to reach their initialization through `super(xwiki, context)`. That superclass constructor no longer exists in the main jar, and an inter-type constructor cannot call another inter-type constructor as its `super(...)`. So all 15 live in a single `StoreConstructorsCompatibilityAspect`, each starting with `this()` and sharing one private helper, rather than duplicating the base initialization into seven aspects.

**Javadoc wording.** All of them say the returned store is not usable and why — except `VoidAttachmentVersioningStore`, which holds no state and no injected collaborator, so its constructor genuinely still works and claiming otherwise would be false.

**No Revapi ignore is needed.** Revapi is skipped on oldcore (the legacy module runs it on the woven jar), and the woven legacy jar's API is unchanged, so it compares clean: `Comparing [xwiki-platform-legacy-oldcore:18.6.0] against [18.7.0-SNAPSHOT] ... API checks completed without failures.`

**No WAR change is needed.** `xwiki-platform-legacy-oldcore` was already a weaver, so `xwiki-platform-oldcore` is already banned in `xwiki-platform-distribution-war-legacydependencies`.

## Verification

- No caller of any of these 15 constructors exists in xwiki-commons, xwiki-rendering or xwiki-platform.
- `mvn clean install -Pquality,legacy` on `xwiki-platform-oldcore` + `xwiki-platform-legacy-oldcore`: BUILD SUCCESS, 1141 + 48 tests green, Revapi clean.
- `javap` on both jars: the main jar exposes only the no-arg constructors; the woven legacy jar re-adds all 15, each keeping its `java.lang.Deprecated` flag.
- New `StoreConstructorsCompatibilityTest` (8 tests) asserts each re-added constructor still sets the Hibernate configuration path as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
