### PR TITLE
XWIKI-23922: Quicksearch: go to search pages is a button instead of a link

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-webjar/src/main/webjar/searchSuggest.css
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-webjar/src/main/webjar/searchSuggest.css
@@ -23,7 +23,7 @@ ul.xlist li.showAllResults.loading {
   background-position: calc(100% - 6px) center;
 }
 
-ul.xlist li.showAllResults button.xitemcontainer {
+ul.xlist li.showAllResults a.xitemcontainer {
   padding: 4px 8px;
   font-size: 1em;
   color: var(--link-color);

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-webjar/src/main/webjar/searchSuggest.js
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-webjar/src/main/webjar/searchSuggest.js
@@ -99,6 +99,9 @@ var XWiki = (function (XWiki) {
         // Show the "No results!" message.
         this.noResultsMessage.removeClassName('hidden');
       }
+      // Keep the "Go to search page..." link in sync with the results it sits alongside, instead of the raw input
+      // (which would update ahead of the results it belongs to).
+      this.updateAllResultsLink();
     },
 
     /**
@@ -133,6 +136,15 @@ var XWiki = (function (XWiki) {
     },
 
     /**
+     * Keeps the href in sync with the text currently typed in the search field.
+     */
+    updateAllResultsLink: function() {
+      var form = this.searchInput.up('form');
+      var params = new URLSearchParams(new FormData(form));
+      this.allResultsLink.href = `${form.action}?${params.toString()}`;
+    },
+
+    /**
      * Creates the underlying suggest widget.
      */
     createSuggest: function() {
@@ -153,7 +165,7 @@ var XWiki = (function (XWiki) {
           eventCallbackScope: this,
           noHighlight: true,
           value: valueNode,
-          containerTagName: 'button'
+          containerTagName: 'a'
         } ),
       ],
       {
@@ -165,6 +177,8 @@ var XWiki = (function (XWiki) {
         }
       });
       var allResults = allResultsNode.getElement();
+      this.allResultsLink = allResults.down('a');
+      this.updateAllResultsLink();
       allResultsNode.items[0].getElement().addEventListener('focusin',
         (event) => this.suggest.setHighlight($(event.currentTarget)));
       this.suggest = new XWiki.widgets.Suggest( this.searchInput, {

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-webjar/src/main/webjar/searchSuggest.js
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-webjar/src/main/webjar/searchSuggest.js
@@ -139,8 +139,8 @@ var XWiki = (function (XWiki) {
      * Keeps the href in sync with the text currently typed in the search field.
      */
     updateAllResultsLink: function() {
-      var form = this.searchInput.up('form');
-      var params = new URLSearchParams(new FormData(form));
+      const form = this.searchInput.up('form');
+      const params = new URLSearchParams(new FormData(form));
       this.allResultsLink.href = `${form.action}?${params.toString()}`;
     },
 


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-23922

# Changes

## Description

* Turn the "Go to search page..." quicksearch suggestion into a real `<a>` link instead of a `<button>`
  * Update the related CSS selector (`button.xitemcontainer` → `a.xitemcontainer`) accordingly
* Keep the link's `href` in sync with the results it sits alongside, refreshing on the same
  `xwiki:suggest:updated` event the results panel itself reacts to (rather than on every keystroke)


## Clarifications

* Using a real link (with a real, up-to-date `href`) instead of a plain button lets browser features
  such as "Open in new tab", "Copy link address", or opening with the middle mouse button work as
  expected, and lets assistive technologies correctly identify it as a link.
* Verified the rendered DOM before/after by hot-swapping the built jar into a local instance (see the
  screenshot below): only the container tag and `href` change, the rest of the markup is identical.
* The item's `style="text-indent: 0px;"` inline style (visible in the DOM screenshot) is unrelated to
  this fix: it's set unconditionally by the shared `XListItem` widget
  (`xlist.js`, `containerElement.setStyle({textIndent: '0px'})`), and gets dynamically recomputed to
  `(iconWidth + 6) + 'px'` for items that use an icon. It predates this change, is shared by every
  other `XList`/suggest consumer in the codebase, and is out of scope here - left untouched.
* The `href` update was initially tied to the input field's `input` event (updating on every
  keystroke), then switched to the `xwiki:suggest:updated` event so it refreshes in lockstep with the
  results panel instead of ahead of it. Checked that this doesn't leave a stale-but-visible link: the
  cases where `xwiki:suggest:updated` doesn't fire (below the 3-character `minchars` threshold, or an
  unchanged normalized query) either remove the whole suggestion container (including the link) or
  don't represent a real query change. Also confirmed the `<a>` node referenced by the widget is
  moved (not cloned) across suggestion-container rebuilds, so the update always reaches the visible
  node.

# Screenshots & Video

<img width="2120" height="1737" alt="comparison-trimmed" src="https://github.com/user-attachments/assets/d2f7ac8a-e61d-4c1e-8526-19268d41c413" />

# Executed Tests

* Searched the whole repo for tests/page objects depending on this element being a `<button>`:
  `QuickSearchElement.java` (used by the `SearchSuggestIT` Docker test) only selects
  `.searchSuggest li.showAllResults.loading` on the parent `<li>` and never queries the inner element
  by tag name or interacts with it directly, so no test needed updating. There is no JS unit test
  harness for `searchSuggest.js`.
* `mvn clean install -B -ntp -pl xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-webjar -Plegacy,quality`
  → `BUILD SUCCESS` (Checkstyle, license check, Revapi API-compat and JavaScript importmap
  validation all pass; module has no unit tests, so JaCoCo has nothing to check). Re-run after
  switching the `href` update to the `xwiki:suggest:updated` event, still green.
* Manually verified the fix end-to-end against a local instance (screenshots above), confirming the
  suggestion renders as a real `<a href="...">` and its `href` stays in sync with the results panel.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None
