### PR TITLE
XWIKI-24679: The cursor in CKEditor sometimes jumps to the start of the document

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-selection/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-selection/plugin.js
@@ -118,6 +118,14 @@
     _applySelection: function({editor, editable, textSelection, ranges}) {
       const focus = textSelection.restoreFocus ? {preventScroll: !textSelection.contentOverwritten} : false;
       if (focus) {
+        // The editor saves (locks) the selection when the editing area loses the focus, in order to restore it when
+        // the editing area is focused again. That saved selection can become stale while the editing area doesn't
+        // have the focus (e.g. when editing in realtime, a remote change can shorten the text node holding the
+        // selection), in which case restoring it throws an IndexSizeError. The error is thrown from a focus listener
+        // so we can't catch it here, and it leaves the editor selection in an inconsistent state, with the caret at
+        // the start of the content. We set the selection ourselves right after, so we simply drop the saved one.
+        editor.unlockSelection(false);
+
         // This is mostly needed for the Source mode. For the WYSIWYG mode we take care of focusing the editable area
         // that contains the selection when we apply it.
         editable.$.focus(focus);


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24679

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Unlock the selection before focusing the editor to avoid an error when CKEditor restores the selection. This is okay because we restore the selection right after.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This is a fix for the flickering of `org.xwiki.realtime.wysiwyg.test.ui.RealtimeWYSIWYGEditorIT#localUndoRedo`.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes, I didn't manage to reproduce this in any way.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

With Chrome: `:xwiki-platform-realtime-wysiwyg-test-docker` and `:xwiki-platform-ckeditor-test-docker` fully passing, executed `localUndoRedo` specifically 10 times in a row (as a repeated test), 10/10 failing before the fix, 10/10 passing after the fix.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-18.4.x
  * stable-17.10.x
  * stable-16.10.x (or we should ignore the `localUndoRedo` test in Chrome)