### PR TITLE
XWIKI-24283: org.xwiki.blocknote.test.ui.AllIT$NestedImageIT#editImage is flickering

### DIFF
--- a/xwiki-platform-core/xwiki-platform-blocknote/xwiki-platform-blocknote-test/xwiki-platform-blocknote-test-docker/src/test/it/org/xwiki/blocknote/test/ui/ImageIT.java
+++ b/xwiki-platform-core/xwiki-platform-blocknote/xwiki-platform-blocknote-test/xwiki-platform-blocknote-test-docker/src/test/it/org/xwiki/blocknote/test/ui/ImageIT.java
@@ -144,7 +144,9 @@ class ImageIT extends AbstractBlockNoteIT
         imageEditModal.switchToAdvancedTab().selectEndAlignment();
         imageEditModal.clickInsert();
 
-        assertEquals("127", textArea.getImage(0).getDomProperty("offsetHeight"));
+        // The image we just selected replaces the previous one, so we have to wait for it to be loaded before its
+        // height reflects the configured width and the image aspect ratio.
+        assertEquals("127", textArea.waitUntilImageIsLoaded(0).getDomProperty("offsetHeight"));
 
         // Save and check the source.
         page.save();

--- a/xwiki-platform-core/xwiki-platform-blocknote/xwiki-platform-blocknote-test/xwiki-platform-blocknote-test-pageobjects/src/main/java/org/xwiki/blocknote/test/po/BlockNoteRichTextArea.java
+++ b/xwiki-platform-core/xwiki-platform-blocknote/xwiki-platform-blocknote-test/xwiki-platform-blocknote-test-pageobjects/src/main/java/org/xwiki/blocknote/test/po/BlockNoteRichTextArea.java
@@ -21,6 +21,7 @@ package org.xwiki.blocknote.test.po;
 
 import org.jspecify.annotations.NonNull;
 import org.openqa.selenium.By;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.xwiki.test.ui.po.BaseElement;
@@ -174,7 +175,8 @@ public class BlockNoteRichTextArea extends BaseElement
      */
     public BlockNoteRichTextArea clickImage(int index)
     {
-        // The image might not be loaded yet, so wait until it's clickable before clicking on it.
+        // Note that this doesn't wait for the image to be loaded: an image that is still being fetched (or that failed
+        // to load, which some tests do on purpose) is already clickable, with the height of a single text line.
         WebElement image = getImage(index);
         getDriver().waitUntilCondition(ExpectedConditions.elementToBeClickable(image));
         image.click();
@@ -191,6 +193,29 @@ public class BlockNoteRichTextArea extends BaseElement
     public WebElement getImage(int index)
     {
         return this.container.findElements(By.tagName("img")).get(index);
+    }
+
+    /**
+     * Waits until the image with the specified index has been loaded successfully, i.e. until its size reflects the
+     * image content rather than the size of a not yet loaded image. Don't call this for an image that is expected to
+     * fail to load, e.g. one pointing to a missing attachment.
+     *
+     * @param index the index of the image to wait for, starting from 0
+     * @return the image element
+     * @since 18.7.0RC1
+     */
+    public WebElement waitUntilImageIsLoaded(int index)
+    {
+        getDriver().waitUntilCondition(driver -> {
+            try {
+                return (Boolean) getDriver()
+                    .executeScript("return arguments[0].complete && arguments[0].naturalWidth > 0", getImage(index));
+            } catch (StaleElementReferenceException | IndexOutOfBoundsException e) {
+                // The editor is re-rendering the image, e.g. because its source has just been changed.
+                return false;
+            }
+        });
+        return getImage(index);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-test/xwiki-platform-wysiwyg-test-pageobjects/src/main/java/org/xwiki/wysiwyg/test/po/image/select/ImageDialogUploadSelectForm.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-test/xwiki-platform-wysiwyg-test-pageobjects/src/main/java/org/xwiki/wysiwyg/test/po/image/select/ImageDialogUploadSelectForm.java
@@ -51,6 +51,10 @@ public class ImageDialogUploadSelectForm extends BaseElement
             fileInput.sendKeys(getUtil().getResourceFile(path).getAbsolutePath());
             WebElement uploadButton = getDriver()
                 .findElementWithoutWaitingWithoutScrolling(By.cssSelector("input[type=submit][value=Upload]"));
+            // The upload button is disabled until the JavaScript that performs the upload has been loaded and has seen
+            // the selected file. Clicking before that submits the form natively, which reloads the page and thus closes
+            // the image dialog.
+            getDriver().waitUntilElementIsEnabled(uploadButton);
             uploadButton.click();
             waitForNotificationSuccessMessage("File upload succeeded.");
         } finally {

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-ui/src/main/resources/XWiki/WYSIWYG/ImageSelectorServiceUIX/Upload.xml
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-ui/src/main/resources/XWiki/WYSIWYG/ImageSelectorServiceUIX/Upload.xml
@@ -133,11 +133,9 @@
 ], function ($, imageSelector, translations, resource) {
   function init(element) {
     const uploadForm = element.find(".upload form");
-    /*
-     * This is called for every element of every xwiki:dom:updated event, most of which have nothing to do with the
-     * image selector, so leave immediately when there is no upload form to initialize. Failing to do so and throwing
-     * from here would prevent the remaining listeners of that event from running.
-     */
+    // This is called for every element of every xwiki:dom:updated event, most of which have nothing to do with the
+    // image selector, so leave immediately when there is no upload form to initialize. Failing to do so and throwing
+    // from here would prevent the remaining listeners of that event from running.
     if (!uploadForm.length) {
       return;
     }
@@ -145,20 +143,16 @@
     const uploadButton = uploadForm.find("input.button");
     const fileInput = uploadForm.find("input[type='file']");
 
-    /*
-     * The form has no action and is submitted with JavaScript only, so submitting it natively would simply reload the
-     * current page with the file field in the query string, losing the editor and its unsaved content. The button is
-     * thus disabled in the HTML, and stays that way until this code has been loaded and a file has been selected.
-     * Prevent the native submit as well, in case the form is submitted with the Enter key.
-     */
+    // The form has no action and is submitted with JavaScript only, so submitting it natively would simply reload the
+    // current page with the file field in the query string, losing the editor and its unsaved content. The button is
+    // thus disabled in the HTML, and stays that way until this code has been loaded and a file has been selected.
+    // Prevent the native submit as well, in case the form is submitted with the Enter key.
     uploadForm.on('submit', function (event) {
       event.preventDefault();
     });
 
-    /*
-     * Compute the state from the file field rather than only toggling it on change: the file may have been selected
-     * before this code was loaded, in which case the change event has been lost and the button would stay disabled.
-     */
+    // Compute the state from the file field rather than only toggling it on change: the file may have been selected
+    // before this code was loaded, in which case the change event has been lost and the button would stay disabled.
     const refreshUploadButton = function () {
       uploadButton.prop("disabled", !fileInput.prop('files')?.length);
     };
@@ -371,10 +365,8 @@
   &lt;/dl&gt;
   &lt;p&gt;
     &lt;span class="buttonwrapper"&gt;
-#*
-  Disabled until the JavaScript extension has been loaded and a file has been selected: this form is submitted with
-  JavaScript only, so a native submit would just reload the page and close the editor.
-*#
+      ## Disabled until the JavaScript extension has been loaded and a file has been selected: this form is submitted
+      ## with JavaScript only, so a native submit would just reload the page and close the editor.
       &lt;input class="button" type="submit" disabled="disabled"
         value="$escapetool.xml($services.localization.render('wysiwyg.imageSelector.uploadTab.uploadButton'))"/&gt;
     &lt;/span&gt;

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-ui/src/main/resources/XWiki/WYSIWYG/ImageSelectorServiceUIX/Upload.xml
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-ui/src/main/resources/XWiki/WYSIWYG/ImageSelectorServiceUIX/Upload.xml
@@ -132,17 +132,38 @@
   'xwiki-wysiwyg-resource'
 ], function ($, imageSelector, translations, resource) {
   function init(element) {
-    const uploadButton = element.find(".upload form input.button");
+    const uploadForm = element.find(".upload form");
+    /*
+     * This is called for every element of every xwiki:dom:updated event, most of which have nothing to do with the
+     * image selector, so leave immediately when there is no upload form to initialize. Failing to do so and throwing
+     * from here would prevent the remaining listeners of that event from running.
+     */
+    if (!uploadForm.length) {
+      return;
+    }
 
-    uploadButton.prop("disabled", true);
+    const uploadButton = uploadForm.find("input.button");
+    const fileInput = uploadForm.find("input[type='file']");
 
-    element.on('change', function () {
-      if ($(this).find("input[type='file']").prop('files').length &gt; 0) {
-        uploadButton.prop("disabled", false);
-      } else {
-        uploadButton.prop("disabled", true);
-      }
+    /*
+     * The form has no action and is submitted with JavaScript only, so submitting it natively would simply reload the
+     * current page with the file field in the query string, losing the editor and its unsaved content. The button is
+     * thus disabled in the HTML, and stays that way until this code has been loaded and a file has been selected.
+     * Prevent the native submit as well, in case the form is submitted with the Enter key.
+     */
+    uploadForm.on('submit', function (event) {
+      event.preventDefault();
     });
+
+    /*
+     * Compute the state from the file field rather than only toggling it on change: the file may have been selected
+     * before this code was loaded, in which case the change event has been lost and the button would stay disabled.
+     */
+    const refreshUploadButton = function () {
+      uploadButton.prop("disabled", !fileInput.prop('files')?.length);
+    };
+    refreshUploadButton();
+    element.on('change', refreshUploadButton);
 
     uploadButton.on('click', function (event) {
       event.preventDefault();
@@ -350,7 +371,11 @@
   &lt;/dl&gt;
   &lt;p&gt;
     &lt;span class="buttonwrapper"&gt;
-      &lt;input class="button" type="submit"
+#*
+  Disabled until the JavaScript extension has been loaded and a file has been selected: this form is submitted with
+  JavaScript only, so a native submit would just reload the page and close the editor.
+*#
+      &lt;input class="button" type="submit" disabled="disabled"
         value="$escapetool.xml($services.localization.render('wysiwyg.imageSelector.uploadTab.uploadButton'))"/&gt;
     &lt;/span&gt;
   &lt;/p&gt;


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24283

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Wait until the image is loaded before asserting its height.
* Change how the upload button is enabled: disable it by default, enable it in JavaScript.
* Let the JavaScript code for the upload button return early when there is no upload form.
* Prevent an actual submit of the form as this is never desired.

This is close to having impact on actual users, but I doubt that the timing of selecting a file before the JavaScript handler is bound can be achieved by a human. Still, I'm wondering if this would need a proper Jira for the production code changes?

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This might also fix flickering in related CKEditor and realtime tests.
* Neither Claude Code nor I tried actually reproducing the flickering as a 10.9% failure rate (44 executions failed out of 402 in the last 30 days) is hard to reproduce. The fix is based on analyzing the screen recordings of the different failure modes that were observed on CI and analyzing the code.
* This does not address the flickering behavior where the modal simply does not open, see, e.g., https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/1334/testReport/org.xwiki.blocknote.test.ui/AllIT$NestedImageIT/MySQL_latest__Tomcat_11_jdk25__Filesystem__Chrome___Docker_tests__2_for_xwiki_platform_attachment_picker__xwiki_platform_attachment__xwiki_platform_attachment_validation__xwiki_platform_blocknote___Build_for_MySQL_latest__Tomcat_11_jdk25__Filesystem__Chrome___Docker_tests__2_for_xwiki_platform_attachment_picker__xwiki_platform_attachment__xwiki_platform_attachment_validation__xwiki_platform_blocknote___editImage_TestUtils__TestReference_/ - Claude Code didn't find any reasonable explanation for that, and I also haven't investigated further. This specific failure happened 4 times so far, always on master with Chrome., first on July 24, last on August 7, so this fix could still result in an about 90% decrease of flickering.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built `:xwiki-platform-wysiwyg-ui`, `:xwiki-platform-wysiwyg-test-pageobjects` and `:xwiki-platform-blocknote-test-pageobjects` with the quality profile. Executed the following integration tests

* `AllIT$NestedImageIT` from `:xwiki-platform-blocknote-test-docker` (the flickering test)
* `TextAreaImageUploadIT` from `:xwiki-platform-edit-test-docker`
* `RealtimeWYSIWYGEditorIT#imageWithCaption` from `:xwiki-platform-realtime-wysiwyg-test-docker`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * Not sure, it would be nice to fix those tests on all branches, but the production code change might have a risk that is not worth the small fix.