### PR TITLE
XWIKI-24673: Race condition in XWiki cache store can lead to existing documents reported as not-existing

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiCacheStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiCacheStore.java
@@ -36,6 +36,7 @@ import org.xwiki.cache.config.LRUCacheConfiguration;
 import org.xwiki.cache.event.CacheEntryEvent;
 import org.xwiki.cache.event.CacheEntryListener;
 import org.xwiki.cache.internal.CacheLoader;
+import org.xwiki.cache.internal.CacheLoaderGroup;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
@@ -111,7 +112,14 @@ public class XWikiCacheStore extends AbstractXWikiStore
      */
     private Cache<Integer> limitSizePropertyCache;
 
-    private CacheLoader<XWikiDocument, XWikiException> cacheLoader = new CacheLoader();
+    /**
+     * The document cache and the page exist cache use the same keys, so they need to be invalidated together.
+     */
+    private final CacheLoaderGroup cacheLoaderGroup = new CacheLoaderGroup();
+
+    private final CacheLoader<XWikiDocument, XWikiException> cacheLoader = new CacheLoader<>(this.cacheLoaderGroup);
+
+    private final CacheLoader<Boolean, XWikiException> existsCacheLoader = new CacheLoader<>(this.cacheLoaderGroup);
 
     /**
      * Default constructor generally used by the Component Manager.
@@ -296,7 +304,7 @@ public class XWikiCacheStore extends AbstractXWikiStore
 
     private void invalidateCache(String key)
     {
-        this.cacheLoader.invalidate(key, k -> {
+        this.cacheLoaderGroup.invalidate(key, k -> {
             Cache<XWikiDocument> documentCache = getCache();
             if (documentCache != null) {
                 documentCache.remove(k);
@@ -312,7 +320,7 @@ public class XWikiCacheStore extends AbstractXWikiStore
     @Override
     public void flushCache()
     {
-        this.cacheLoader.invalidateAll(() -> {
+        this.cacheLoaderGroup.invalidateAll(() -> {
             getCache().removeAll();
             getPageExistCache().removeAll();
         });
@@ -822,12 +830,21 @@ public class XWikiCacheStore extends AbstractXWikiStore
                     return result;
                 }
             } catch (Exception e) {
+                this.logger.error("Failed to get the existence of the document [{}] from the cache", key, e);
             }
 
-            boolean result = this.store.exists(doc, context);
-            getPageExistCache().set(key, Boolean.valueOf(result));
-
-            return result;
+            // Load through the cache loader to ensure that the loaded value isn't stored anymore when the document
+            // has been modified while the existence was loaded from the database. This cache loader shares the group
+            // with the document cache loader, so a single invalidation stops the running loads of both of them.
+            return this.existsCacheLoader.loadAndStoreInCache(key, k -> this.store.exists(doc, context),
+                (k, result) -> getPageExistCache().set(k, result));
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof XWikiException xwikiException) {
+                throw xwikiException;
+            } else {
+                throw new XWikiException("Error checking the existence of the document [%s]"
+                    .formatted(getKey(doc, context)), e);
+            }
         } finally {
             restoreExecutionXContext();
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiCacheStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiCacheStoreTest.java
@@ -270,6 +270,78 @@ class XWikiCacheStoreTest
     }
 
     @Test
+    void documentSavedDuringExistsCheckIsNotCachedAsNotExisting() throws Exception
+    {
+        this.oldcore.getXWikiContext().setWikiId("wiki");
+        XWikiDocument document = new XWikiDocument(new DocumentReference("wiki", "space", "page"));
+
+        XWikiStoreInterface hibernateStore = this.oldcore.getMockStore();
+        XWikiCacheStore store = new XWikiCacheStore(hibernateStore, this.oldcore.getXWikiContext());
+
+        CompletableFuture<XWikiDocument> arrivedInExistsFuture = new CompletableFuture<>();
+        CompletableFuture<Boolean> continueExistsFuture = new CompletableFuture<>();
+
+        when(hibernateStore.exists(any(), any())).then(invocation -> {
+            arrivedInExistsFuture.complete(document);
+            return continueExistsFuture.get(10, TimeUnit.SECONDS);
+        });
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+        try {
+            Future<Boolean> existsFuture =
+                executorService.submit(() -> store.exists(document, this.oldcore.getXWikiContext()));
+
+            assertSame(document, arrivedInExistsFuture.get(10, TimeUnit.SECONDS));
+
+            // Save the document while the existence check is querying the database.
+            XWikiDocument savedDocument = document.clone();
+            savedDocument.setTitle("Saved");
+            store.saveXWikiDoc(savedDocument, this.oldcore.getXWikiContext());
+
+            // Let the check complete with the now stale information that the document doesn't exist.
+            continueExistsFuture.complete(false);
+
+            assertFalse(existsFuture.get(10, TimeUnit.SECONDS));
+
+            // The stale result must not have been stored in the cache.
+            String key = "4:wiki5:space4:page0:";
+            assertNull(this.existCache.get(key));
+
+            // Therefore, the next check needs to ask the store again.
+            when(hibernateStore.exists(any(), any())).thenReturn(true);
+
+            assertTrue(store.exists(document, this.oldcore.getXWikiContext()));
+            assertTrue(this.existCache.get(key));
+            verify(hibernateStore, times(2)).exists(document, this.oldcore.getXWikiContext());
+
+            // Now the result is cached, so no further call to the store.
+            assertTrue(store.exists(document, this.oldcore.getXWikiContext()));
+            verify(hibernateStore, times(2)).exists(document, this.oldcore.getXWikiContext());
+        } finally {
+            executorService.shutdown();
+        }
+        assertTrue(executorService.awaitTermination(10, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void existsExceptionIsPropagated() throws Exception
+    {
+        this.oldcore.getXWikiContext().setWikiId("wiki");
+        XWikiDocument document = new XWikiDocument(new DocumentReference("wiki", "space", "page"));
+
+        XWikiStoreInterface hibernateStore = this.oldcore.getMockStore();
+        XWikiCacheStore store = new XWikiCacheStore(hibernateStore, this.oldcore.getXWikiContext());
+
+        XWikiException exception = new XWikiException();
+        when(hibernateStore.exists(any(), any())).thenThrow(exception);
+
+        XWikiException actualException =
+            assertThrows(XWikiException.class, () -> store.exists(document, this.oldcore.getXWikiContext()));
+        assertSame(exception, actualException);
+    }
+
+    @Test
     void loadExceptionIsPropagated() throws Exception
     {
         this.oldcore.getXWikiContext().setWikiId("wiki");


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24673

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Use CacheLoaderGroup to synchronize loads between the exists and the page cache.
* Add a unit test verifying the race condition.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This depends on https://github.com/xwiki/xwiki-commons/pull/1886 for the CacheLoaderGroup which is required to synchronize the loading.
* I'm fixing this for correctness and to possibly avoid test failures, not because I believe this is likely to occur on a running instance - a page created while it is missing from the exists cache seems extremely unlikely, I'm pretty sure all code paths will first try loading the page which should populate the exists cache, and it is unlikely to be evicted again. Still, if I've learned one thing working with highly parallel code - any race condition will eventually trigger, so I wouldn't be surprised if this actually fails for real at some point. And with this fixed, we can rule out one more reason why documents might magically disappear.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built the changed module with the quality profile. Claude Code verified that the new test fails without the fix.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, seems too rare of a bug and too critical code for a backport.