### PR TITLE
XWIKI-23710: The profile button name is being read twice by the narrators on Chrome and Edge

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/css/users.css
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/css/users.css
@@ -67,6 +67,14 @@ li.group {
   margin-right: .3em;
 }
 
+// #displayUser()/#displayGroup() add this class on the avatar when the name isn't visually displayed
+// (e.g. an icon-only avatar link): there is then no visible name next to the avatar to justify the spacing
+// above, and keeping it would widen the link's box past the avatar image itself (see XWIKI-23710).
+.user-avatar.icon-only,
+.group-avatar.icon-only {
+  margin-right: 0;
+}
+
 .user img.user-avatar,
 .group img.group-avatar {
   border-radius: var(--border-radius-small);

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/css/users.css
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/css/users.css
@@ -102,7 +102,6 @@ img.group-avatar.large-avatar {
 img.user-avatar.circle-avatar,
 img.group-avatar.circle-avatar {
   border-radius: 50%;
-  object-fit: cover;
 }
 
 img.user-avatar.small-avatar.circle-avatar,

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/css/users.css
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/css/users.css
@@ -102,6 +102,25 @@ img.group-avatar.large-avatar {
 img.user-avatar.circle-avatar,
 img.group-avatar.circle-avatar {
   border-radius: 50%;
+  object-fit: cover;
+}
+
+img.user-avatar.small-avatar.circle-avatar,
+img.group-avatar.small-avatar.circle-avatar {
+  height: 18px;
+  width: 18px;
+}
+
+img.user-avatar.medium-avatar.circle-avatar,
+img.group-avatar.medium-avatar.circle-avatar {
+  height: 32px;
+  width: 32px;
+}
+
+img.user-avatar.large-avatar.circle-avatar,
+img.group-avatar.large-avatar.circle-avatar {
+  height: 50px;
+  width: 50px;
 }
 
 .user .user-alias,

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/css/users.css
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/css/users.css
@@ -67,9 +67,6 @@ li.group {
   margin-right: .3em;
 }
 
-// #displayUser()/#displayGroup() add this class on the avatar when the name isn't visually displayed
-// (e.g. an icon-only avatar link): there is then no visible name next to the avatar to justify the spacing
-// above, and keeping it would widen the link's box past the avatar image itself (see XWIKI-23710).
 .user-avatar.icon-only,
 .group-avatar.icon-only {
   margin-right: 0;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/css/users.css
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/css/users.css
@@ -81,14 +81,26 @@ li.group {
   max-width: 32px;
 }
 
-.large-avatars img.user-avatar,
-.large-avatars img.group-avatar {
+img.user-avatar.small-avatar,
+img.group-avatar.small-avatar {
+  max-height: 18px;
+  max-width: 18px;
+}
+
+img.user-avatar.medium-avatar,
+img.group-avatar.medium-avatar {
+  max-height: 32px;
+  max-width: 32px;
+}
+
+img.user-avatar.large-avatar,
+img.group-avatar.large-avatar {
   max-height: 50px;
   max-width: 50px;
 }
 
-.circle-avatars img.user-avatar,
-.circle-avatars img.group-avatar {
+img.user-avatar.circle-avatar,
+img.group-avatar.circle-avatar {
   border-radius: 50%;
 }
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/css/users.css
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/css/users.css
@@ -81,6 +81,17 @@ li.group {
   max-width: 32px;
 }
 
+.large-avatars img.user-avatar,
+.large-avatars img.group-avatar {
+  max-height: 50px;
+  max-width: 50px;
+}
+
+.circle-avatars img.user-avatar,
+.circle-avatars img.group-avatar {
+  border-radius: 50%;
+}
+
 .user .user-alias,
 .group .group-alias {
   color: var(--text-muted);

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/drawer.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/drawer.vm
@@ -27,10 +27,11 @@ aria-label="$escapetool.xml($services.localization.render('core.menu.drawer.labe
     ##
     ## Drawer header (with elements concerning the current user: profile, login, logout, register, etc...)
     ##
-    <li class="drawer-brand clearfix">
-      <a href="$xwiki.getURL($xcontext.user, 'view')">
-        #largeUserAvatar($xcontext.user)
-      </a>
+    <li class="drawer-brand clearfix large-avatars circle-avatars">
+      #displayUser($xcontext.user {
+        'useInlineHTML': true,
+        'displayName': false
+      })
       <div class="brand-links">
         #define ($logoutLink)
           ## In the event of a logout action being performed while currently on the logout page

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/drawer.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/drawer.vm
@@ -27,10 +27,11 @@ aria-label="$escapetool.xml($services.localization.render('core.menu.drawer.labe
     ##
     ## Drawer header (with elements concerning the current user: profile, login, logout, register, etc...)
     ##
-    <li class="drawer-brand clearfix large-avatars circle-avatars">
+    <li class="drawer-brand clearfix">
       #displayUser($xcontext.user {
         'useInlineHTML': true,
-        'displayName': false
+        'displayName': false,
+        'avatarCssClass': 'large-avatar circle-avatar'
       })
       <div class="brand-links">
         #define ($logoutLink)

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/action-menus.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/action-menus.less
@@ -185,10 +185,10 @@ li:has(+ li #tmRegister) #tmLogin {
 // Navbar avatar ==========================================================
 
 .navbar-avatar {
-  > a {
+  a {
     max-height: @navbar-height;
 
-    > img {
+    img {
       @avatar-size: floor((ceil((@navbar-height / 2)) / 2)) * 2;
       border-radius: @thumbnail-border-radius;
       height: @avatar-size;
@@ -201,7 +201,8 @@ li:has(+ li #tmRegister) #tmLogin {
 
 // Icon in a navbar  ======================================================
 
-.icon-navbar {
+.icon-navbar,
+.navbar-avatar a {
   cursor: pointer;
 }
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
@@ -100,7 +100,7 @@
       }
 
       // Avoid squishing down the avatar when the account name is too large
-      > :first-child {
+      > .user {
         flex-shrink: 0;
       }
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
@@ -99,13 +99,9 @@
         }
       }
 
-      // Avatar styling
-      img.avatar {
-        border-radius: 50%;
-        height: 50px;
-        width: 50px;
-        // Overwrite the default for img and avoid squishing down the avatar when the account name is too large
-        max-width: unset;
+      // Avoid squishing down the avatar when the account name is too large
+      > :first-child {
+        flex-shrink: 0;
       }
 
       .brand-links {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -943,6 +943,9 @@ web.paging.previousPage=&lt; Previous
 web.paging.nextPage=Next &gt;
 web.paging.lastPage=Last &raquo;
 
+### #displayUser()
+web.displayUser.viewProfile.hint=View the profile of {0}
+
 tempdirnotset=Temporary directory not set. Please follow the instructions on <a href="http://www.xwiki.org/xwiki/bin/view/FAQ/WhyAmIGettingANullPointerExceptionWhenUploadingFiles">xwiki.org</a> on how to fix this.
 
 # Comments for history

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/UserProfileUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/UserProfileUIX.xml
@@ -166,12 +166,11 @@
 {{html clean="false"}}
 #if ($xcontext.user != 'XWiki.XWikiGuest')
   &lt;li class="navbar-avatar"&gt;
-    &lt;a href="$xwiki.getURL($xcontext.user)" class="icon-navbar"&gt;
-      &lt;span class="sr-only"&gt;$services.localization.render('homepage')&lt;/span&gt;
-      ## Use a mix of server side and client side resizing to improve the page loading time without affecting too
-      ## much the image quality.
-      #mediumUserAvatar($xcontext.user)
-    &lt;/a&gt;
+    #displayUser($xcontext.user {
+      'useInlineHTML': true,
+      'avatarSize': 50,
+      'displayName': false
+    })
   &lt;/li&gt;
 #end
 {{/html}}

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/UserProfileUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/UserProfileUIX.xml
@@ -168,7 +168,7 @@
   &lt;li class="navbar-avatar"&gt;
     #displayUser($xcontext.user {
       'useInlineHTML': true,
-      'avatarSize': 50,
+      'avatarCssClass': 'medium-avatar',
       'displayName': false
     })
   &lt;/li&gt;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -242,6 +242,10 @@ $xwiki.getUserName("xwiki:${username}")
  *   useInlineHTML: false, // whether to use in-line HTML elements to display the user or not
  *   wrapAvatar: false // whether to wrap the avatar image with a span or not
  *   displayLink: true // @since 15.9 ; whether to wrap the user name in a link to the user profile
+ *   avatarSize: 120 // @since 18.7.0RC1 ; the size (in pixels) of the avatar
+ *   displayName: true // @since 18.7.0RC1 ; whether to visually display the name (it stays exposed to assistive
+ *                      // technologies either way, through a native tooltip on the avatar when false); set to
+ *                      // false together with displayLink when the avatar alone is enough on screen
  * }
  *#
 #macro (displayUser $arg $options)
@@ -258,7 +262,9 @@ $xwiki.getUserName("xwiki:${username}")
     'showAlias': false,
     'useInlineHTML': false,
     'wrapAvatar': false,
-    'displayLink': true
+    'displayLink': true,
+    'avatarSize': 120,
+    'displayName': true
   })
   #if ($options.entrySet())
     #set ($discard = $macro.options.putAll($options))
@@ -301,12 +307,21 @@ $xwiki.getUserName("xwiki:${username}")
       #set ($userAliasDisplay = "<span class=""${type}-alias"">" + $escapetool.xml($userAlias) + '</span>')
     #end
     #set ($escapedUserName = $escapetool.xml($userName))
-    #getUserAvatarURL($userReference $avatarURL 120)
+    #getUserAvatarURL($userReference $avatarURL $macro.options.avatarSize)
     #set ($avatarWrapperStart = '')
     #set ($avatarWrapperEnd = '')
     #if ($macro.options.wrapAvatar)
       #set ($avatarWrapperStart = "<span class=""${type}-avatar-wrapper"">")
       #set ($avatarWrapperEnd = '</span>')
+    #end
+    #set ($avatarExtraAttributes = '')
+    #set ($displayedUserName = $escapedUserName)
+    #if (!$macro.options.displayName)
+      ## The name isn't visible, so give the avatar a native tooltip instead - and hide it from assistive
+      ## technologies since it now carries a tooltip duplicating the name; without this, some screen readers
+      ## announce the name a second time on hover (see XWIKI-23710).
+      #set ($avatarExtraAttributes = " title=""$escapedUserName"" aria-hidden=""true""")
+      #set ($displayedUserName = "<span class=""sr-only"">$escapedUserName</span>")
     #end
     #set($userNameTagAttributes = "class=""${type}-name""")
     #if ($macro.options.displayLink)
@@ -320,9 +335,9 @@ $xwiki.getUserName("xwiki:${username}")
       "<$userTag class=""$type"" data-reference=""$escapetool.xml($userReference)"">",
         "<$userNameTag $userNameTagAttributes>",
         $avatarWrapperStart,
-          "<img class=""${type}-avatar"" src=""$escapetool.xml($avatarURL.url)"" alt="""" />",
+          "<img class=""${type}-avatar""$avatarExtraAttributes src=""$escapetool.xml($avatarURL.url)"" alt="""" />",
         $avatarWrapperEnd,
-        $escapedUserName,
+        $displayedUserName,
         "</$userNameTag>",
         $userAliasDisplay,
       "</$userTag>"

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -324,9 +324,6 @@ $xwiki.getUserName("xwiki:${username}")
       ## The name isn't visible, so give the avatar a native tooltip instead - and hide it from assistive
       ## technologies since it now carries a tooltip duplicating the name; without this, some screen readers
       ## announce the name a second time on hover (see XWIKI-23710).
-      ## Also drop the spacing that "${type}-avatar" normally reserves for a visible name next to it: with no
-      ## visible name, that margin is invisible but still widens the link's box past the avatar image, which
-      ## e.g. throws off the browser's native focus ring around the link (see XWIKI-23710).
       #set ($avatarClass = "$avatarClass icon-only")
       #set ($avatarExtraAttributes = " title=""$escapedUserName"" aria-hidden=""true""")
       #set ($accessibleUserName = $escapedUserName)

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -242,7 +242,9 @@ $xwiki.getUserName("xwiki:${username}")
  *   useInlineHTML: false, // whether to use in-line HTML elements to display the user or not
  *   wrapAvatar: false // whether to wrap the avatar image with a span or not
  *   displayLink: true // @since 15.9 ; whether to wrap the user name in a link to the user profile
- *   avatarSize: 120 // @since 18.7.0RC1 ; the size (in pixels) of the avatar
+ *   avatarCssClass: '' // @since 18.7.0RC1 ; extra CSS class(es) to add on the avatar image; available classes
+ *                       // are "small-avatar"/"medium-avatar"/"large-avatar" for the size and "circle-avatar"
+ *                       // for a fully rounded avatar
  *   displayName: true // @since 18.7.0RC1 ; whether to visually display the name (it stays exposed to assistive
  *                      // technologies either way, through a native tooltip on the avatar when false); set to
  *                      // false together with displayLink when the avatar alone is enough on screen
@@ -263,7 +265,7 @@ $xwiki.getUserName("xwiki:${username}")
     'useInlineHTML': false,
     'wrapAvatar': false,
     'displayLink': true,
-    'avatarSize': 120,
+    'avatarCssClass': '',
     'displayName': true
   })
   #if ($options.entrySet())
@@ -307,12 +309,16 @@ $xwiki.getUserName("xwiki:${username}")
       #set ($userAliasDisplay = "<span class=""${type}-alias"">" + $escapetool.xml($userAlias) + '</span>')
     #end
     #set ($escapedUserName = $escapetool.xml($userName))
-    #getUserAvatarURL($userReference $avatarURL $macro.options.avatarSize)
+    #getUserAvatarURL($userReference $avatarURL 120)
     #set ($avatarWrapperStart = '')
     #set ($avatarWrapperEnd = '')
     #if ($macro.options.wrapAvatar)
       #set ($avatarWrapperStart = "<span class=""${type}-avatar-wrapper"">")
       #set ($avatarWrapperEnd = '</span>')
+    #end
+    #set ($avatarClass = "${type}-avatar")
+    #if ("$!macro.options.avatarCssClass" != '')
+      #set ($avatarClass = "$avatarClass $macro.options.avatarCssClass")
     #end
     #set ($avatarExtraAttributes = '')
     #set ($displayedUserName = $escapedUserName)
@@ -335,7 +341,7 @@ $xwiki.getUserName("xwiki:${username}")
       "<$userTag class=""$type"" data-reference=""$escapetool.xml($userReference)"">",
         "<$userNameTag $userNameTagAttributes>",
         $avatarWrapperStart,
-          "<img class=""${type}-avatar""$avatarExtraAttributes src=""$escapetool.xml($avatarURL.url)"" alt="""" />",
+          "<img class=""$escapetool.xml($avatarClass)""$avatarExtraAttributes src=""$escapetool.xml($avatarURL.url)"" alt="""" />",
         $avatarWrapperEnd,
         $displayedUserName,
         "</$userNameTag>",

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -325,7 +325,12 @@ $xwiki.getUserName("xwiki:${username}")
       ## technologies since it now carries a tooltip duplicating the name; without this, some screen readers
       ## announce the name a second time on hover (see XWIKI-23710).
       #set ($avatarExtraAttributes = " title=""$escapedUserName"" aria-hidden=""true""")
-      #set ($displayedUserName = "<span class=""sr-only"">$escapedUserName</span>")
+      #set ($accessibleUserName = $escapedUserName)
+      #if ($macro.options.displayLink)
+        ## Without a visible name, provide an appropriate accessible name for the link.
+        #set ($accessibleUserName = $escapetool.xml($services.localization.render('web.displayUser.viewProfile.hint', [$userName])))
+      #end
+      #set ($displayedUserName = "<span class=""sr-only"">$accessibleUserName</span>")
     #end
     #set($userNameTagAttributes = "class=""${type}-name""")
     #if ($macro.options.displayLink)

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -245,9 +245,7 @@ $xwiki.getUserName("xwiki:${username}")
  *   avatarCssClass: '' // @since 18.7.0RC1 ; extra CSS class(es) to add on the avatar image; available classes
  *                       // are "small-avatar"/"medium-avatar"/"large-avatar" for the size and "circle-avatar"
  *                       // for a fully rounded avatar
- *   displayName: true // @since 18.7.0RC1 ; whether to visually display the name (it stays exposed to assistive
- *                      // technologies either way, through a native tooltip on the avatar when false); set to
- *                      // false together with displayLink when the avatar alone is enough on screen
+ *   displayName: true // @since 18.7.0RC1 ; whether to visually display the name
  * }
  *#
 #macro (displayUser $arg $options)

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -324,6 +324,10 @@ $xwiki.getUserName("xwiki:${username}")
       ## The name isn't visible, so give the avatar a native tooltip instead - and hide it from assistive
       ## technologies since it now carries a tooltip duplicating the name; without this, some screen readers
       ## announce the name a second time on hover (see XWIKI-23710).
+      ## Also drop the spacing that "${type}-avatar" normally reserves for a visible name next to it: with no
+      ## visible name, that margin is invisible but still widens the link's box past the avatar image, which
+      ## e.g. throws off the browser's native focus ring around the link (see XWIKI-23710).
+      #set ($avatarClass = "$avatarClass icon-only")
       #set ($avatarExtraAttributes = " title=""$escapedUserName"" aria-hidden=""true""")
       #set ($accessibleUserName = $escapedUserName)
       #if ($macro.options.displayLink)


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-23710

# Changes

## Description

* Hide the avatar's native tooltip from assistive technologies to stop screen readers announcing the user name twice
* Factorize the profile avatar button and the Drawer's avatar link onto the existing #displayUser() macro
  * Add "avatarCssClass" and "displayName" options to #displayUser():
    * "avatarCssClass" lets callers add extra CSS class(es) on the avatar image, picking from the new "small-avatar"/"medium-avatar"/"large-avatar" size modifiers and the "circle-avatar" shape modifier
    * "displayName" (default true) controls whether the user name is visually displayed; when false, the avatar gets a native `title` tooltip and is hidden from assistive technologies (`aria-hidden`), and an accessible name is provided on the link instead (a new translation key, `web.displayUser.viewProfile.hint`, localizes that hint for icon-only avatar links)
  * Add "small-avatar"/"medium-avatar"/"large-avatar" and "circle-avatar" classes to users.less, applied directly on the avatar `<img>` instead of on an ancestor container
  * Use "avatarCssClass" in the Drawer's avatar link and the profile avatar button instead of container-based avatar styling
  * Widen two LESS selectors (in drawer.less and action-menus.less) to match #displayUser()'s markup

## Clarifications

* Firefox has a separate, related bug (reads the full profile URL instead of duplicating the name) tracked as XWIKI-23714.
* `#resizedUserAvatar()`/`#largeUserAvatar()`/etc. are untouched.

# Screenshots & Video

<img width="2160" height="1600" alt="comparison-nocrop" src="https://github.com/user-attachments/assets/7f1b4b79-f17e-4bff-85e7-e386b11d7a21" />

# Executed Tests

* `mvn clean install -B -ntp -Plegacy -fae -pl xwiki-platform-core/xwiki-platform-oldcore,xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates,xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources,xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui` - all four touched modules compile, LESS/XAR verify, Checkstyle (0 violations) and Revapi pass; `xwiki-platform-web-templates` (82/82) and `xwiki-platform-user-profile-ui` (1/1) tests pass.
* `xwiki-platform-oldcore`'s test run has one pre-existing, unrelated failure (`XWikiDocumentTest.testRenderedTitleWhenVelocityError`), already present on `origin/master` since the unrelated logging-cleanup PR #6063 - confirmed not caused by this branch (this PR's diff touches only `drawer.vm`, `action-menus.less`, `drawer.less`, `users.less`, `ApplicationResources.properties`, `UserProfileUIX.xml` and `macros.vm`).

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None

