### PR TITLE
XWIKI-24665: Apply the logging best practices across commons, rendering and platform

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
@@ -846,7 +846,11 @@ public class Package
                         // let's log the error but not stop
                         result = DocumentInfo.INSTALL_ERROR;
                         addToErrors(doc.getFullName() + ":" + doc.getLanguage(), context);
-                        LOGGER.error("Failed to delete document [{}]", previousdoc.getDocumentReference(), e);
+                        // The stack trace is kept for the debug level: this runs once per document of the
+                        // package, so printing a trace for every failure would flood the log.
+                        String failedToDelete = "Failed to delete document [{}]";
+                        LOGGER.error(failedToDelete, previousdoc.getDocumentReference());
+                        LOGGER.debug(failedToDelete, previousdoc.getDocumentReference(), e);
                     }
                 } else if (previousdoc.hasElement(XWikiDocument.HAS_ATTACHMENTS)) {
                     // We conserve the old attachments in the new documents

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/stats/impl/xwiki/XWikiStatsStoreService.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/stats/impl/xwiki/XWikiStatsStoreService.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.context.ExecutionContext;
@@ -111,8 +110,7 @@ public class XWikiStatsStoreService extends AbstractXWikiRunnable
             this.thread.join();
             this.thread = null;
         } catch (InterruptedException e) {
-            LOGGER.warn("Thread join has been interrupted. Root cause is [{}]",
-                ExceptionUtils.getRootCauseMessage(e));
+            LOGGER.warn("Thread join has been interrupted", e);
         }
     }
 
@@ -124,11 +122,10 @@ public class XWikiStatsStoreService extends AbstractXWikiRunnable
                 register();
             }
         } catch (InterruptedException e) {
-            LOGGER.warn("Statistics storing thread has been interrupted. Root cause is [{}]",
-                ExceptionUtils.getRootCauseMessage(e));
+            LOGGER.warn("Statistics storing thread has been interrupted.", e);
             throw e;
         } catch (StopStatsStoreException e) {
-            LOGGER.info("Statistics storing thread received stop order.");
+            LOGGER.warn("Statistics storing thread received stop order.", e);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/HibernateAttachmentVersioningStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/HibernateAttachmentVersioningStore.java
@@ -25,7 +25,6 @@ import javax.inject.Singleton;
 import jakarta.inject.Inject;
 
 import org.hibernate.ObjectNotFoundException;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 
@@ -108,9 +107,8 @@ public class HibernateAttachmentVersioningStore extends XWikiHibernateBaseStore 
                 return null;
             });
         } catch (Exception e) {
-            this.logger.warn("Error deleting attachment archive [{}] of doc [{}]. Root cause is [{}]",
-                attachment.getFilename(), attachment.getDoc().getDocumentReference(),
-                ExceptionUtils.getRootCauseMessage(e));
+            this.logger.warn("Error deleting attachment archive [{}] of doc [{}]", attachment.getFilename(),
+                attachment.getDoc().getDocumentReference(), e);
         }
     }
 }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24665

# Changes

## Description

Three commits, **split by risk class** so each can be reviewed — or dropped — on its own.

### 1. `XWikiStatsStoreService` — revert the level change, drop a buggy guard

The sweep turned the stop-order statement from `warn` into `info`. It goes back to `warn`, with its throwable.

The `isInfoEnabled()` guard that used to wrap it is **not** restored, because it was a bug: it tested the *info* level while the statement logged at *warn*, so the message was silently dropped whenever `warn` was enabled and `info` was not. Removing it is preferred over correcting it to `isWarnEnabled()`, since SLF4J already applies that test itself.

### 2. `XWikiStatsStoreService` + `HibernateAttachmentVersioningStore` — finish #6101

Three `warn()` sites that #6101 was supposed to fix and **missed**, so they still format the root cause into the message instead of passing the throwable:

* `XWikiStatsStoreService` — the two interrupted-thread warnings
* `HibernateAttachmentVersioningStore` — the attachment archive deletion failure

They were missed because of a tooling bug, not a decision. The classifier's detector anchored its throwable pattern at end-of-string, so any hunk that removed an `isXxxEnabled()` guard **and** dropped the throwable in the same edit ends in `}` rather than `, e);` and was filed as a harmless guard removal.

`XWikiStatsStoreService` was left internally inconsistent by that: a third site in the same class logging the very same `InterruptedException` still passes it, at `error`.

### 3. `Package#installDocument` — restore the `error` + `debug` pair

The sweep collapsed an `error` + `debug` pair into a single `error(msg, e)`. This is the **third** occurrence of that collapse and the one that was never resolved; the other two were settled earlier. The pair is deliberate: this runs once per document of a package, so a trace per failure floods the log of a large import, while raising the level still reaches it. The reason is now stated inline, since nothing in the code said why the trace sat at `debug`.

## Clarifications

* Commits 1 and 3 are the safe-side response to @tmortagne's remark that some of the sweep's level changes were *"not fully accurate"*. Rather than defend them individually, the levels go back to what their authors chose. The commons half is xwiki/xwiki-commons#1883.
* **Commit 2 finishes #6101 rather than extending it.** Forum post 11 settled that there is no further sweep of existing `warn()` sites pending XCOMMONS-3738 — that applies to sites the sweep never touched. These three were in #6101's scope and were meant to be restored.
* The two `InterruptedException` traces are of low value on their own; they are restored for consistency with the 106 others and with the `error` site next to them, not because the trace is interesting. `HibernateAttachmentVersioningStore` is the opposite case: it catches every `Exception` out of a Hibernate write, so the trace is the only thing that says which one.
* Message improvements are kept throughout — `{}` placeholders instead of `String.format`, values in brackets. In commit 3 the message goes through a local variable so it is not duplicated as a literal, which would trip Checkstyle's `MultipleStringLiterals`.
* Unused `ExceptionUtils` imports are dropped from both files.

# Executed Tests

`mvn clean install -B -ntp -Pquality,legacy -DskipITs --fail-at-end` in `xwiki-platform-oldcore`: **BUILD SUCCESS**.

* **1141 tests, 0 failures, 0 errors, 0 skipped**
* 0 Checkstyle violations
* All JaCoCo coverage checks met (755 classes analyzed)

# Expected merging strategy

* Prefers squash: No — please keep the three commits, they are separate risk classes
* Backport on branches:
  * none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
