### PR TITLE
XWIKI-24672: WCAG "Form elements must have labels" warnings on Extension Support / xclass object edit forms

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BooleanClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BooleanClass.java
@@ -224,10 +224,7 @@ public class BooleanClass extends PropertyClass
         select.setName(prefix + name);
         select.setID(prefix + name);
         select.setDisabled(isDisabled());
-        // This is a text alternative fallback to explain what the select is about. If the select has already been
-        // labelled in another way, this fallback will be ignored by Assistive Techs.
-        select.addAttribute("aria-label", localizePlainOrKey("core.model.xclass.editClassProperty.textAlternative",
-            getTranslatedPrettyName(context)));
+        setAriaLabelFallback(select, context);
 
         String string0 = getDisplayValue(0);
         String string1 = getDisplayValue(1);
@@ -335,6 +332,7 @@ public class BooleanClass extends PropertyClass
         check.setAttributeFilter(new XMLAttributeValueFilter());
         check.setID(prefix + name);
         check.setDisabled(isDisabled());
+        setAriaLabelFallback(check, context);
         // If the (visible) checkbox is unchecked, it will not post anything back so the hidden input by the same
         // name will post back 0 and the save function will save the first entry it finds.
         org.apache.ecs.xhtml.input checkNo = new input(input.hidden, prefix + name, 0);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DBListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DBListClass.java
@@ -597,6 +597,7 @@ public class DBListClass extends ListClass
             }
 
             input.setDisabled(isDisabled());
+            setAriaLabelFallback(input, context);
             buffer.append(input.toString());
         } else if (getDisplayType().equals(DISPLAYTYPE_RADIO) || getDisplayType().equals(DISPLAYTYPE_CHECKBOX)) {
             displayRadioEdit(buffer, name, prefix, object, context);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DBTreeListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DBTreeListClass.java
@@ -345,6 +345,7 @@ public class DBTreeListClass extends DBListClass
         select.setName(prefix + name);
         select.setID(prefix + name);
         select.setDisabled(isDisabled());
+        setAriaLabelFallback(select, context);
 
         Map<String, ListItem> map = getMap(context);
         Map<String, List<ListItem>> treemap = getTreeMap(context);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/LevelsClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/LevelsClass.java
@@ -171,6 +171,7 @@ public class LevelsClass extends ListClass
         select.setName(prefix + name);
         select.setID(prefix + name);
         select.setDisabled(isDisabled());
+        setAriaLabelFallback(select, context);
 
         List<String> list = getList(context);
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
@@ -814,10 +814,7 @@ public abstract class ListClass extends PropertyClass
             input.setName(prefix + name);
             input.setID(prefix + name);
             input.setDisabled(isDisabled());
-            // This is a text alternative fallback to explain what the input is about. If the input has already been
-            // labelled in another way, this fallback will be ignored by Assistive Techs.
-            input.addAttribute("aria-label", localizePlainOrKey("core.model.xclass.editClassProperty.textAlternative",
-                getTranslatedPrettyName(context)));
+            setAriaLabelFallback(input, context);
             buffer.append(input.toString());
         } else if (getDisplayType().equals(DISPLAYTYPE_RADIO) || getDisplayType().equals(DISPLAYTYPE_CHECKBOX)) {
             displayRadioEdit(buffer, name, prefix, object, context);
@@ -924,10 +921,7 @@ public abstract class ListClass extends PropertyClass
         select.setName(prefix + name);
         select.setID(prefix + name);
         select.setDisabled(isDisabled());
-        // This is a text alternative fallback to explain what the select is about. If the select has already been
-        // labelled in another way, this fallback will be ignored by Assistive Techs.
-        select.addAttribute("aria-label", localizePlainOrKey("core.model.xclass.editClassProperty.textAlternative",
-            getTranslatedPrettyName(context)));
+        setAriaLabelFallback(select, context);
 
         List<String> list = getList(context);
         Map<String, ListItem> map = getMap(context);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/NumberClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/NumberClass.java
@@ -224,6 +224,7 @@ public class NumberClass extends PropertyClass
         input.setName(prefix + name);
         input.setID(prefix + name);
         input.setDisabled(isDisabled());
+        setAriaLabelFallback(input, context);
 
         String ntype = getNumberType();
         input.addAttribute(DATA_VALIDATION_BAD_INPUT,

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PasswordClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PasswordClass.java
@@ -141,6 +141,7 @@ public class PasswordClass extends StringClass
         input.setID(prefix + name);
         input.setSize(getSize());
         input.setDisabled(isDisabled());
+        setAriaLabelFallback(input, context);
         buffer.append(input.toString());
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
@@ -68,12 +68,12 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
      * The name of the HTML attribute used to provide a text alternative for an edit widget, as an accessibility
      * fallback for the cases when the widget is not already associated with a visible {@code <label>}.
      */
-    protected static final String ARIA_LABEL = "aria-label";
+    static final String ARIA_LABEL = "aria-label";
 
     /**
      * The translation key used to compute the {@link #ARIA_LABEL} fallback value.
      */
-    protected static final String ARIA_LABEL_TRANSLATION_KEY =
+    static final String ARIA_LABEL_TRANSLATION_KEY =
         "core.model.xclass.editClassProperty.textAlternative";
 
     private static final long serialVersionUID = 1L;
@@ -667,9 +667,8 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
     /**
      * @param context the current context, used to resolve the translation
      * @return the {@link #ARIA_LABEL} text alternative fallback value for this property's edit widget
-     * @since 18.7.0RC1
      */
-    protected String getAriaLabelFallback(XWikiContext context)
+    String getAriaLabelFallback(XWikiContext context)
     {
         return localizePlainOrKey(ARIA_LABEL_TRANSLATION_KEY, getTranslatedPrettyName(context));
     }
@@ -679,9 +678,8 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
      *
      * @param element the edit widget on which to set the fallback
      * @param context the current context, used to resolve the translation
-     * @since 18.7.0RC1
      */
-    protected void setAriaLabelFallback(ConcreteElement element, XWikiContext context)
+    void setAriaLabelFallback(ConcreteElement element, XWikiContext context)
     {
         element.addAttribute(ARIA_LABEL, getAriaLabelFallback(context));
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
@@ -666,9 +666,7 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
 
     /**
      * @param context the current context, used to resolve the translation
-     * @return the {@link #ARIA_LABEL} text alternative fallback value for this property's edit widget, to explain
-     *         what it is about. If the widget has already been labelled in another way, this fallback will be
-     *         ignored by Assistive Techs
+     * @return the {@link #ARIA_LABEL} text alternative fallback value for this property's edit widget
      */
     protected String getAriaLabelFallback(XWikiContext context)
     {
@@ -676,8 +674,7 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
     }
 
     /**
-     * Sets the {@link #ARIA_LABEL} text alternative fallback (see {@link #getAriaLabelFallback(XWikiContext)}) on
-     * the given edit widget.
+     * Sets the {@link #ARIA_LABEL} text alternative fallback on the given edit widget.
      *
      * @param element the edit widget on which to set the fallback
      * @param context the current context, used to resolve the translation

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
@@ -65,12 +65,9 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
     implements PropertyClassInterface, Comparable<PropertyClass>
 {
     /**
-     * The name of the HTML attribute used to set an accessible name on a property's edit widget (there is no
-     * equivalent need in view mode, where {@link #displayView} only outputs the plain value). Per the HTML
-     * accessible name computation, this attribute takes precedence over any {@code <label>} that may already
-     * target the widget, which is why {@link #getAriaLabelFallback(XWikiContext)} returns the bare translated
-     * pretty name: it then matches the visible label's text wherever one already exists (e.g. the object editor),
-     * and still provides a usable name where none does.
+     * The name of the HTML attribute used to set an accessible name on a property's edit widget ({@link
+     * #displayView} has no equivalent need). It takes precedence over any existing {@code <label>}, so {@link
+     * #getAriaLabelFallback(XWikiContext)} uses the bare pretty name to match it rather than override it.
      */
     static final String ARIA_LABEL = "aria-label";
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
@@ -65,16 +65,14 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
     implements PropertyClassInterface, Comparable<PropertyClass>
 {
     /**
-     * The name of the HTML attribute used to provide a text alternative for an edit widget, as an accessibility
-     * fallback for the cases when the widget is not already associated with a visible {@code <label>}.
+     * The name of the HTML attribute used to set an accessible name on a property's edit widget (there is no
+     * equivalent need in view mode, where {@link #displayView} only outputs the plain value). Per the HTML
+     * accessible name computation, this attribute takes precedence over any {@code <label>} that may already
+     * target the widget, which is why {@link #getAriaLabelFallback(XWikiContext)} returns the bare translated
+     * pretty name: it then matches the visible label's text wherever one already exists (e.g. the object editor),
+     * and still provides a usable name where none does.
      */
     static final String ARIA_LABEL = "aria-label";
-
-    /**
-     * The translation key used to compute the {@link #ARIA_LABEL} fallback value.
-     */
-    static final String ARIA_LABEL_TRANSLATION_KEY =
-        "core.model.xclass.editClassProperty.textAlternative";
 
     private static final long serialVersionUID = 1L;
 
@@ -434,7 +432,10 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
                 ScriptContext.ENGINE_SCOPE);
             scontext.setAttribute("object", new com.xpn.xwiki.api.Object(object, context), ScriptContext.ENGINE_SCOPE);
             scontext.setAttribute("type", type, ScriptContext.ENGINE_SCOPE);
-            scontext.setAttribute(ARIA_LABEL, getAriaLabelFallback(context), ScriptContext.ENGINE_SCOPE);
+            // Named "ariaLabel", not ARIA_LABEL ("aria-label"): a Velocity binding with a dash isn't reachable as
+            // $aria-label (parsed as $aria minus label), so a custom displayer wanting this value has to use
+            // $ariaLabel.
+            scontext.setAttribute("ariaLabel", getAriaLabelFallback(context), ScriptContext.ENGINE_SCOPE);
 
             BaseProperty prop = (BaseProperty) object.safeget(fieldName);
             if (prop != null) {
@@ -665,19 +666,19 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
     }
 
     /**
-     * @param context the current context, used to resolve the translation
-     * @return the {@link #ARIA_LABEL} text alternative fallback value for this property's edit widget
+     * @param context the current context, used to resolve the translated pretty name
+     * @return the {@link #ARIA_LABEL} value to use for this property's edit widget
      */
     String getAriaLabelFallback(XWikiContext context)
     {
-        return localizePlainOrKey(ARIA_LABEL_TRANSLATION_KEY, getTranslatedPrettyName(context));
+        return getTranslatedPrettyName(context);
     }
 
     /**
-     * Sets the {@link #ARIA_LABEL} text alternative fallback on the given edit widget.
+     * Sets the {@link #ARIA_LABEL} attribute on the given edit widget.
      *
-     * @param element the edit widget on which to set the fallback
-     * @param context the current context, used to resolve the translation
+     * @param element the edit widget on which to set the attribute
+     * @param context the current context, used to resolve the translated pretty name
      */
     void setAriaLabelFallback(ConcreteElement element, XWikiContext context)
     {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
@@ -25,6 +25,7 @@ import javax.script.ScriptContext;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
+import org.apache.ecs.ConcreteElement;
 import org.apache.ecs.xhtml.input;
 import org.dom4j.Element;
 import org.dom4j.dom.DOMElement;
@@ -63,6 +64,18 @@ import com.xpn.xwiki.web.Utils;
 public class PropertyClass extends BaseCollection<ClassPropertyReference>
     implements PropertyClassInterface, Comparable<PropertyClass>
 {
+    /**
+     * The name of the HTML attribute used to provide a text alternative for an edit widget, as an accessibility
+     * fallback for the cases when the widget is not already associated with a visible {@code <label>}.
+     */
+    protected static final String ARIA_LABEL = "aria-label";
+
+    /**
+     * The translation key used to compute the {@link #ARIA_LABEL} fallback value.
+     */
+    protected static final String ARIA_LABEL_TRANSLATION_KEY =
+        "core.model.xclass.editClassProperty.textAlternative";
+
     private static final long serialVersionUID = 1L;
 
     /**
@@ -295,6 +308,7 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
         input.setName(prefix + name);
         input.setID(prefix + name);
         input.setDisabled(isDisabled());
+        setAriaLabelFallback(input, context);
         buffer.append(input.toString());
     }
 
@@ -420,11 +434,7 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
                 ScriptContext.ENGINE_SCOPE);
             scontext.setAttribute("object", new com.xpn.xwiki.api.Object(object, context), ScriptContext.ENGINE_SCOPE);
             scontext.setAttribute("type", type, ScriptContext.ENGINE_SCOPE);
-            // This is a text alternative fallback to explain what the input is about. 
-            // If the input has already been labelled in another way, this fallback will be ignored by Assistive Techs.
-            scontext.setAttribute("aria-label",
-                localizePlainOrKey("core.model.xclass.editClassProperty.textAlternative",
-                    this.getTranslatedPrettyName(context)), ScriptContext.ENGINE_SCOPE);
+            scontext.setAttribute(ARIA_LABEL, getAriaLabelFallback(context), ScriptContext.ENGINE_SCOPE);
 
             BaseProperty prop = (BaseProperty) object.safeget(fieldName);
             if (prop != null) {
@@ -652,6 +662,29 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
             return getPrettyName();
         }
         return prettyName;
+    }
+
+    /**
+     * @param context the current context, used to resolve the translation
+     * @return the {@link #ARIA_LABEL} text alternative fallback value for this property's edit widget, to explain
+     *         what it is about. If the widget has already been labelled in another way, this fallback will be
+     *         ignored by Assistive Techs
+     */
+    protected String getAriaLabelFallback(XWikiContext context)
+    {
+        return localizePlainOrKey(ARIA_LABEL_TRANSLATION_KEY, getTranslatedPrettyName(context));
+    }
+
+    /**
+     * Sets the {@link #ARIA_LABEL} text alternative fallback (see {@link #getAriaLabelFallback(XWikiContext)}) on
+     * the given edit widget.
+     *
+     * @param element the edit widget on which to set the fallback
+     * @param context the current context, used to resolve the translation
+     */
+    protected void setAriaLabelFallback(ConcreteElement element, XWikiContext context)
+    {
+        element.addAttribute(ARIA_LABEL, getAriaLabelFallback(context));
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
@@ -64,13 +64,10 @@ import com.xpn.xwiki.web.Utils;
 public class PropertyClass extends BaseCollection<ClassPropertyReference>
     implements PropertyClassInterface, Comparable<PropertyClass>
 {
-    /**
-     * The name of the HTML attribute used to set an accessible name on a property's edit widget ({@link
-     * #displayView} has no equivalent need). It takes precedence over any existing {@code <label>}, so {@link
-     * #getAriaLabelFallback(XWikiContext)} uses the bare pretty name to match it rather than override it.
-     */
+    /** HTML attribute for a property edit widget's accessible name; takes precedence over any {@code <label>}. */
     static final String ARIA_LABEL = "aria-label";
 
+    /** Serialization identifier. */
     private static final long serialVersionUID = 1L;
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
@@ -667,6 +667,7 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
     /**
      * @param context the current context, used to resolve the translation
      * @return the {@link #ARIA_LABEL} text alternative fallback value for this property's edit widget
+     * @since 18.7.0RC1
      */
     protected String getAriaLabelFallback(XWikiContext context)
     {
@@ -678,6 +679,7 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
      *
      * @param element the edit widget on which to set the fallback
      * @param context the current context, used to resolve the translation
+     * @since 18.7.0RC1
      */
     protected void setAriaLabelFallback(ConcreteElement element, XWikiContext context)
     {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/StaticListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/StaticListClass.java
@@ -116,6 +116,7 @@ public class StaticListClass extends ListClass
             input.setName(prefix + name);
             input.setID(prefix + name);
             input.setDisabled(isDisabled());
+            setAriaLabelFallback(input, context);
 
             if (isPicker()) {
                 input.setClass("suggested");

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/StringClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/StringClass.java
@@ -126,11 +126,7 @@ public class StringClass extends PropertyClass
         input.setID(prefix + name);
         input.setSize(getSize());
         input.setDisabled(isDisabled());
-        /* This is a text alternative fallback to explain what the input is about. 
-         If the input has already been labelled in another way, this fallback will be ignored by Assistive Techs.
-         */
-        input.addAttribute("aria-label", localizePlainOrKey("core.model.xclass.editClassProperty.textAlternative",
-            this.getTranslatedPrettyName(context)));
+        setAriaLabelFallback(input, context);
 
         if (isPicker()) {
             displayPickerEdit(input);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/TextAreaClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/TextAreaClass.java
@@ -448,6 +448,7 @@ public class TextAreaClass extends StringClass
         parameters.put("cols", getSize());
         parameters.put(ROWS, getRows());
         parameters.put("disabled", isDisabled());
+        parameters.put(ARIA_LABEL, getAriaLabelFallback(context));
         parameters.put(RESTRICTED, isRestricted() || (ownerDocument != null && ownerDocument.isRestricted()));
         // The document reference is used client-side (e.g. to resolve relative references and build URLs).
         parameters.put("sourceDocumentReference", ownerDocument.getDocumentReferenceWithLocale());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/api/ContextTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/api/ContextTest.java
@@ -73,7 +73,7 @@ class ContextTest
         context.setDisplayMode("edit");
 
         // We verify that the result contains a form input
-        assertEquals("<input size='5' id='space.page_0_prop' aria-label='core.model.xclass.editClassProperty.textAlternative' value='value' name='space.page_0_prop' " + "type='text'/>",
+        assertEquals("<input size='5' id='space.page_0_prop' aria-label='prop' value='value' name='space.page_0_prop' " + "type='text'/>",
             document.display("prop", xcontext));
 
         assertEquals("edit", context.getDisplayMode());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentTest.java
@@ -723,7 +723,7 @@ class XWikiDocumentTest
         this.document.setSyntax(Syntax.XWIKI_2_0);
 
         assertEquals(
-            "{{html clean=\"false\" wiki=\"false\"}}<input size='30' id='Space.Page_0_string' aria-label='core.model.xclass.editClassProperty.textAlternative' value='string' name='Space.Page_0_string' type='text'/>{{/html}}",
+            "{{html clean=\"false\" wiki=\"false\"}}<input size='30' id='Space.Page_0_string' aria-label='String' value='string' name='Space.Page_0_string' type='text'/>{{/html}}",
             this.document.display("string", "edit", this.oldcore.getXWikiContext()));
 
         assertEquals("string", this.document.display("string", "view", this.oldcore.getXWikiContext()));
@@ -759,7 +759,7 @@ class XWikiDocumentTest
 
         assertEquals("string", this.document.display("string", "view", this.oldcore.getXWikiContext()));
         assertEquals(
-            "{pre}<input size='30' id='Space.Page_0_string' aria-label='core.model.xclass.editClassProperty.textAlternative' value='string' name='Space.Page_0_string' type='text'/>{/pre}",
+            "{pre}<input size='30' id='Space.Page_0_string' aria-label='String' value='string' name='Space.Page_0_string' type='text'/>{/pre}",
             this.document.display("string", "edit", this.oldcore.getXWikiContext()));
 
         assertEquals("<p>area</p>", this.document.display("area", "view", this.oldcore.getXWikiContext()));
@@ -776,7 +776,7 @@ class XWikiDocumentTest
 
         assertEquals("string", this.document.display("string", "view", this.oldcore.getXWikiContext()));
         assertEquals(
-            "<input size='30' id='Space.Page_0_string' aria-label='core.model.xclass.editClassProperty.textAlternative' value='string' name='Space.Page_0_string' type='text'/>",
+            "<input size='30' id='Space.Page_0_string' aria-label='String' value='string' name='Space.Page_0_string' type='text'/>",
             this.document.display("string", "edit", this.oldcore.getXWikiContext()));
 
         assertEquals("<p>area</p>", this.document.display("area", "view", this.oldcore.getXWikiContext()));

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/DBListClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/DBListClassTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.xwiki.localization.ContextualLocalizationManager;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.query.Query;
 import org.xwiki.query.QueryBuilder;
@@ -36,11 +37,14 @@ import org.xwiki.test.junit5.mockito.MockComponent;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.test.MockitoOldcore;
 import com.xpn.xwiki.test.junit5.mockito.InjectMockitoOldcore;
 import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
 import com.xpn.xwiki.test.reference.ReferenceComponentList;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -71,6 +75,9 @@ class DBListClassTest
     @MockComponent
     private AuthorExecutor authorExecutor;
 
+    @MockComponent
+    private ContextualLocalizationManager contextualLocalizationManager;
+
     @BeforeEach
     void before()
     {
@@ -78,6 +85,19 @@ class DBListClassTest
             .when(this.oldcore.getSpyXWiki()).parseContent(any(), any(XWikiContext.class));
 
         this.oldcore.getXWikiContext().setDoc(new XWikiDocument());
+    }
+
+    @Test
+    void displayEditSetsAriaLabel()
+    {
+        DBListClass dblc = new DBListClass();
+        dblc.setPrettyName("Related pages");
+        BaseObject object = new BaseObject();
+        StringBuffer buffer = new StringBuffer();
+
+        dblc.displayEdit(buffer, "related", "prefix_", object, this.oldcore.getXWikiContext());
+
+        assertThat(buffer.toString(), containsString("aria-label='Related pages'"));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/DBTreeListClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/DBTreeListClassTest.java
@@ -21,14 +21,19 @@ package com.xpn.xwiki.objects.classes;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.xwiki.localization.ContextualLocalizationManager;
+import org.xwiki.test.junit5.mockito.MockComponent;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.test.MockitoOldcore;
 import com.xpn.xwiki.test.junit5.mockito.InjectMockitoOldcore;
 import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
 import com.xpn.xwiki.test.reference.ReferenceComponentList;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -45,6 +50,9 @@ class DBTreeListClassTest
     @InjectMockitoOldcore
     private MockitoOldcore oldcore;
 
+    @MockComponent
+    private ContextualLocalizationManager contextualLocalizationManager;
+
     @BeforeEach
     void before()
     {
@@ -52,6 +60,19 @@ class DBTreeListClassTest
             .when(this.oldcore.getSpyXWiki()).parseContent(any(), any(XWikiContext.class));
 
         this.oldcore.getXWikiContext().setDoc(new XWikiDocument());
+    }
+
+    @Test
+    void displayEditSetsAriaLabel()
+    {
+        DBTreeListClass dbtlc = new DBTreeListClass();
+        dbtlc.setPrettyName("Category tree");
+        BaseObject object = new BaseObject();
+        StringBuffer buffer = new StringBuffer();
+
+        dbtlc.displayEdit(buffer, "category", "prefix_", object, this.oldcore.getXWikiContext());
+
+        assertThat(buffer.toString(), containsString("aria-label='Category tree'"));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/LevelsClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/LevelsClassTest.java
@@ -40,6 +40,11 @@ import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
 import com.xpn.xwiki.user.api.XWikiRightService;
 import com.xpn.xwiki.web.XWikiRequest;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -103,10 +108,21 @@ class LevelsClassTest
 
         // View and edit should be selected even despite the weird case in edit right
         // Comment should not be selected since there's a space before it
-        String expectedString = "<select size='6' id='authorizationrights' "
-            + "aria-label='core.model.xclass.editClassProperty.textAlternative' "
-            + "name='authorizationrights'>"
-            + "<option value='admin' label='admin'>admin</option>"
+        String actual = stringBuffer.toString();
+        int selectOpeningTagEnd = actual.indexOf('>') + 1;
+
+        // org.apache.ecs.xhtml.select stores its attributes in a java.util.Hashtable, whose iteration order shifts
+        // whenever an attribute is added or removed. Assert the opening tag's attributes are present rather than
+        // relying on a specific order, so the next attribute added here doesn't break this test again.
+        assertThat(actual.substring(0, selectOpeningTagEnd), allOf(
+            startsWith("<select "),
+            endsWith(">"),
+            containsString(" size='6' "),
+            containsString(" id='authorizationrights' "),
+            containsString(" aria-label='Levels List' "),
+            containsString(" name='authorizationrights'")));
+
+        String expectedRest = "<option value='admin' label='admin'>admin</option>"
             + "<option value='programming' label='programming'>programming</option>"
             + "<option selected='selected' value='edit' label='edit'>edit</option>"
             + "<option selected='selected' value='view' label='view'>view</option>"
@@ -114,7 +130,7 @@ class LevelsClassTest
             + "<option value='script' label='script'>script</option>"
             + "<option value='delete' label='delete'>delete</option>"
             + "</select><input name='authorizationrights' type='hidden'/>";
-        assertEquals(expectedString, stringBuffer.toString());
+        assertEquals(expectedRest, actual.substring(selectOpeningTagEnd));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/LevelsClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/LevelsClassTest.java
@@ -24,6 +24,8 @@ import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.xwiki.localization.ContextualLocalizationManager;
+import org.xwiki.test.junit5.mockito.MockComponent;
 
 import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
@@ -32,6 +34,9 @@ import com.xpn.xwiki.objects.BaseCollection;
 import com.xpn.xwiki.objects.BaseProperty;
 import com.xpn.xwiki.objects.LargeStringProperty;
 import com.xpn.xwiki.objects.StringProperty;
+import com.xpn.xwiki.test.MockitoOldcore;
+import com.xpn.xwiki.test.junit5.mockito.InjectMockitoOldcore;
+import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
 import com.xpn.xwiki.user.api.XWikiRightService;
 import com.xpn.xwiki.web.XWikiRequest;
 
@@ -47,6 +52,7 @@ import static org.mockito.Mockito.when;
  * @since 13.3RC1
  * @since 12.10.7
  */
+@OldcoreTest
 class LevelsClassTest
 {
     private static final List<String> DEFAULT_LIST = Arrays.asList(
@@ -59,20 +65,26 @@ class LevelsClassTest
         "delete"
     );
 
+    @InjectMockitoOldcore
+    private MockitoOldcore oldcore;
+
+    @MockComponent
+    private ContextualLocalizationManager contextualLocalizationManager;
+
     private XWikiContext context;
     private XWikiRequest xWikiRequest;
 
     @BeforeEach
     void setup() throws XWikiException
     {
-        this.context = mock(XWikiContext.class);
+        this.context = this.oldcore.getXWikiContext();
         XWiki xWiki = mock(XWiki.class);
-        when(this.context.getWiki()).thenReturn(xWiki);
+        this.context.setWiki(xWiki);
         XWikiRightService xWikiRightService = mock(XWikiRightService.class);
         when(xWiki.getRightService()).thenReturn(xWikiRightService);
         when(xWikiRightService.listAllLevels(context)).thenReturn(DEFAULT_LIST);
         this.xWikiRequest = mock(XWikiRequest.class);
-        when(this.context.getRequest()).thenReturn(this.xWikiRequest);
+        this.context.setRequest(this.xWikiRequest);
     }
 
     @Test
@@ -91,7 +103,9 @@ class LevelsClassTest
 
         // View and edit should be selected even despite the weird case in edit right
         // Comment should not be selected since there's a space before it
-        String expectedString = "<select id='authorizationrights' name='authorizationrights' size='6'>"
+        String expectedString = "<select size='6' id='authorizationrights' "
+            + "aria-label='core.model.xclass.editClassProperty.textAlternative' "
+            + "name='authorizationrights'>"
             + "<option value='admin' label='admin'>admin</option>"
             + "<option value='programming' label='programming'>programming</option>"
             + "<option selected='selected' value='edit' label='edit'>edit</option>"

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/NumberClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/NumberClassTest.java
@@ -29,12 +29,15 @@ import org.xwiki.localization.ContextualLocalizationManager;
 import org.xwiki.test.junit5.mockito.MockComponent;
 
 import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.objects.BaseProperty;
 import com.xpn.xwiki.test.MockitoOldcore;
 import com.xpn.xwiki.test.junit5.mockito.InjectMockitoOldcore;
 import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
 import com.xpn.xwiki.test.reference.ReferenceComponentList;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -58,6 +61,19 @@ class NumberClassTest
 
     @MockComponent
     private ContextualLocalizationManager contextualLocalizationManager;
+
+    @Test
+    void displayEditSetsAriaLabel()
+    {
+        NumberClass nc = new NumberClass();
+        nc.setPrettyName("Quantity");
+        BaseObject object = new BaseObject();
+        StringBuffer buffer = new StringBuffer();
+
+        nc.displayEdit(buffer, "quantity", "prefix_", object, null);
+
+        assertThat(buffer.toString(), containsString("aria-label='Quantity'"));
+    }
 
     /** Test the fromString method. */
     @Test

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/PropertyClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/PropertyClassTest.java
@@ -52,6 +52,8 @@ import com.xpn.xwiki.test.MockitoOldcore;
 import com.xpn.xwiki.test.junit5.mockito.InjectMockitoOldcore;
 import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -116,6 +118,19 @@ class PropertyClassTest
         this.oldCore.getXWikiContext().setDoc(new XWikiDocument(contextDocumentReference));
 
         when(this.renderingContext.getTargetSyntax()).thenReturn(Syntax.HTML_5_0);
+    }
+
+    @Test
+    void displayEditSetsAriaLabel()
+    {
+        PropertyClass propertyClass = new PropertyClass();
+        propertyClass.setPrettyName("Summary");
+        BaseObject object = new BaseObject();
+        StringBuffer buffer = new StringBuffer();
+
+        propertyClass.displayEdit(buffer, "summary", "prefix_", object, null);
+
+        assertThat(buffer.toString(), containsString("aria-label='Summary'"));
     }
 
     /** Test the {@link PropertyClass#compareTo(PropertyClass)} method. */

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/StaticListClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/StaticListClassTest.java
@@ -167,6 +167,7 @@ class StaticListClassTest
     void testDisplayEditInput()
     {
         testDisplayEdit("input", VALUES_WITH_HTML_SPECIAL_CHARS, "<input size='7' id='w&#62;vb&#38;a&#60;r' "
+            + "aria-label='core.model.xclass.editClassProperty.textAlternative' "
             + "value='a&#60;b&#62;c|1&#34;2&#39;3|x&#123;y&#38;z' name='w&#62;vb&#38;a&#60;r' type='text'/>");
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/StaticListClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/StaticListClassTest.java
@@ -167,7 +167,7 @@ class StaticListClassTest
     void testDisplayEditInput()
     {
         testDisplayEdit("input", VALUES_WITH_HTML_SPECIAL_CHARS, "<input size='7' id='w&#62;vb&#38;a&#60;r' "
-            + "aria-label='core.model.xclass.editClassProperty.textAlternative' "
+            + "aria-label='Static List' "
             + "value='a&#60;b&#62;c|1&#34;2&#39;3|x&#123;y&#38;z' name='w&#62;vb&#38;a&#60;r' type='text'/>");
     }
 
@@ -178,7 +178,7 @@ class StaticListClassTest
     void testDisplayEditSelect()
     {
         String expectedHTML = "<select size='7' id='w&#62;vb&#38;a&#60;r' "
-            + "aria-label='core.model.xclass.editClassProperty.textAlternative' name='w&#62;vb&#38;a&#60;r'>"
+            + "aria-label='Static List' name='w&#62;vb&#38;a&#60;r'>"
             + "<option value='' label='---'>---</option>"
             + "<option value='a&#60;b&#62;c' label='c&#62;b&#60;a'>c&#62;b&#60;a</option>"
             + "<option selected='selected' value='1&#34;2&#39;3' label='3&#39;2&#34;1'>3&#39;2&#34;1</option>"

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/StringClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/StringClassTest.java
@@ -74,7 +74,7 @@ class StringClassTest
         StringBuffer stringBuffer = new StringBuffer();
         stringClass.displayEdit(stringBuffer, fieldName, spaceName + "." + pageName + "_0_", baseClass,
             xWikiContext);
-        assertEquals("<input aria-label='core.model.xclass.editClassProperty.textAlternative' "
+        assertEquals("<input aria-label='String' "
             + "onfocus='new ajaxSuggest(this, &#123;script:&#34;\\/a\\/b?xpage=suggest&#38;"
             + "classname=%22%20%2B%20alert%281%29%20%2B%20%22.WebHome&#38;fieldname=test&#38;firCol=-&#38;"
             + "secCol=-&#38;&#34;, varname:&#34;input&#34;} )' "

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/TextAreaClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/TextAreaClassTest.java
@@ -19,15 +19,22 @@
  */
 package com.xpn.xwiki.objects.classes;
 
+import java.util.Map;
+
 import javax.inject.Provider;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.xwiki.edit.Editor;
+import org.xwiki.edit.EditorManager;
+import org.xwiki.localization.ContextualLocalizationManager;
 import org.xwiki.model.document.DocumentAuthors;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.rendering.syntax.Syntax;
+import org.xwiki.rendering.syntax.SyntaxContent;
 import org.xwiki.security.authorization.Right;
 import org.xwiki.test.annotation.ComponentList;
 import org.xwiki.test.junit5.LogCaptureExtension;
@@ -50,6 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -78,8 +86,37 @@ class TextAreaClassTest
     @MockComponent
     private VelocityEvaluator velocityEvaluator;
 
+    @MockComponent
+    private EditorManager editorManager;
+
+    @MockComponent
+    private ContextualLocalizationManager contextualLocalizationManager;
+
     @RegisterExtension
     private final LogCaptureExtension logCaptureExtension = new LogCaptureExtension();
+
+    @Test
+    void displayEditSetsAriaLabel() throws Exception
+    {
+        XWikiDocument spyDocument = getSpyDocument();
+
+        TextAreaClass textAreaClass = new TextAreaClass();
+        textAreaClass.setPrettyName("Description");
+        // Avoid falling back to XWiki#getEditorPreference(), which needs an EditConfiguration component.
+        textAreaClass.setEditor("text");
+        BaseObject object = new BaseObject();
+        object.setOwnerDocument(spyDocument);
+
+        Editor<SyntaxContent> editor = mock(Editor.class);
+        when(this.editorManager.<SyntaxContent>getDefaultEditor(eq(SyntaxContent.class), any())).thenReturn(editor);
+
+        textAreaClass.displayEdit(new StringBuffer(), PROPERTY_NAME, "", object, this.oldcore.getXWikiContext());
+
+        ArgumentCaptor<Map<String, Object>> parametersCaptor = ArgumentCaptor.captor();
+        verify(editor).render(any(), parametersCaptor.capture());
+        // This is the parameter actually consumed by xdom_macros.vm, on the text/puretext editors' path.
+        assertEquals("Description", parametersCaptor.getValue().get("aria-label"));
+    }
 
     @Test
     void viewWikiText()

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-ui/src/main/resources/Extension/Support/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-ui/src/main/resources/Extension/Support/WebHome.xml
@@ -46,8 +46,10 @@
   #end
   {{html}}
     &lt;form&gt;
-      &lt;label class="sr-only" for="extensionsupporter_0_name"&gt;$escapetool.xml($services.localization.render('ExtensionCode.ExtensionSupporterClass_doc.title'))&lt;/label&gt;
-      &lt;input type="text" id="extensionsupporter_0_name" name="ExtensionCode.ExtensionSupporterClass_0_name"/&gt;
+      ## The live table's "doc.title" column label is reused here since this input's value becomes the new
+      ## supporter page's title (passed as title= in the redirect above).
+      &lt;label class="sr-only" for="ExtensionCode.ExtensionSupporterClass_0_name"&gt;$escapetool.xml($services.localization.render('ExtensionCode.ExtensionSupporterClass_doc.title'))&lt;/label&gt;
+      &lt;input type="text" id="ExtensionCode.ExtensionSupporterClass_0_name" name="ExtensionCode.ExtensionSupporterClass_0_name"/&gt;
       &lt;button name="register_supporter" class="btn btn-primary"&gt;$escapetool.xml($services.localization.render('repository.support.createsupporter'))&lt;/button&gt;
     &lt;/form&gt;
   {{/html}}

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-ui/src/main/resources/Extension/Support/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-ui/src/main/resources/Extension/Support/WebHome.xml
@@ -46,7 +46,8 @@
   #end
   {{html}}
     &lt;form&gt;
-      &lt;input type="text" name="ExtensionCode.ExtensionSupporterClass_0_name"/&gt;
+      &lt;label class="sr-only" for="extensionsupporter_0_name"&gt;$escapetool.xml($services.localization.render('ExtensionCode.ExtensionSupporterClass_doc.title'))&lt;/label&gt;
+      &lt;input type="text" id="extensionsupporter_0_name" name="ExtensionCode.ExtensionSupporterClass_0_name"/&gt;
       &lt;button name="register_supporter" class="btn btn-primary"&gt;$escapetool.xml($services.localization.render('repository.support.createsupporter'))&lt;/button&gt;
     &lt;/form&gt;
   {{/html}}

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-ui/src/main/resources/ExtensionCode/ExtensionSupporterSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-ui/src/main/resources/ExtensionCode/ExtensionSupporterSheet.xml
@@ -65,7 +65,8 @@
   #end
   {{html}}
     &lt;form&gt;
-      &lt;input type="text" name="ExtensionCode.ExtensionSupportPlanClass_0_name"/&gt;
+      &lt;label class="sr-only" for="extensionsupportplan_0_name"&gt;$escapetool.xml($services.localization.render('ExtensionCode.ExtensionSupportPlanClass_doc.title'))&lt;/label&gt;
+      &lt;input type="text" id="extensionsupportplan_0_name" name="ExtensionCode.ExtensionSupportPlanClass_0_name"/&gt;
       &lt;button name="add_plan" class="btn btn-primary"&gt;$escapetool.xml($services.localization.render('repository.supporter.sheet.createplan'))&lt;/button&gt;
     &lt;/form&gt;
   {{/html}}

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-ui/src/main/resources/ExtensionCode/ExtensionSupporterSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-ui/src/main/resources/ExtensionCode/ExtensionSupporterSheet.xml
@@ -65,8 +65,10 @@
   #end
   {{html}}
     &lt;form&gt;
-      &lt;label class="sr-only" for="extensionsupportplan_0_name"&gt;$escapetool.xml($services.localization.render('ExtensionCode.ExtensionSupportPlanClass_doc.title'))&lt;/label&gt;
-      &lt;input type="text" id="extensionsupportplan_0_name" name="ExtensionCode.ExtensionSupportPlanClass_0_name"/&gt;
+      ## The live table's "doc.title" column label is reused here since this input's value becomes the new
+      ## plan page's title (passed as title= in the redirect above).
+      &lt;label class="sr-only" for="ExtensionCode.ExtensionSupportPlanClass_0_name"&gt;$escapetool.xml($services.localization.render('ExtensionCode.ExtensionSupportPlanClass_doc.title'))&lt;/label&gt;
+      &lt;input type="text" id="ExtensionCode.ExtensionSupportPlanClass_0_name" name="ExtensionCode.ExtensionSupportPlanClass_0_name"/&gt;
       &lt;button name="add_plan" class="btn btn-primary"&gt;$escapetool.xml($services.localization.render('repository.supporter.sheet.createplan'))&lt;/button&gt;
     &lt;/form&gt;
   {{/html}}

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
@@ -107,8 +107,7 @@ public class WCAGContext
             entry("image-alt", true),
             entry("input-button-name", true),
             entry("input-image-alt", true),
-            // Set to true once the build doesn't fail this rule anymore
-            entry("label", false),
+            entry("label", true),
             entry("link-in-text-block", true),
             entry("link-name", true),
             entry("list", true),

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/editors/xdom_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/editors/xdom_macros.vm
@@ -34,7 +34,7 @@
     #set ($attributes.disabled = 'disabled')
   #end
   #if ("$!parameters.get('aria-label')" != '')
-    #set ($attributes.aria-label = $parameters.get('aria-label'))
+    #set ($discard = $attributes.put('aria-label', $parameters.get('aria-label')))
   #end
   #set ($attributes.data-restricted = "$!parameters.restricted" == 'true')
 #end

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/editors/xdom_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/editors/xdom_macros.vm
@@ -33,6 +33,9 @@
   #if ("$!parameters.disabled" == 'true')
     #set ($attributes.disabled = 'disabled')
   #end
+  #if ("$!parameters.get('aria-label')" != '')
+    #set ($attributes.aria-label = $parameters.get('aria-label'))
+  #end
   #set ($attributes.data-restricted = "$!parameters.restricted" == 'true')
 #end
 #macro (getTextArea)

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/DisplayPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/DisplayPageTest.java
@@ -82,8 +82,11 @@ class DisplayPageTest extends PageTest
     private static final String VALUE_1 = "value1";
 
     private static final String DEFAULT_SELECT =
+        // PageTest's localization stub returns every key as its own translation (see LocalizationSetup), so this
+        // resolves the property's full name instead of falling back to its untranslated pretty name as it would in
+        // a real wiki.
         "<select size='1' id='space.page_0_testField' "
-        + "aria-label='core.model.xclass.editClassProperty.textAlternative [space.page_testField]' "
+        + "aria-label='space.page_testField' "
         + "name='space.page_0_testField'>"
         + "<option selected='selected' value='' label='space.page_testField_'>space.page_testField_</option>"
         + "<option value='value1' label='space.page_testField_value1'>space.page_testField_value1</option></select>"


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24672

# Changes

## Description

* Added the missing `aria-label` text alternative fallback to `PropertyClass`, `NumberClass`, `PasswordClass`, `BooleanClass`'s checkbox edit and `TextAreaClass`
* Added the same fallback to `DBListClass`, `StaticListClass`, `LevelsClass` and `DBTreeListClass`, which override `ListClass`'s edit widgets without inheriting its existing `aria-label` handling
* Factored the `aria-label` attribute name, translation key and computation into shared `PropertyClass` constants/helper methods, reused across all of the above plus `StringClass`, `ListClass` and `BooleanClass`'s pre-existing `aria-label` usages (from XWIKI-22580)
* Passed the fallback through to `TextAreaClass`'s pluggable text editors via `xdom_macros.vm`
* Updated `StaticListClassTest` and `LevelsClassTest` to expect the new attribute
* Added a visually-hidden (`sr-only`) `<label>` to the two hand-written "quick add" `<input>` elements (Support/WebHome's "register a supporter" form, and the Supporter sheet's "add plan" form) that never went through `PropertyClass` at all

## Clarifications

* Root cause and the list of affected `PropertyClass` subclasses were identified in the Jira issue's code investigation
* This is not a regression: these `aria-label` gaps pre-date this PR by a long time. They only started failing CI because [the Repository app's functional test was migrated from the legacy JUnit4/Selenium framework to the JUnit5 Docker framework](https://github.com/xwiki/xwiki-platform/commit/db5d75bc955a704e4598a21e35be55c77b3c25bc), which automatically runs WCAG/axe-core validation on every visited page — the old framework never ran that check on these pages
* `LevelsClassTest`'s expected HTML attribute order changed (`id, name, size` → `size, id, aria-label, name`): `org.apache.ecs.xhtml.select` stores all attributes in a `java.util.Hashtable`, whose iteration order shifts whenever an attribute is added (not related to setter call order) — not a bug, just exposed by the new attribute

# Screenshots & Video

N/A — no visible UI change. This PR only adds `aria-label` attributes and one `sr-only` (visually-hidden) `<label>`, exposed to assistive technologies only.

# Executed Tests

* `mvn clean install -Plegacy,quality` on `xwiki-platform-oldcore` (1141 tests, 0 failures), `xwiki-platform-legacy-oldcore`, `xwiki-platform-web-templates`, `xwiki-platform-web-war` and `xwiki-platform-repository-server-ui`: all clean, 0 Checkstyle violations, coverage checks pass
* Ran `org.xwiki.repository.test.docker.AllIT#validateAllFeatures` (the actual Docker/browser IT that reported this bug) with `-Dxwiki.test.ui.wcag=true -Dxwiki.test.ui.wcagStopOnError=true`: **10 → 0** "Form elements must have labels" violations, `BUILD SUCCESS`

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None.





