### PR TITLE
XWIKI-24582: Old PDF export fail with custom CSS rules

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/xhtml2fo.xsl
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/xhtml2fo.xsl
@@ -1138,7 +1138,9 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING O
                 <xsl:when test="starts-with($name, '-')"/>
                 <xsl:otherwise>
                     <xsl:attribute name="{$name}">
-                        <xsl:value-of select="$value"/>
+                        <xsl:call-template name="process-color-alpha">
+                            <xsl:with-param name="value" select="$value"/>
+                        </xsl:call-template>
                     </xsl:attribute>
                 </xsl:otherwise>
             </xsl:choose>
@@ -1150,6 +1152,45 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING O
                 <xsl:with-param name="style" select="$rest"/>
             </xsl:call-template>
         </xsl:if>
+    </xsl:template>
+
+    <!-- FOP only understands the #RGB and #RRGGBB hexadecimal color notations. It doesn't just ignore the CSS Color
+         Level 4 notations that carry an alpha channel (#RGBA and #RRGGBBAA), it fails on them with a
+         StringIndexOutOfBoundsException, which aborts the whole export. Since CSS4J does produce such values (it
+         computes, e.g., 'background: none' into 'background-color: #0000'), we rewrite them here: a fully transparent
+         color becomes the 'transparent' keyword, any other one simply loses its alpha channel. Values are processed
+         space-separated token by token as colors also appear inside shorthand values such as 'border'. -->
+    <xsl:template name="process-color-alpha">
+        <xsl:param name="value"/>
+        <xsl:choose>
+            <!-- Process each token of a compound value (e.g. "1pt solid #12345678") separately. -->
+            <xsl:when test="contains($value, ' ')">
+                <xsl:call-template name="process-color-alpha">
+                    <xsl:with-param name="value" select="substring-before($value, ' ')"/>
+                </xsl:call-template>
+                <xsl:text> </xsl:text>
+                <xsl:call-template name="process-color-alpha">
+                    <xsl:with-param name="value" select="substring-after($value, ' ')"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:when test="(string-length($value) = 5 or string-length($value) = 9)
+                            and starts-with($value, '#')
+                            and not(translate(substring($value, 2), '0123456789abcdefABCDEF', ''))">
+                <!-- The alpha channel is the last digit of #RGBA and the last two digits of #RRGGBBAA. -->
+                <xsl:variable name="alphaLength" select="(string-length($value) - 1) div 4"/>
+                <xsl:variable name="alpha"
+                              select="substring($value, string-length($value) - $alphaLength + 1)"/>
+                <xsl:choose>
+                    <xsl:when test="translate($alpha, '0', '') = ''">transparent</xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="substring($value, 1, string-length($value) - $alphaLength)"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$value"/>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/pdf/XHTML2FOTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/pdf/XHTML2FOTest.java
@@ -62,6 +62,9 @@ import com.xpn.xwiki.test.MockitoOldcore;
 import com.xpn.xwiki.test.junit5.mockito.InjectMockitoOldcore;
 import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -135,9 +138,9 @@ class XHTML2FOTest
             </div>""");
 
         String transformedXML = getTransformedXML(xml);
-        assertFalse(transformedXML.contains("box-sizing"), "Generated FO shouldn't contain 'box-sizing'");
-        assertFalse(transformedXML.contains("text-justify"), "Generated FO shouldn't contain 'text-justify'");
-        assertFalse(transformedXML.contains("text-autospace"), "Generated FO shouldn't contain 'text-autospace'");
+        assertThat(transformedXML, not(containsString("box-sizing")));
+        assertThat(transformedXML, not(containsString("text-justify")));
+        assertThat(transformedXML, not(containsString("text-autospace")));
     }
 
     /**
@@ -155,14 +158,11 @@ class XHTML2FOTest
             </p>""");
 
         String transformedXML = getTransformedXML(xml);
-        assertTrue(transformedXML.contains("background-color=\"transparent\""),
-            "The fully transparent #RGBA background should have been converted to 'transparent'");
-        assertTrue(transformedXML.contains("color=\"#f00\""),
-            "The alpha channel should have been dropped from the #RGBA text color");
-        assertTrue(transformedXML.contains("border=\"1pt solid #123456\""),
-            "The alpha channel should have been dropped from the #RRGGBBAA border color");
-        assertFalse(transformedXML.contains("#11223300"),
-            "The fully transparent #RRGGBBAA background should have been converted to 'transparent'");
+        // The fully transparent colors become the 'transparent' keyword, the others just lose their alpha channel.
+        assertThat(transformedXML, containsString("background-color=\"transparent\""));
+        assertThat(transformedXML, containsString("color=\"#f00\""));
+        assertThat(transformedXML, containsString("border=\"1pt solid #123456\""));
+        assertThat(transformedXML, not(containsString("#11223300")));
     }
 
     private String constructXML(String xmlContent)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/pdf/XHTML2FOTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/pdf/XHTML2FOTest.java
@@ -140,6 +140,31 @@ class XHTML2FOTest
         assertFalse(transformedXML.contains("text-autospace"), "Generated FO shouldn't contain 'text-autospace'");
     }
 
+    /**
+     * CSS4J computes {@code background: none} into {@code background-color: #0000}, i.e. a CSS Color Level 4 hex
+     * notation with an alpha channel, which FOP doesn't support.
+     *
+     * @see <a href="https://jira.xwiki.org/browse/XWIKI-24582">XWIKI-24582</a>
+     */
+    @Test
+    void transformWithTransparentColors() throws Exception
+    {
+        String xml = constructXML("""
+            <p style="background-color: #0000; color: #f00c; ">
+              <span style="border: 1pt solid #12345678; background-color: #11223300; color: #0000; ">Test</span>
+            </p>""");
+
+        String transformedXML = getTransformedXML(xml);
+        assertTrue(transformedXML.contains("background-color=\"transparent\""),
+            "The fully transparent #RGBA background should have been converted to 'transparent'");
+        assertTrue(transformedXML.contains("color=\"#f00\""),
+            "The alpha channel should have been dropped from the #RGBA text color");
+        assertTrue(transformedXML.contains("border=\"1pt solid #123456\""),
+            "The alpha channel should have been dropped from the #RRGGBBAA border color");
+        assertFalse(transformedXML.contains("#11223300"),
+            "The fully transparent #RRGGBBAA background should have been converted to 'transparent'");
+    }
+
     private String constructXML(String xmlContent)
     {
         return """

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/pdf/impl/PdfExportImplTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/pdf/impl/PdfExportImplTest.java
@@ -64,6 +64,7 @@ import com.xpn.xwiki.test.reference.ReferenceComponentList;
 import com.xpn.xwiki.web.XWikiServletRequestStub;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -229,6 +230,21 @@ class PdfExportImplTest
             + "</body></html>";
 
         assertEquals(expected, this.pdfExport.applyCSS(this.htmlContent, this.cssProperties, this.context));
+    }
+
+    /**
+     * Verify that a CSS rule resetting the background is computed by CSS4J into a fully transparent color using the
+     * CSS Color Level 4 hexadecimal notation, which the XSL-FO conversion then has to deal with.
+     *
+     * @see <a href="https://jira.xwiki.org/browse/XWIKI-24582">XWIKI-24582</a>
+     */
+    @Test
+    void applyCSSWithTransparentBackground()
+    {
+        String styledHTML = this.pdfExport.applyCSS(this.htmlContent, "p { background: none; }", this.context);
+
+        assertTrue(styledHTML.contains("<p style=\"background-image: none; "), styledHTML);
+        assertTrue(styledHTML.contains("background-color: #0000; \">"), styledHTML);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/pdf/impl/PdfExportImplTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/pdf/impl/PdfExportImplTest.java
@@ -63,8 +63,9 @@ import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
 import com.xpn.xwiki.test.reference.ReferenceComponentList;
 import com.xpn.xwiki.web.XWikiServletRequestStub;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -243,8 +244,8 @@ class PdfExportImplTest
     {
         String styledHTML = this.pdfExport.applyCSS(this.htmlContent, "p { background: none; }", this.context);
 
-        assertTrue(styledHTML.contains("<p style=\"background-image: none; "), styledHTML);
-        assertTrue(styledHTML.contains("background-color: #0000; \">"), styledHTML);
+        assertThat(styledHTML, containsString("<p style=\"background-image: none; "));
+        assertThat(styledHTML, containsString("background-color: #0000; \">"));
     }
 
     /**


### PR DESCRIPTION

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24582

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Transform CSS Color Level 4 notations that aren't understood by Apache FOP into either a fully transparent (when fully transparent) or fully opaque color. While this drops transparency in some cases, this is the best we can get with Apache FOP.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The XSL code looks plausible to me and seems to have appropriate safeguards to really only match the failing colors, but I'm mostly relying on Claude Opus 5 here.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built `:xwiki-platform-legacy-oldcore,:xwiki-platform-oldcore` with the quality profile.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-17.10x
  * stable-18.4.x