### PR TITLE
XWIKI-24665: Apply the logging best practices across commons, rendering and platform

### DIFF
--- a/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/internal/ActiveInstallsPingRunnable.java
+++ b/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/internal/ActiveInstallsPingRunnable.java
@@ -93,15 +93,14 @@ public class ActiveInstallsPingRunnable extends AbstractXWikiRunnable
                 this.manager.sendPing();
                 break;
             } catch (Exception e) {
+                String message = String.format(
+                    "Failed to send Active Installation ping to [%s] (try [%s]). Error = [%s].",
+                    this.configuration.getPingInstanceURL(), count, ExceptionUtils.getRootCauseMessage(e));
                 if (count == RETRIES) {
-                    LOGGER.warn("Failed to send Active Installation ping to [{}] (try [{}]). Error = [{}]. Will "
-                        + "retry in [{} {}]...", this.configuration.getPingInstanceURL(), count,
-                        ExceptionUtils.getRootCauseMessage(e), this.period,
+                    message = String.format("%s Will retry in [%s %s]...", message, this.period,
                         this.timeUnit.toString().toLowerCase(Locale.ROOT));
-                } else {
-                    LOGGER.warn("Failed to send Active Installation ping to [{}] (try [{}]). Error = [{}].",
-                        this.configuration.getPingInstanceURL(), count, ExceptionUtils.getRootCauseMessage(e));
                 }
+                LOGGER.warn(message);
                 // Wait a little but before retrying so that it makes a difference.
                 if (count < RETRIES) {
                     Thread.sleep(getRetryTimeout());

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-validation/xwiki-platform-attachment-validation-api/src/main/java/org/xwiki/attachment/validation/AttachmentValidationScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-validation/xwiki-platform-attachment-validation-api/src/main/java/org/xwiki/attachment/validation/AttachmentValidationScriptService.java
@@ -138,7 +138,7 @@ public class AttachmentValidationScriptService implements ScriptService
             return Optional.of(attachmentValidationConfiguration);
         } catch (ComponentLookupException e) {
             this.logger.error("Failed to retrieve an instance of [{}] with hint [default].",
-                AttachmentValidationConfiguration.class.getName(), e);
+                AttachmentValidationConfiguration.class.getName());
             return Optional.empty();
         }
     }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/handler/XarExtensionHandler.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/handler/XarExtensionHandler.java
@@ -289,7 +289,7 @@ public class XarExtensionHandler extends AbstractExtensionHandler
             try {
                 currentJob = this.componentManager.<JobContext>getInstance(JobContext.class).getCurrentJob();
             } catch (Exception e) {
-                this.logger.error("Failed to lookup JobContext, it will be impossible to do interactive install", e);
+                this.logger.error("Failed to lookup JobContext, it will be impossible to do interactive install");
             }
 
             if (currentJob != null) {

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/repository/InstalledExtensionSynchronizer.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/repository/InstalledExtensionSynchronizer.java
@@ -115,7 +115,7 @@ public class InstalledExtensionSynchronizer extends AbstractEventListener
                 getXarRepository().pagesAdded(extensionEvent.getExtensionId(), extensionEvent.getNamespace());
             }
         } catch (UnsupportedNamespaceException e) {
-            logger.error("Failed to extract wiki from namespace [{}]", extensionEvent.getNamespace(), e);
+            logger.error("Failed to extract wiki from namespace [{}]", extensionEvent.getNamespace());
         }
 
         // Trigger the corresponding XAR extension event after the XAR extension repository has been synchronized.

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/DefaultGroupingEventManager.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/DefaultGroupingEventManager.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentLookupException;
@@ -89,7 +90,8 @@ public class DefaultGroupingEventManager implements GroupingEventManager
                         this.componentManager.getInstance(GroupingEventStrategy.class, strategyHint);
                 } catch (ComponentLookupException e) {
                     this.logger.error("Error when getting grouping event strategy instance with hint [{}]. "
-                        + "It will fallback on default strategy.", strategyHint, e);
+                            + "It will fallback on default strategy. Root cause: [{}].", strategyHint,
+                        ExceptionUtils.getRootCauseMessage(e));
                 }
             } else {
                 this.logger.warn(

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/rcs/XWikiRCSArchive.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/rcs/XWikiRCSArchive.java
@@ -275,7 +275,7 @@ public class XWikiRCSArchive extends Archive
                     // 3) Cannot get the revision as a string from a node version. Not sure why this
                     //    is happening though... See https://jira.xwiki.org/browse/XWIKI-2076
                     LOGGER.warn("Error in revision [{}]: [{}]. Ignoring non-fatal error, the Author, Comment and Date "
-                        + "are not set.", node.getVersion(), ExceptionUtils.getRootCauseMessage(e));
+                        + "are not set.", node.getVersion().toString(), ExceptionUtils.getRootCauseMessage(e));
                 }
             }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseElement.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseElement.java
@@ -649,7 +649,7 @@ public abstract class BaseElement<R extends EntityReference> implements ElementI
                 result = true;
             } catch (XWikiException e) {
                 LOGGER.error("Error while trying to load document [{}] as owner document of [{}]", documentReference,
-                    this, e);
+                    this);
             }
         }
         return result;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactory.java
@@ -201,7 +201,7 @@ public class FileSystemURLFactory extends XWikiServletURLFactory
                 }
 
                 File file = getTemporaryFile(key, context);
-                LOGGER.debug("Temporary PDF export file [{}]", file);
+                LOGGER.debug("Temporary PDF export file [{}]", file.toString());
 
                 if (StringUtils.isNotEmpty(revision)) {
                     attachment = attachment.getAttachmentRevision(revision, context);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/stats/impl/xwiki/RefererStatsStoreItem.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/stats/impl/xwiki/RefererStatsStoreItem.java
@@ -101,7 +101,7 @@ public class RefererStatsStoreItem extends AbstractStatsStoreItem
             // TODO Fix use of deprecated call.
             store.saveXWikiCollection(refererStat, this.context, true);
         } catch (XWikiException e) {
-            LOGGER.error("Failed to save referer statistics object [{}]", getId(), e);
+            LOGGER.error("Failed to save referer statistics object [{}]", getId());
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R140600000XWIKI19869DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R140600000XWIKI19869DataMigration.java
@@ -252,8 +252,8 @@ public class R140600000XWIKI19869DataMigration extends AbstractHibernateDataMigr
                 }
             } catch (Exception e) {
                 this.logger.warn(
-                    "Failed to handle revision [{}] for user page [{}]: [{}]. It's recommended to delete this version.",
-                    node.getVersion(), userDoc.getDocumentReference(),
+                    "Failed to handle revision [{}] for user page [{}]: {}. It's recommended to delete this version.",
+                    node.getVersion().toString(), userDoc.getDocumentReference(),
                     ExceptionUtils.getRootCauseMessage(e));
             }
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R4359XWIKI1459DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R4359XWIKI1459DataMigration.java
@@ -124,7 +124,7 @@ public class R4359XWIKI1459DataMigration extends AbstractHibernateDataMigration
                             session.createSQLQuery("update xwikidoc set XWD_ARCHIVE=' ' where XWD_ID=?");
 
                     for (Object[] result : rs) {
-                        R4359XWIKI1459DataMigration.this.logger.info("Updating document [{}]...", result[2]);
+                        R4359XWIKI1459DataMigration.this.logger.info("Updating document [{}]...", result[2].toString());
                         long docId = Long.parseLong(result[0].toString());
                         String sArchive = result[1].toString();
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyPersistentLoginManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyPersistentLoginManager.java
@@ -236,7 +236,7 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
         try {
             cookie.setMaxAge(Math.round(60 * 60 * 24 * Float.parseFloat(this.cookieLife)));
         } catch (Exception e) {
-            LOGGER.error("Failed to set the cookie max age with duration [{}]", this.cookieLife, e);
+            LOGGER.error("Failed to set the cookie max age with duration [{}]", this.cookieLife);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiURLFactoryServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiURLFactoryServiceImpl.java
@@ -63,7 +63,7 @@ public class XWikiURLFactoryServiceImpl implements XWikiURLFactoryService
                     (Class<? extends XWikiURLFactory>) Class.forName(urlFactoryClassName);
                 this.factoryMap.put(mode, urlFactoryClass);
             } catch (Exception e) {
-                LOGGER.error("Failed to load custom url factory class [{}]", urlFactoryClassName, e);
+                LOGGER.error("Failed to load custom url factory class [{}]", urlFactoryClassName);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/RatingDeletedEntityListener.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/RatingDeletedEntityListener.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.bridge.event.DocumentDeletedEvent;
 import org.xwiki.bridge.event.WikiDeletedEvent;
@@ -104,7 +105,8 @@ public class RatingDeletedEntityListener extends AbstractEventListener
                 manager.removeRatings(deletedReference);
             }
         } catch (RatingsException e) {
-            logger.error("Error while removing ratings related to reference [{}] from ratings", deletedReference, e);
+            logger.error("Error while removing ratings related to reference [{}] from ratings: [{}]",
+                deletedReference, ExceptionUtils.getRootCause(e));
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/RatingMovedEntityListener.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/RatingMovedEntityListener.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
@@ -76,7 +77,8 @@ public class RatingMovedEntityListener extends AbstractLocalEventListener
                 manager.moveRatings(oldReference, newReference);
             }
         } catch (RatingsException e) {
-            logger.error("Error while updating ratings related to old reference [{}] from ratings", oldReference, e);
+            logger.error("Error while updating ratings related to old reference [{}] from ratings: [{}]", oldReference,
+                ExceptionUtils.getRootCause(e));
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractReplaceUserJob.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractReplaceUserJob.java
@@ -32,6 +32,7 @@ import javax.inject.Named;
 
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
@@ -113,7 +114,8 @@ public abstract class AbstractReplaceUserJob
             return getDocumentsToUpdateQuery(entityReference).<Object[]>execute().stream()
                 .map(this.resolveDocumentReferenceWithLocale(entityReference)).toList();
         } catch (QueryException e) {
-            this.logger.error("Failed to retrieve the list of documents to update from [{}].", entityReference, e);
+            this.logger.error("Failed to retrieve the list of documents to update from [{}]. Root cause is [{}].",
+                entityReference, ExceptionUtils.getRootCauseMessage(e));
             return Collections.emptyList();
         }
     }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultModelBridge.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultModelBridge.java
@@ -581,7 +581,7 @@ public class DefaultModelBridge implements ModelBridge
                 result.add(deletedDocument.getId());
             }
         } catch (Exception e) {
-            logger.error("Failed to get deleted document IDs for batch [{}]", batchId, e);
+            logger.error("Failed to get deleted document IDs for batch [{}]", batchId);
         }
 
         return result;

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/job/ReplaceUserJob.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/job/ReplaceUserJob.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.refactoring.job.RefactoringJobs;
@@ -55,7 +56,8 @@ public class ReplaceUserJob extends AbstractReplaceUserJob
         try {
             update(xcontext.getWiki().getDocument(documentReference, xcontext));
         } catch (XWikiException e) {
-            this.logger.error("Failed to update document [{}].", documentReference, e);
+            this.logger.error("Failed to update document [{}]. Root cause is [{}].", documentReference,
+                ExceptionUtils.getRootCauseMessage(e));
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/ExtensionStore.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/ExtensionStore.java
@@ -375,7 +375,8 @@ public class ExtensionStore implements Initializable, Disposable
                     }
                 }
             } catch (Exception e) {
-                this.logger.error("Failed to resolve the support plan with id [{}]", supportPlanId, e);
+                this.logger.error("Failed to resolve the support plan with id [{}]: {}", supportPlanId,
+                    ExceptionUtils.getRootCauseMessage(e));
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/RepositoryManager.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/RepositoryManager.java
@@ -414,7 +414,7 @@ public class RepositoryManager
             try {
                 resourceReference = getDownloadReference(document, extensionVersion);
             } catch (Exception e) {
-                logger.debug("Cannot obtain download source reference for version [{}]", extensionVersion, e);
+                logger.debug("Cannot obtain download source reference for version [({})]", extensionVersion);
 
                 return false;
             }

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrIndexer.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrIndexer.java
@@ -756,7 +756,7 @@ public class DefaultSolrIndexer implements SolrIndexer, Initializable, Disposabl
         try {
             result = this.componentManager.getInstance(SolrMetadataExtractor.class, entityType.name().toLowerCase());
         } catch (ComponentLookupException e) {
-            this.logger.warn("Unsupported entity type: [{}]", entityType, e);
+            this.logger.warn("Unsupported entity type: [{}]", entityType.toString(), e);
         }
 
         return result;

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/AbstractDocumentSkinExtensionPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/AbstractDocumentSkinExtensionPlugin.java
@@ -30,6 +30,7 @@ import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.bridge.event.DocumentCreatedEvent;
@@ -315,7 +316,9 @@ public abstract class AbstractDocumentSkinExtensionPlugin extends AbstractSkinEx
             return getAuthorizationManager().hasAccess(Right.SCRIPT, EntityType.DOCUMENT, authorReference,
                 documentReference);
         } catch (XWikiException e) {
-            LOGGER.error("Error while loading [{}] for checking script right", documentReference, e);
+            LOGGER.error("Error while loading [{}] for checking script right: [{}]", documentReference,
+                ExceptionUtils.getRootCauseMessage(e));
+            LOGGER.debug("Original error stack trace: ", e);
             return false;
         }
     }


### PR DESCRIPTION
## What this does

Reverts a selected set of the 2026-08-01→07 logging sweep's structural changes, identified by parsing
every logging statement in the whole sweep range in both tree versions and diffing them pairwise. The
full report of that analysis is posted verbatim in the comments of this PR.

The sweep was too large to review statement by statement when it was merged. This PR is the outcome of
doing that review afterwards: the changes below alter *what is logged* — an exception argument added or
removed, a root cause replaced by the exception object, an explicit `toString()` dropped — rather than
only how it is formatted, so they go back to what they were and can be re-proposed individually, on
their own merits, with a reviewer who knows the code.

Everything else from the sweep stays: the ~550 message-text and placeholder changes, the
`printStackTrace()` replacements, the `isXxxEnabled()` guard removals and the
`static final Logger` → `@Inject Logger` changes.

Commons half: xwiki/xwiki-commons#1884.

## Scope

**Reverts are statement-scoped, and narrower than the statement where possible.** Where the sweep
bundled a genuine message improvement with a behaviour change in the same statement, only the
behaviour change is undone — the better message text and the `{}` placeholders are kept. `ExceptionUtils`
imports are restored where a reverted statement needs one again.

22 files.

### Exception argument added by the sweep → dropped again (9)

| File | Module |
|---|---|
| `AttachmentValidationScriptService` | `xwiki-platform-attachment-validation-api` |
| `XarExtensionHandler` | `xwiki-platform-extension-handler-xar` |
| `InstalledExtensionSynchronizer` | `xwiki-platform-extension-handler-xar` |
| `BaseElement` | `xwiki-platform-oldcore` |
| `RefererStatsStoreItem` | `xwiki-platform-oldcore` |
| `MyPersistentLoginManager` | `xwiki-platform-oldcore` |
| `XWikiURLFactoryServiceImpl` | `xwiki-platform-oldcore` |
| `DefaultModelBridge` | `xwiki-platform-refactoring-default` |
| `RepositoryManager` | `xwiki-platform-repository-server-api` |

Only the `e` argument goes; the reworded messages and `{}` placeholders the sweep introduced at these
sites are kept.

### Root cause restored in place of the exception object (7)

| File | Module |
|---|---|
| `DefaultGroupingEventManager` | `xwiki-platform-notifications-sources` |
| `RatingDeletedEntityListener` | `xwiki-platform-ratings-api` |
| `RatingMovedEntityListener` | `xwiki-platform-ratings-api` |
| `AbstractReplaceUserJob` | `xwiki-platform-refactoring-api` |
| `ReplaceUserJob` | `xwiki-platform-refactoring-default` |
| `ExtensionStore` (support-plan site only) | `xwiki-platform-repository-server-api` |
| `AbstractDocumentSkinExtensionPlugin` | `xwiki-platform-skin-skinx` |

`AbstractDocumentSkinExtensionPlugin` gets its `error` + `debug` pair back rather than the single
`error(msg, e)` it was collapsed into: that site runs per request on a failing document, so the trace
belongs at `debug`, not in every `error` line.

### Explicit `toString()` restored (5)

| File | Module |
|---|---|
| `XWikiRCSArchive` | `xwiki-platform-oldcore` |
| `FileSystemURLFactory` | `xwiki-platform-oldcore` |
| `R140600000XWIKI19869DataMigration` | `xwiki-platform-oldcore` |
| `R4359XWIKI1459DataMigration` | `xwiki-platform-oldcore` |
| `DefaultSolrIndexer` | `xwiki-platform-search-solr-api` |

This is not cosmetic. A log argument captured into a job log is XStream-serialized whole, and
`SafeArrayConverter#readBareItem()` swallows read failures and yields `null` — so an argument whose
class can no longer be resolved (typically from an extension jar) is lost entirely, where a `String`
would have survived. Some of these were already restored in #6085; these are the rest of the same class
of change.

### Message rebuilt from a concatenation (1)

`ActiveInstallsPingRunnable` (`xwiki-platform-activeinstalls2-api`) — back to one `String.format` plus a
single `LOGGER.warn(message)`, instead of the two-branch placeholder form that duplicated the message.

## Verification

`mvn -B -ntp install -Plegacy,quality` on the 11 affected modules, including `xwiki-platform-oldcore`.
No test in the repository asserts on any of the reverted message texts.

Revapi was skipped for this run: no signature is touched here (every change is inside a method body),
and in a partial reactor it reports a pre-existing, unrelated break — the `XWikiHibernateStore`
constructors removed on master by 37f5d9353b6 (#6110).

## The report this is derived from

Below, in five comments, is the **full structural-changes report** for the whole sweep range across the
three repos. Please read it and say if something that should have been flagged was missed, or if
something reverted here should not have been — the point of publishing it is that the review that did
not happen before the merge can happen now.

| Repo | Base (commit *before* first logging change) | Head | Compare URL |
|---|---|---|---|
| xwiki-platform | `bc62d691219` | `0732dc45bd8` | https://github.com/xwiki/xwiki-platform/compare/bc62d691219...0732dc45bd8 |
| xwiki-commons | `92a59937ce` | `d100cb2c14` | https://github.com/xwiki/xwiki-commons/compare/92a59937ce...d100cb2c14 |
| xwiki-rendering | `d89fd5a37` | `d8ce0b9f6` | https://github.com/xwiki/xwiki-rendering/compare/d89fd5a37...d8ce0b9f6 |

### Method used to produce it

Every `.java` file changed in each range was parsed in **both** tree versions; every
`LOGGER/logger/LOG.trace|debug|info|warn|error(...)` call was extracted as a full balanced-paren
statement and the two sets were diffed and paired by similarity. A pair is **bracket-only** when the two
statements are identical after stripping `[`/`]` and whitespace — those are excluded from the detail.

**681 logging statements changed** across **317 files** in the 3 repos:

| Bucket | Count |
|---|---|
| Bracket-only (`x` → `[x]`) — no structural change | 107 |
| Structural (paired, something else changed too) | 461 |
| Statement removed with no clear replacement | 52 |
| Statement added with no clear predecessor | 61 |

Non-statement changes in the same range:

| Change | Count |
|---|---|
| `if (LOGGER.isXxxEnabled())` guards removed | 80 (platform), 0 (commons/rendering) |
| `e.printStackTrace()` removed | 22 (all replaced by a logged exception) |
| `@SuppressWarnings("java:S2629")` added (deliberate eager `toString()`) | 4 |
| `static final Logger LOGGER` → `@Inject private Logger logger` | 16 classes |
