### PR TITLE
XWIKI-23002: The attachment selector create should be a button instead of link

### DIFF
--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects/src/main/java/org/xwiki/user/test/po/ProfileUserProfilePage.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects/src/main/java/org/xwiki/user/test/po/ProfileUserProfilePage.java
@@ -65,7 +65,7 @@ public class ProfileUserProfilePage extends AbstractUserProfilePage
     @FindBy(xpath = "//dd[preceding-sibling::dt[1]/label[. = 'Blog Feed']]//a")
     private WebElement userBlogFeed;
 
-    @FindBy(xpath = "//div[@id='avatar']//a")
+    @FindBy(xpath = "//div[@id='avatar']//button[contains(@class, 'attachment-picker-start')]")
     private WebElement changeAvatar;
 
     @FindBy(css = ".activity-follow .notificationWatchUserFollowing")


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-23002

# Changes

## Description

* Fix `ProfileUserProfilePage`'s `changeAvatar` xpath locator to find the new button element

## Clarifications

* Follow-up to #4589, which changed the attachment selector's trigger element in `AttachmentSelector.xml` from an `<a class="attachment-picker-start button">` link to a `<button type="button" class="attachment-picker-start button">`. The user profile's avatar-change widget in `XWikiUserSheet.xml` (`<div id="avatar">`) uses that same macro, so the page object's old `//div[@id='avatar']//a` locator stopped matching anything.
* This is what caused `AllIT$NestedUserProfileIT#changeAvatarImage` to fail on CI master build [#8831](https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/8831/) with `NoSuchElementException: Unable to locate element: //div[@id='avatar']//a`.

# Screenshots & Video

None, no visual change (test-only fix).

# Executed Tests

* Ran the actual failing test through the real Docker IT framework (real Selenium + Firefox container, real `@FindBy` locator resolution) against an already-running local `18.7.0-SNAPSHOT` instance, using `ServletEngine.EXTERNAL` mode (`-Dxwiki.test.ui.servletEngine=EXTERNAL`). Note that I couldn't get the full WAR build from nexus consistently so I just relied on my local instance.
  ```
  mvn clean verify -Plegacy,integration-tests,docker \
    -Dxwiki.test.ui.servletEngine=EXTERNAL -Dxwiki.test.ui.offline=true \
    -Dit.test=AllIT\$NestedUserProfileIT#changeAvatarImage
  ```
  Result: `Tests run: 1, Failures: 0, Errors: 0` — `BUILD SUCCESS`. This exercises the exact scenario that failed in CI build #8831.
* Also manually validated the locator itself beforehand: against the rendered profile page of that same instance, the old xpath (`//div[@id='avatar']//a`) matches 0 elements, the new xpath matches the "Change photo" button, and clicking it opens the attachment upload modal (`uploadAttachment`), matching what `changeAvatarImage()` expects.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None.
