### PR TITLE
XWIKI-24665: Apply the logging best practices across commons, rendering and platform

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -208,6 +208,92 @@
                 </item>
               </differences>
             </revapi.differences>
+            <revapi.differences>
+              <justification>
+                These deprecated store constructors moved out of xwiki-platform-oldcore and are re-added by
+                xwiki-platform-legacy-oldcore, so existing code calling them keeps working when the legacy jar is
+                used. They cannot produce a working store anyway, since these classes get all their collaborators
+                through component injection.
+              </justification>
+              <criticality>allowed</criticality>
+              <differences>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method void com.xpn.xwiki.store.XWikiHibernateBaseStore::&lt;init&gt;(com.xpn.xwiki.XWiki, com.xpn.xwiki.XWikiContext)</old>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method void com.xpn.xwiki.store.XWikiHibernateBaseStore::&lt;init&gt;(java.lang.String)</old>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method void com.xpn.xwiki.store.XWikiHibernateStore::&lt;init&gt;(com.xpn.xwiki.XWiki, com.xpn.xwiki.XWikiContext)</old>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method void com.xpn.xwiki.store.XWikiHibernateStore::&lt;init&gt;(java.lang.String)</old>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method void com.xpn.xwiki.store.XWikiHibernateStore::&lt;init&gt;(com.xpn.xwiki.XWikiContext)</old>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method void com.xpn.xwiki.store.XWikiHibernateAttachmentStore::&lt;init&gt;(com.xpn.xwiki.XWiki, com.xpn.xwiki.XWikiContext)</old>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method void com.xpn.xwiki.store.XWikiHibernateAttachmentStore::&lt;init&gt;(com.xpn.xwiki.XWikiContext)</old>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method void com.xpn.xwiki.store.XWikiHibernateAttachmentStore::&lt;init&gt;(java.lang.String)</old>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method void com.xpn.xwiki.store.XWikiHibernateVersioningStore::&lt;init&gt;(com.xpn.xwiki.XWiki, com.xpn.xwiki.XWikiContext)</old>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method void com.xpn.xwiki.store.XWikiHibernateVersioningStore::&lt;init&gt;(java.lang.String)</old>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method void com.xpn.xwiki.store.XWikiHibernateVersioningStore::&lt;init&gt;(com.xpn.xwiki.XWikiContext)</old>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method void com.xpn.xwiki.store.XWikiHibernateRecycleBinStore::&lt;init&gt;(com.xpn.xwiki.XWikiContext)</old>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method void com.xpn.xwiki.store.hibernate.HibernateAttachmentRecycleBinStore::&lt;init&gt;(com.xpn.xwiki.XWikiContext)</old>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method void com.xpn.xwiki.store.hibernate.HibernateAttachmentVersioningStore::&lt;init&gt;(com.xpn.xwiki.XWikiContext)</old>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method void com.xpn.xwiki.store.VoidAttachmentVersioningStore::&lt;init&gt;(com.xpn.xwiki.XWikiContext)</old>
+                </item>
+              </differences>
+            </revapi.differences>
           </analysisConfiguration>
         </configuration>
       </plugin>


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24665

# Changes

## Description

* Add the Revapi ignores for the 15 deprecated `*Store` constructors that
  [37f5d93](https://github.com/xwiki/xwiki-platform/commit/37f5d9353b65c43e2731ac67d489caaa1883f82c)
  moved out of `xwiki-platform-oldcore` and re-added from `xwiki-platform-legacy-oldcore`. Without
  them the build fails on `master` — see
  [#8830](https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/8830/).

## Clarifications

* The removals were not reported on the changed modules themselves. `xwiki-platform-oldcore` sets
  `<xwiki.revapi.skip>true</xwiki.revapi.skip>` (delegating to its legacy wrapper), and the wrapper's
  own check is green by construction since its woven jar re-adds exactly the constructors the main jar
  dropped. Revapi compares transitive dependencies, so the break surfaced on a downstream consumer
  instead: `XWiki.getHibernateStore()` puts `XWikiHibernateStore` in
  `xwiki-platform-extension-script`'s API, so that is the module that failed.
* All 15 constructors are ignored, not only the 3 that CI reported: the build aborted at the first
  failing module, and other consumers reach the other store classes.
* The `xwiki-legacy` skill's verification step was blind to this class of break; it is fixed in
  https://github.com/xwiki/xwiki-dev-llm/pull/new/okf-revapi-legacy-verification-gap.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

`mvn compile revapi:check -B -ntp -Pquality` in `xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script`:

* without this change: `BUILD FAILURE`, with the 3 `java.method.removed` errors from #8830;
* with this change: `BUILD SUCCESS`.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None — the moved constructors only exist on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
