### PR TITLE
XWIKI-24680: Renaming an attachment without changing its location deletes the attachment

### DIFF
--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/pom.xml
@@ -143,5 +143,19 @@
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
+    <!-- User reference Component List for the tests resolving document authors. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-user-default</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-user-default</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
   </dependencies>
 </project>

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/main/java/org/xwiki/attachment/internal/refactoring/job/MoveAttachmentJob.java
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/main/java/org/xwiki/attachment/internal/refactoring/job/MoveAttachmentJob.java
@@ -146,9 +146,13 @@ public class MoveAttachmentJob
         XWiki wiki)
     {
         XWikiContext context = this.xcontextProvider.get();
+        boolean sameDocument = Objects.equals(source.getParent(), destination.getParent());
         try {
             XWikiDocument sourceDocument = wiki.getDocument(source.getParent(), context).clone();
-            XWikiDocument targetDocument = wiki.getDocument(destination.getParent(), context).clone();
+            // When the source and the destination are the same document, the removal of the old attachment and the
+            // addition of the new one must be performed on the single document instance that is saved below.
+            XWikiDocument targetDocument =
+                sameDocument ? sourceDocument : wiki.getDocument(destination.getParent(), context).clone();
             XWikiAttachment sourceAttachment = sourceDocument.getExactAttachment(source.getName());
 
             // Update the author of the source and target documents.
@@ -170,7 +174,7 @@ public class MoveAttachmentJob
                 initializeAutoRedirection(source, destination, sourceDocument);
             }
 
-            if (Objects.equals(source.getParent(), destination.getParent())) {
+            if (sameDocument) {
                 wiki.saveDocument(sourceDocument,
                     this.contextualLocalizationManager.getTranslationPlain("attachment.job.saveDocument.inPlace",
                         source.getName(), destination.getName()), context);

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/test/java/org/xwiki/attachment/internal/refactoring/job/MoveAttachmentJobTest.java
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/test/java/org/xwiki/attachment/internal/refactoring/job/MoveAttachmentJobTest.java
@@ -22,14 +22,13 @@ package org.xwiki.attachment.internal.refactoring.job;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
-import javax.inject.Named;
-
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
 import org.xwiki.attachment.internal.AttachmentsManager;
 import org.xwiki.attachment.internal.RedirectAttachmentClassDocumentInitializer;
 import org.xwiki.attachment.refactoring.MoveAttachmentRequest;
@@ -43,7 +42,8 @@ import org.xwiki.test.LogLevel;
 import org.xwiki.test.junit5.LogCaptureExtension;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
-import org.xwiki.user.GuestUserReference;
+import org.xwiki.user.UserReference;
+import org.xwiki.user.UserReferenceComponentList;
 import org.xwiki.user.UserReferenceResolver;
 
 import com.xpn.xwiki.XWikiContext;
@@ -52,9 +52,9 @@ import com.xpn.xwiki.doc.XWikiAttachment;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.internal.doc.ListAttachmentArchive;
 import com.xpn.xwiki.test.MockitoOldcore;
+import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.test.junit5.mockito.InjectMockitoOldcore;
 import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
-import com.xpn.xwiki.test.reference.ReferenceComponentList;
 
 import ch.qos.logback.classic.Level;
 
@@ -63,25 +63,29 @@ import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
  * Test of {@link MoveAttachmentJob}. The documents the job loads, modifies and saves are actual
- * {@link XWikiDocument} instances going through the test store, so that the assertions are made on what the job
- * persists.
+ * {@link XWikiDocument} instances going through the test store, so that the assertions can be made both on the calls
+ * performed by the job and on what it ends up persisting.
  *
  * @version $Id$
  * @since 14.0RC1
  */
 @OldcoreTest
-@ReferenceComponentList
+@UserReferenceComponentList
 class MoveAttachmentJobTest
 {
     private static final DocumentReference SOURCE_LOCATION = new DocumentReference("xwiki", "Space", "Source");
@@ -103,6 +107,15 @@ class MoveAttachmentJobTest
 
     private static final String ATTACHMENT_CONTENT = "The content of the attachment.";
 
+    private static final String SOURCE_SAVE_COMMENT = "attachment.job.saveDocument.source [xwiki:Space.Target]";
+
+    private static final String TARGET_SAVE_COMMENT = "attachment.job.saveDocument.target [xwiki:Space.Source]";
+
+    private static final String IN_PLACE_SAVE_COMMENT = "attachment.job.saveDocument.inPlace [oldName, newName]";
+
+    private static final String ROLLBACK_SAVE_COMMENT =
+        "attachment.job.rollbackDocument.target [oldName, xwiki:Space.Source]";
+
     @InjectMockitoOldcore
     private MockitoOldcore oldcore;
 
@@ -121,14 +134,18 @@ class MoveAttachmentJobTest
     @MockComponent
     private ModelBridge modelBridge;
 
-    @MockComponent
-    @Named("document")
-    private UserReferenceResolver<DocumentReference> documentReferenceUserReferenceResolver;
-
     @RegisterExtension
     private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.WARN);
 
     private MoveAttachmentRequest request;
+
+    /**
+     * The document instance held by the store before the job runs, which the job must leave untouched since modifying
+     * it would corrupt the document cache.
+     */
+    private XWikiDocument cachedSourceDocument;
+
+    private UserReference authorUserReference;
 
     @BeforeEach
     void setUp() throws Exception
@@ -136,8 +153,10 @@ class MoveAttachmentJobTest
         this.request = new MoveAttachmentRequest();
         this.job.initialize(this.request);
 
-        when(this.documentReferenceUserReferenceResolver.resolve(AUTHOR_REFERENCE))
-            .thenReturn(GuestUserReference.INSTANCE);
+        this.authorUserReference = this.oldcore.getMocker()
+            .<UserReferenceResolver<DocumentReference>>getInstance(UserReferenceResolver.TYPE_DOCUMENT_REFERENCE,
+                "document")
+            .resolve(AUTHOR_REFERENCE);
 
         // Grant global view and edit right.
         AuthorizationManager authorizationManager = this.oldcore.getMockAuthorizationManager();
@@ -147,16 +166,13 @@ class MoveAttachmentJobTest
             .thenReturn(true);
 
         when(this.contextualLocalizationManager.getTranslationPlain("attachment.job.saveDocument.source",
-            "xwiki:Space.Target"))
-            .thenReturn("attachment.job.saveDocument.source [xwiki:Space.Target]");
+            "xwiki:Space.Target")).thenReturn(SOURCE_SAVE_COMMENT);
         when(this.contextualLocalizationManager.getTranslationPlain("attachment.job.saveDocument.target",
-            "xwiki:Space.Source"))
-            .thenReturn("attachment.job.saveDocument.target [xwiki:Space.Source]");
+            "xwiki:Space.Source")).thenReturn(TARGET_SAVE_COMMENT);
         when(this.contextualLocalizationManager.getTranslationPlain("attachment.job.saveDocument.inPlace",
-            "oldName", "newName")).thenReturn("attachment.job.saveDocument.inPlace [oldName, newName]");
+            "oldName", "newName")).thenReturn(IN_PLACE_SAVE_COMMENT);
         when(this.contextualLocalizationManager.getTranslationPlain("attachment.job.rollbackDocument.target",
-            "oldName", "xwiki:Space.Source"))
-            .thenReturn("attachment.job.rollbackDocument.target [oldName, xwiki:Space.Source]");
+            "oldName", "xwiki:Space.Source")).thenReturn(ROLLBACK_SAVE_COMMENT);
 
         // Store the document holding the attachment to move.
         XWikiDocument sourceDocument = new XWikiDocument(SOURCE_LOCATION);
@@ -166,6 +182,10 @@ class MoveAttachmentJobTest
         attachment.setAttachment_archive(new ListAttachmentArchive(attachment));
         sourceDocument.setAttachment(attachment);
         this.oldcore.getSpyXWiki().saveDocument(sourceDocument, this.oldcore.getXWikiContext());
+        this.cachedSourceDocument = getDocument(SOURCE_LOCATION);
+
+        // Only the documents saved by the job must be taken into account by the verifications.
+        clearInvocations(this.oldcore.getSpyXWiki());
     }
 
     @Test
@@ -178,18 +198,19 @@ class MoveAttachmentJobTest
         XWikiDocument sourceDocument = getDocument(SOURCE_LOCATION);
         assertNull(sourceDocument.getExactAttachment("oldName"),
             "The attachment is still present in the source document.");
-        assertEquals("attachment.job.saveDocument.source [xwiki:Space.Target]", sourceDocument.getComment());
         // The redirection has been initialized on the source document.
         assertRedirection(sourceDocument, "xwiki:Space.Target");
+        assertAuthors(sourceDocument);
+        verifySave(SOURCE_LOCATION, SOURCE_SAVE_COMMENT);
 
         XWikiDocument targetDocument = getDocument(TARGET_LOCATION);
-        assertAttachmentContent(targetDocument, "newName");
-        assertEquals("attachment.job.saveDocument.target [xwiki:Space.Source]", targetDocument.getComment());
-        assertEquals(GuestUserReference.INSTANCE, targetDocument.getAuthors().getEffectiveMetadataAuthor());
-        assertEquals(GuestUserReference.INSTANCE, sourceDocument.getAuthors().getEffectiveMetadataAuthor());
+        assertAttachment(targetDocument, "newName");
+        assertAuthors(targetDocument);
+        verifySave(TARGET_LOCATION, TARGET_SAVE_COMMENT);
 
         verify(this.modelBridge).setContextUserReference(AUTHOR_REFERENCE);
-        verify(this.attachmentsManager).removeExistingRedirection(eq("newName"), any(XWikiDocument.class));
+        verifyRemoveExistingRedirection(TARGET_LOCATION);
+        assertCachedSourceDocumentNotModified();
     }
 
     @Test
@@ -202,13 +223,19 @@ class MoveAttachmentJobTest
 
         this.job.process(SOURCE_ATTACHMENT_LOCATION);
 
-        // The attachment has been put back in the source document.
+        // The source document has first been saved without the attachment, then rolled back with it.
+        verifySave(SOURCE_LOCATION, SOURCE_SAVE_COMMENT);
+        verify(this.oldcore.getSpyXWiki()).saveDocument(
+            argThat(document -> SOURCE_LOCATION.equals(document.getDocumentReference())), eq(ROLLBACK_SAVE_COMMENT),
+            eq(true), any(XWikiContext.class));
+
         XWikiDocument sourceDocument = getDocument(SOURCE_LOCATION);
-        assertAttachmentContent(sourceDocument, "oldName");
-        assertEquals("attachment.job.rollbackDocument.target [oldName, xwiki:Space.Source]",
-            sourceDocument.getComment());
+        assertAttachment(sourceDocument, "oldName");
+        assertRedirection(sourceDocument, "xwiki:Space.Target");
         assertNull(getDocument(TARGET_LOCATION).getExactAttachment("newName"),
             "The attachment has been added to the target document even though its save failed.");
+        verifyRemoveExistingRedirection(TARGET_LOCATION);
+        assertCachedSourceDocumentNotModified();
 
         assertEquals(1, this.logCapture.size());
         assertEquals(Level.WARN, this.logCapture.getLogEvent(0).getLevel());
@@ -231,13 +258,20 @@ class MoveAttachmentJobTest
         assertEquals(1, document.getAttachmentList().size());
         assertNull(document.getExactAttachment("oldName"),
             "The attachment is still present in the document under its old name.");
-        assertAttachmentContent(document, "newName");
-        assertEquals("attachment.job.saveDocument.inPlace [oldName, newName]", document.getComment());
+        assertAttachment(document, "newName");
         // The redirection has been initialized on the document, which is also the destination.
         assertRedirection(document, "xwiki:Space.Source");
+        assertAuthors(document);
+
+        // Since the source and the destination are the same document, that document is saved once and no other
+        // document is saved.
+        verifySave(SOURCE_LOCATION, IN_PLACE_SAVE_COMMENT);
+        verify(this.oldcore.getSpyXWiki(), times(1)).saveDocument(any(XWikiDocument.class), anyString(),
+            any(XWikiContext.class));
 
         verify(this.modelBridge).setContextUserReference(AUTHOR_REFERENCE);
-        verify(this.attachmentsManager).removeExistingRedirection("newName", document);
+        verifyRemoveExistingRedirection(SOURCE_LOCATION);
+        assertCachedSourceDocumentNotModified();
     }
 
     @ParameterizedTest
@@ -262,10 +296,13 @@ class MoveAttachmentJobTest
         this.job.process(SOURCE_ATTACHMENT_LOCATION);
 
         // Verify nothing has been modified.
-        assertAttachmentContent(getDocument(SOURCE_LOCATION), "oldName");
+        verify(this.oldcore.getSpyXWiki(), never()).saveDocument(any(XWikiDocument.class), anyString(),
+            any(XWikiContext.class));
+        assertAttachment(getDocument(SOURCE_LOCATION), "oldName");
         assertNull(getDocument(TARGET_LOCATION).getExactAttachment("newName"),
             "The attachment has been moved despite the missing rights.");
         verifyNoInteractions(this.attachmentsManager);
+        assertCachedSourceDocumentNotModified();
 
         if (!canEdit || !canView) {
             assertEquals("You don't have sufficient permissions over the source attachment "
@@ -291,27 +328,55 @@ class MoveAttachmentJobTest
         return this.oldcore.getSpyXWiki().getDocument(documentReference, this.oldcore.getXWikiContext());
     }
 
-    private void assertRedirection(XWikiDocument document, String expectedTargetLocation)
+    private void verifySave(DocumentReference documentReference, String comment) throws Exception
     {
-        var redirection = document.getXObject(RedirectAttachmentClassDocumentInitializer.REFERENCE);
-        assertNotNull(redirection, String.format("The redirection is missing from the document [%s].",
-            document.getDocumentReference()));
-        assertEquals("oldName", redirection.getStringValue(
-            RedirectAttachmentClassDocumentInitializer.SOURCE_NAME_FIELD));
-        assertEquals(expectedTargetLocation, redirection.getStringValue(
-            RedirectAttachmentClassDocumentInitializer.TARGET_LOCATION_FIELD));
-        assertEquals("newName", redirection.getStringValue(
-            RedirectAttachmentClassDocumentInitializer.TARGET_NAME_FIELD));
+        verify(this.oldcore.getSpyXWiki()).saveDocument(
+            argThat(document -> documentReference.equals(document.getDocumentReference())), eq(comment),
+            any(XWikiContext.class));
     }
 
-    private void assertAttachmentContent(XWikiDocument document, String attachmentName) throws Exception
+    private void verifyRemoveExistingRedirection(DocumentReference documentReference)
+    {
+        ArgumentCaptor<XWikiDocument> documentCaptor = ArgumentCaptor.forClass(XWikiDocument.class);
+        verify(this.attachmentsManager).removeExistingRedirection(eq("newName"), documentCaptor.capture());
+        assertEquals(documentReference, documentCaptor.getValue().getDocumentReference());
+    }
+
+    private void assertAuthors(XWikiDocument document)
+    {
+        assertEquals(this.authorUserReference, document.getAuthors().getEffectiveMetadataAuthor());
+        assertEquals(this.authorUserReference, document.getAuthors().getOriginalMetadataAuthor());
+    }
+
+    private void assertRedirection(XWikiDocument document, String targetLocation)
+    {
+        BaseObject redirection = document.getXObject(RedirectAttachmentClassDocumentInitializer.REFERENCE);
+        assertNotNull(redirection, String.format("The redirection is missing from the document [%s].",
+            document.getDocumentReference()));
+        assertEquals("oldName",
+            redirection.getStringValue(RedirectAttachmentClassDocumentInitializer.SOURCE_NAME_FIELD));
+        assertEquals(targetLocation,
+            redirection.getStringValue(RedirectAttachmentClassDocumentInitializer.TARGET_LOCATION_FIELD));
+        assertEquals("newName",
+            redirection.getStringValue(RedirectAttachmentClassDocumentInitializer.TARGET_NAME_FIELD));
+    }
+
+    private void assertAttachment(XWikiDocument document, String attachmentName) throws Exception
     {
         XWikiAttachment attachment = document.getExactAttachment(attachmentName);
-        assertNotNull(attachment,
-            String.format("The attachment [%s] is missing from the document [%s].", attachmentName,
-                document.getDocumentReference()));
+        assertNotNull(attachment, String.format("The attachment [%s] is missing from the document [%s].",
+            attachmentName, document.getDocumentReference()));
+        assertSame(document, attachment.getDoc());
         try (InputStream contentInputStream = attachment.getContentInputStream(this.oldcore.getXWikiContext())) {
             assertEquals(ATTACHMENT_CONTENT, IOUtils.toString(contentInputStream, UTF_8));
         }
+    }
+
+    private void assertCachedSourceDocumentNotModified()
+    {
+        assertNotNull(this.cachedSourceDocument.getExactAttachment("oldName"),
+            "The attachment has been removed from the cached document.");
+        assertNull(this.cachedSourceDocument.getXObject(RedirectAttachmentClassDocumentInitializer.REFERENCE),
+            "The redirection has been added to the cached document.");
     }
 }

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/test/java/org/xwiki/attachment/internal/refactoring/job/MoveAttachmentJobTest.java
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/test/java/org/xwiki/attachment/internal/refactoring/job/MoveAttachmentJobTest.java
@@ -19,62 +19,69 @@
  */
 package org.xwiki.attachment.internal.refactoring.job;
 
-import javax.inject.Named;
-import javax.inject.Provider;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
+import javax.inject.Named;
+
+import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.mockito.Mock;
 import org.xwiki.attachment.internal.AttachmentsManager;
 import org.xwiki.attachment.internal.RedirectAttachmentClassDocumentInitializer;
 import org.xwiki.attachment.refactoring.MoveAttachmentRequest;
 import org.xwiki.localization.ContextualLocalizationManager;
-import org.xwiki.model.document.DocumentAuthors;
 import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.DocumentReference;
-import org.xwiki.model.reference.EntityReference;
-import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.refactoring.internal.ModelBridge;
 import org.xwiki.security.authorization.AuthorizationManager;
 import org.xwiki.security.authorization.Right;
 import org.xwiki.test.LogLevel;
 import org.xwiki.test.junit5.LogCaptureExtension;
-import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
-import org.xwiki.user.UserReference;
+import org.xwiki.user.GuestUserReference;
 import org.xwiki.user.UserReferenceResolver;
 
-import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiAttachment;
 import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.internal.doc.ListAttachmentArchive;
+import com.xpn.xwiki.test.MockitoOldcore;
+import com.xpn.xwiki.test.junit5.mockito.InjectMockitoOldcore;
+import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
+import com.xpn.xwiki.test.reference.ReferenceComponentList;
 
 import ch.qos.logback.classic.Level;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
- * Test of {@link MoveAttachmentJob}.
+ * Test of {@link MoveAttachmentJob}. The documents the job loads, modifies and saves are actual
+ * {@link XWikiDocument} instances going through the test store, so that the assertions are made on what the job
+ * persists.
  *
  * @version $Id$
  * @since 14.0RC1
  */
-@ComponentTest
+@OldcoreTest
+@ReferenceComponentList
 class MoveAttachmentJobTest
 {
     private static final DocumentReference SOURCE_LOCATION = new DocumentReference("xwiki", "Space", "Source");
@@ -91,20 +98,22 @@ class MoveAttachmentJobTest
     private static final AttachmentReference TARGET_ATTACHMENT_LOCATION =
         new AttachmentReference("newName", TARGET_LOCATION);
 
+    private static final AttachmentReference RENAMED_ATTACHMENT_LOCATION =
+        new AttachmentReference("newName", SOURCE_LOCATION);
+
+    private static final String ATTACHMENT_CONTENT = "The content of the attachment.";
+
+    @InjectMockitoOldcore
+    private MockitoOldcore oldcore;
+
     @InjectMockComponents
     private MoveAttachmentJob job;
 
-    @MockComponent
-    private Provider<XWikiContext> xcontextProvider;
-
-    @MockComponent
-    private EntityReferenceSerializer<String> entityReferenceSerializer;
-
+    /**
+     * Mocked because no translation bundle is available, so that the save comments can be asserted.
+     */
     @MockComponent
     private ContextualLocalizationManager contextualLocalizationManager;
-
-    @MockComponent
-    private EntityReferenceSerializer<String> referenceSerializer;
 
     @MockComponent
     private AttachmentsManager attachmentsManager;
@@ -116,30 +125,6 @@ class MoveAttachmentJobTest
     @Named("document")
     private UserReferenceResolver<DocumentReference> documentReferenceUserReferenceResolver;
 
-    @MockComponent
-    private AuthorizationManager authorizationManager;
-
-    @Mock
-    private XWikiContext context;
-
-    @Mock
-    private XWiki wiki;
-
-    @Mock
-    private XWikiDocument sourceDocument;
-
-    @Mock
-    private XWikiDocument targetDocument;
-
-    @Mock
-    private DocumentAuthors sourceAuthors;
-
-    @Mock
-    private DocumentAuthors targetAuthors;
-
-    @Mock
-    private UserReference authorReference;
-
     @RegisterExtension
     private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.WARN);
 
@@ -150,166 +135,109 @@ class MoveAttachmentJobTest
     {
         this.request = new MoveAttachmentRequest();
         this.job.initialize(this.request);
-        when(this.xcontextProvider.get()).thenReturn(this.context);
-        when(this.context.getWiki()).thenReturn(this.wiki);
-        when(this.sourceDocument.clone()).thenReturn(this.sourceDocument);
-        when(this.targetDocument.clone()).thenReturn(this.targetDocument);
 
-        // The cast is mandatory otherwise the wrong method is mocked (the DocumentReference one).
-        when(this.wiki.getDocument((EntityReference) SOURCE_LOCATION, this.context)).thenReturn(this.sourceDocument);
-        when(this.wiki.getDocument((EntityReference) TARGET_LOCATION, this.context)).thenReturn(this.targetDocument);
-        when(this.sourceDocument.getAuthors()).thenReturn(this.sourceAuthors);
-        when(this.targetDocument.getAuthors()).thenReturn(this.targetAuthors);
-        when(this.sourceDocument.getDocumentReference()).thenReturn(SOURCE_LOCATION);
-        when(this.targetDocument.getDocumentReference()).thenReturn(TARGET_LOCATION);
-        when(this.referenceSerializer.serialize(TARGET_ATTACHMENT_LOCATION)).thenReturn("xwiki:Space.Target@newName");
-        when(this.referenceSerializer.serialize(SOURCE_ATTACHMENT_LOCATION)).thenReturn("xwiki:Space.Source@oldName");
-        when(this.referenceSerializer.serialize(TARGET_LOCATION)).thenReturn("xwiki:Space.Target");
-        when(this.referenceSerializer.serialize(SOURCE_LOCATION)).thenReturn("xwiki:Space.Source");
-        when(this.documentReferenceUserReferenceResolver.resolve(AUTHOR_REFERENCE)).thenReturn(this.authorReference);
+        when(this.documentReferenceUserReferenceResolver.resolve(AUTHOR_REFERENCE))
+            .thenReturn(GuestUserReference.INSTANCE);
 
         // Grant global view and edit right.
-        when(this.authorizationManager.hasAccess(eq(Right.VIEW), eq(AUTHOR_REFERENCE), any(AttachmentReference.class)))
+        AuthorizationManager authorizationManager = this.oldcore.getMockAuthorizationManager();
+        when(authorizationManager.hasAccess(eq(Right.VIEW), eq(AUTHOR_REFERENCE), any(AttachmentReference.class)))
             .thenReturn(true);
-        when(this.authorizationManager.hasAccess(eq(Right.EDIT), eq(AUTHOR_REFERENCE), any(AttachmentReference.class)))
+        when(authorizationManager.hasAccess(eq(Right.EDIT), eq(AUTHOR_REFERENCE), any(AttachmentReference.class)))
             .thenReturn(true);
+
+        when(this.contextualLocalizationManager.getTranslationPlain("attachment.job.saveDocument.source",
+            "xwiki:Space.Target"))
+            .thenReturn("attachment.job.saveDocument.source [xwiki:Space.Target]");
+        when(this.contextualLocalizationManager.getTranslationPlain("attachment.job.saveDocument.target",
+            "xwiki:Space.Source"))
+            .thenReturn("attachment.job.saveDocument.target [xwiki:Space.Source]");
+        when(this.contextualLocalizationManager.getTranslationPlain("attachment.job.saveDocument.inPlace",
+            "oldName", "newName")).thenReturn("attachment.job.saveDocument.inPlace [oldName, newName]");
+        when(this.contextualLocalizationManager.getTranslationPlain("attachment.job.rollbackDocument.target",
+            "oldName", "xwiki:Space.Source"))
+            .thenReturn("attachment.job.rollbackDocument.target [oldName, xwiki:Space.Source]");
+
+        // Store the document holding the attachment to move.
+        XWikiDocument sourceDocument = new XWikiDocument(SOURCE_LOCATION);
+        XWikiAttachment attachment = new XWikiAttachment(sourceDocument, "oldName");
+        attachment.setContent(new ByteArrayInputStream(ATTACHMENT_CONTENT.getBytes(UTF_8)));
+        // Set the archive explicitly so that the attachment history is not loaded from the store.
+        attachment.setAttachment_archive(new ListAttachmentArchive(attachment));
+        sourceDocument.setAttachment(attachment);
+        this.oldcore.getSpyXWiki().saveDocument(sourceDocument, this.oldcore.getXWikiContext());
     }
 
     @Test
     void process() throws Exception
     {
-        // Request initialization.
-        this.request.setEntityReferences(singletonList(SOURCE_ATTACHMENT_LOCATION));
-        this.request.setProperty(MoveAttachmentRequest.DESTINATION, TARGET_ATTACHMENT_LOCATION);
-        this.request.setProperty(MoveAttachmentRequest.AUTO_REDIRECT, true);
-        this.request.setInteractive(false);
-        this.request.setUserReference(AUTHOR_REFERENCE);
-        this.request.setAuthorReference(AUTHOR_REFERENCE);
-
-        XWikiAttachment sourceAttachment = mock(XWikiAttachment.class);
-        XWikiAttachment targetAttachment = mock(XWikiAttachment.class);
-
-        when(sourceAttachment.getFilename()).thenReturn("oldName");
-        when(this.sourceDocument.getExactAttachment("oldName")).thenReturn(sourceAttachment);
-        when(this.contextualLocalizationManager.getTranslationPlain("attachment.job.saveDocument.source",
-            "xwiki:Space.Target"))
-            .thenReturn("attachment.job.saveDocument.source [xwiki:Space.Target]");
-        when(this.contextualLocalizationManager.getTranslationPlain("attachment.job.saveDocument.target",
-            "xwiki:Space.Source"))
-            .thenReturn("attachment.job.saveDocument.target [xwiki:Space.Source]");
-        when(sourceAttachment.clone("newName", this.context)).thenReturn(targetAttachment);
+        initializeRequest(TARGET_ATTACHMENT_LOCATION, AUTHOR_REFERENCE);
 
         this.job.process(SOURCE_ATTACHMENT_LOCATION);
-        verify(this.sourceDocument).removeAttachment(sourceAttachment);
-        verify(this.attachmentsManager).removeExistingRedirection("newName", this.targetDocument);
-        // Initialization of the redirection.
-        verify(this.sourceDocument).createXObject(RedirectAttachmentClassDocumentInitializer.REFERENCE, this.context);
-        verify(this.wiki).saveDocument(this.sourceDocument,
-            "attachment.job.saveDocument.source [xwiki:Space.Target]", this.context);
-        verify(this.wiki).saveDocument(this.targetDocument,
-            "attachment.job.saveDocument.target [xwiki:Space.Source]", this.context);
+
+        XWikiDocument sourceDocument = getDocument(SOURCE_LOCATION);
+        assertNull(sourceDocument.getExactAttachment("oldName"),
+            "The attachment is still present in the source document.");
+        assertEquals("attachment.job.saveDocument.source [xwiki:Space.Target]", sourceDocument.getComment());
+        // The redirection has been initialized on the source document.
+        assertRedirection(sourceDocument, "xwiki:Space.Target");
+
+        XWikiDocument targetDocument = getDocument(TARGET_LOCATION);
+        assertAttachmentContent(targetDocument, "newName");
+        assertEquals("attachment.job.saveDocument.target [xwiki:Space.Source]", targetDocument.getComment());
+        assertEquals(GuestUserReference.INSTANCE, targetDocument.getAuthors().getEffectiveMetadataAuthor());
+        assertEquals(GuestUserReference.INSTANCE, sourceDocument.getAuthors().getEffectiveMetadataAuthor());
+
         verify(this.modelBridge).setContextUserReference(AUTHOR_REFERENCE);
-        verify(this.targetAuthors).setEffectiveMetadataAuthor(this.authorReference);
-        verify(this.sourceAuthors).setEffectiveMetadataAuthor(this.authorReference);
-        verify(this.targetAuthors).setOriginalMetadataAuthor(this.authorReference);
-        verify(this.sourceAuthors).setOriginalMetadataAuthor(this.authorReference);
-        verify(targetAttachment).setDoc(this.targetDocument);
-        verify(this.targetDocument).setAttachment(targetAttachment);
-        verify(this.sourceDocument).clone();
-        verify(this.targetDocument).clone();
+        verify(this.attachmentsManager).removeExistingRedirection(eq("newName"), any(XWikiDocument.class));
     }
 
     @Test
     void processTargetSaveFail() throws Exception
     {
-        // Request initialization.
-        this.request.setEntityReferences(singletonList(SOURCE_ATTACHMENT_LOCATION));
-        this.request.setProperty(MoveAttachmentRequest.DESTINATION, TARGET_ATTACHMENT_LOCATION);
-        this.request.setProperty(MoveAttachmentRequest.AUTO_REDIRECT, true);
-        this.request.setInteractive(false);
-        this.request.setUserReference(AUTHOR_REFERENCE);
-        this.request.setAuthorReference(AUTHOR_REFERENCE);
-
-        XWikiAttachment sourceAttachment = mock(XWikiAttachment.class);
-        XWikiAttachment targetAttachment = mock(XWikiAttachment.class);
-        XWikiAttachment newSourceAttachment = mock(XWikiAttachment.class);
-        when(sourceAttachment.getFilename()).thenReturn("oldName");
-        when(this.sourceDocument.getExactAttachment("oldName")).thenReturn(sourceAttachment);
-        when(this.targetDocument.getExactAttachment("newName")).thenReturn(targetAttachment);
-        when(this.contextualLocalizationManager.getTranslationPlain("attachment.job.saveDocument.source",
-            "xwiki:Space.Target"))
-            .thenReturn("attachment.job.saveDocument.source [xwiki:Space.Target]");
-        when(this.contextualLocalizationManager.getTranslationPlain("attachment.job.saveDocument.target",
-            "xwiki:Space.Source"))
-            .thenReturn("attachment.job.saveDocument.target [xwiki:Space.Source]");
-        when(this.contextualLocalizationManager.getTranslationPlain("attachment.job.rollbackDocument.target",
-            "oldName", "xwiki:Space.Source")).thenReturn(
-            "attachment.job.rollbackDocument.target [oldName, xwiki:Space.Source]");
-        doThrow(new XWikiException()).when(this.wiki)
-            .saveDocument(this.targetDocument, "attachment.job.saveDocument.target [xwiki:Space.Source]", this.context);
-        when(sourceAttachment.clone("newName", this.context)).thenReturn(targetAttachment);
-        when(targetAttachment.clone("oldName", this.context)).thenReturn(newSourceAttachment);
+        initializeRequest(TARGET_ATTACHMENT_LOCATION, AUTHOR_REFERENCE);
+        doThrow(new XWikiException()).when(this.oldcore.getSpyXWiki())
+            .saveDocument(argThat(document -> TARGET_LOCATION.equals(document.getDocumentReference())), anyString(),
+                any(XWikiContext.class));
 
         this.job.process(SOURCE_ATTACHMENT_LOCATION);
-        verify(this.sourceDocument).removeAttachment(sourceAttachment);
-        verify(this.attachmentsManager).removeExistingRedirection("newName", this.targetDocument);
-        // Initialization of the redirection.
-        verify(this.sourceDocument).createXObject(RedirectAttachmentClassDocumentInitializer.REFERENCE, this.context);
-        verify(this.wiki).saveDocument(this.sourceDocument,
-            "attachment.job.saveDocument.source [xwiki:Space.Target]", this.context);
-        // Check that the attachment is rolled back and saved again.
-        verify(this.wiki).saveDocument(this.sourceDocument,
-            "attachment.job.rollbackDocument.target [oldName, xwiki:Space.Source]", true, this.context);
-        verify(targetAttachment).setDoc(this.targetDocument);
-        verify(this.targetDocument).setAttachment(targetAttachment);
-        verify(newSourceAttachment).setDoc(this.sourceDocument);
-        verify(this.sourceDocument).setAttachment(newSourceAttachment);
+
+        // The attachment has been put back in the source document.
+        XWikiDocument sourceDocument = getDocument(SOURCE_LOCATION);
+        assertAttachmentContent(sourceDocument, "oldName");
+        assertEquals("attachment.job.rollbackDocument.target [oldName, xwiki:Space.Source]",
+            sourceDocument.getComment());
+        assertNull(getDocument(TARGET_LOCATION).getExactAttachment("newName"),
+            "The attachment has been added to the target document even though its save failed.");
+
         assertEquals(1, this.logCapture.size());
         assertEquals(Level.WARN, this.logCapture.getLogEvent(0).getLevel());
         assertEquals(
             "Failed to move attachment [Attachment xwiki:Space.Source@oldName] to "
                 + "[Attachment xwiki:Space.Target@newName]. Cause: [XWikiException: Error number 0 in 0]",
             this.logCapture.getMessage(0));
-        verify(this.sourceDocument).clone();
-        verify(this.targetDocument).clone();
     }
 
     @Test
     void processRename() throws Exception
     {
-        // Request initialization.
-        this.request.setEntityReferences(singletonList(SOURCE_ATTACHMENT_LOCATION));
-        this.request.setProperty(MoveAttachmentRequest.DESTINATION,
-            new AttachmentReference("newName", SOURCE_LOCATION));
-        this.request.setProperty(MoveAttachmentRequest.AUTO_REDIRECT, true);
-        this.request.setInteractive(false);
-        this.request.setUserReference(AUTHOR_REFERENCE);
-        this.request.setAuthorReference(AUTHOR_REFERENCE);
-
-        XWikiAttachment sourceAttachment = mock(XWikiAttachment.class);
-        XWikiAttachment targetAttachment = mock(XWikiAttachment.class);
-        when(sourceAttachment.getFilename()).thenReturn("oldName");
-        when(this.sourceDocument.getExactAttachment("oldName")).thenReturn(sourceAttachment);
-        when(this.contextualLocalizationManager.getTranslationPlain("attachment.job.saveDocument.inPlace",
-            "oldName", "newName")).thenReturn("attachment.job.saveDocument.inPlace [oldName, newName]");
-        when(sourceAttachment.clone("newName", this.context)).thenReturn(targetAttachment);
+        initializeRequest(RENAMED_ATTACHMENT_LOCATION, AUTHOR_REFERENCE);
 
         this.job.process(SOURCE_ATTACHMENT_LOCATION);
 
-        // Since we rename inside the source, the target document must not be modified.
-        verifyNoInteractions(this.targetDocument);
-        verify(this.sourceDocument).removeAttachment(sourceAttachment);
-        verify(this.attachmentsManager).removeExistingRedirection("newName", this.sourceDocument);
-        verify(targetAttachment).setDoc(this.sourceDocument);
-        verify(this.sourceDocument).setAttachment(targetAttachment);
-        // Initialization of the redirection.
-        verify(this.sourceDocument).createXObject(RedirectAttachmentClassDocumentInitializer.REFERENCE, this.context);
-        verify(this.wiki).saveDocument(this.sourceDocument, "attachment.job.saveDocument.inPlace [oldName, newName]",
-            this.context);
+        // The renamed attachment must be the only one left in the document, i.e. the rename must neither lose the
+        // attachment nor keep a copy under the old name.
+        XWikiDocument document = getDocument(SOURCE_LOCATION);
+        assertEquals(1, document.getAttachmentList().size());
+        assertNull(document.getExactAttachment("oldName"),
+            "The attachment is still present in the document under its old name.");
+        assertAttachmentContent(document, "newName");
+        assertEquals("attachment.job.saveDocument.inPlace [oldName, newName]", document.getComment());
+        // The redirection has been initialized on the document, which is also the destination.
+        assertRedirection(document, "xwiki:Space.Source");
+
         verify(this.modelBridge).setContextUserReference(AUTHOR_REFERENCE);
-        verify(this.sourceAuthors, times(2)).setEffectiveMetadataAuthor(this.authorReference);
-        verify(this.sourceAuthors, times(2)).setOriginalMetadataAuthor(this.authorReference);
-        verify(this.sourceDocument, times(2)).clone();
+        verify(this.attachmentsManager).removeExistingRedirection("newName", document);
     }
 
     @ParameterizedTest
@@ -321,28 +249,23 @@ class MoveAttachmentJobTest
     })
     void failWithoutRights(boolean canView, boolean canEdit) throws Exception
     {
-        // Request initialization.
-        this.request.setEntityReferences(singletonList(SOURCE_ATTACHMENT_LOCATION));
-        this.request.setProperty(MoveAttachmentRequest.DESTINATION, TARGET_ATTACHMENT_LOCATION);
-        this.request.setProperty(MoveAttachmentRequest.AUTO_REDIRECT, true);
-        this.request.setInteractive(false);
-        this.request.setUserReference(USER2_REFERENCE);
-        this.request.setAuthorReference(AUTHOR_REFERENCE);
+        initializeRequest(TARGET_ATTACHMENT_LOCATION, USER2_REFERENCE);
 
-        when(this.authorizationManager.hasAccess(Right.EDIT, USER2_REFERENCE, SOURCE_ATTACHMENT_LOCATION))
+        AuthorizationManager authorizationManager = this.oldcore.getMockAuthorizationManager();
+        when(authorizationManager.hasAccess(Right.EDIT, USER2_REFERENCE, SOURCE_ATTACHMENT_LOCATION))
             .thenReturn(canEdit);
-        when(this.authorizationManager.hasAccess(Right.VIEW, USER2_REFERENCE, SOURCE_ATTACHMENT_LOCATION))
+        when(authorizationManager.hasAccess(Right.VIEW, USER2_REFERENCE, SOURCE_ATTACHMENT_LOCATION))
             .thenReturn(canView);
-        when(this.authorizationManager.hasAccess(Right.EDIT, USER2_REFERENCE, TARGET_ATTACHMENT_LOCATION))
+        when(authorizationManager.hasAccess(Right.EDIT, USER2_REFERENCE, TARGET_ATTACHMENT_LOCATION))
             .thenReturn(false);
 
         this.job.process(SOURCE_ATTACHMENT_LOCATION);
 
         // Verify nothing has been modified.
-        verifyNoInteractions(this.sourceDocument, this.targetDocument);
+        assertAttachmentContent(getDocument(SOURCE_LOCATION), "oldName");
+        assertNull(getDocument(TARGET_LOCATION).getExactAttachment("newName"),
+            "The attachment has been moved despite the missing rights.");
         verifyNoInteractions(this.attachmentsManager);
-        verify(this.wiki, never()).saveDocument(any(), any(), any());
-        verifyNoInteractions(this.targetAuthors, this.sourceAuthors);
 
         if (!canEdit || !canView) {
             assertEquals("You don't have sufficient permissions over the source attachment "
@@ -350,6 +273,45 @@ class MoveAttachmentJobTest
         } else {
             assertEquals("You don't have sufficient permissions over the destination attachment "
                 + "[Attachment xwiki:Space.Target@newName].", this.logCapture.getMessage(0));
+        }
+    }
+
+    private void initializeRequest(AttachmentReference destination, DocumentReference userReference)
+    {
+        this.request.setEntityReferences(singletonList(SOURCE_ATTACHMENT_LOCATION));
+        this.request.setProperty(MoveAttachmentRequest.DESTINATION, destination);
+        this.request.setProperty(MoveAttachmentRequest.AUTO_REDIRECT, true);
+        this.request.setInteractive(false);
+        this.request.setUserReference(userReference);
+        this.request.setAuthorReference(AUTHOR_REFERENCE);
+    }
+
+    private XWikiDocument getDocument(DocumentReference documentReference) throws Exception
+    {
+        return this.oldcore.getSpyXWiki().getDocument(documentReference, this.oldcore.getXWikiContext());
+    }
+
+    private void assertRedirection(XWikiDocument document, String expectedTargetLocation)
+    {
+        var redirection = document.getXObject(RedirectAttachmentClassDocumentInitializer.REFERENCE);
+        assertNotNull(redirection, String.format("The redirection is missing from the document [%s].",
+            document.getDocumentReference()));
+        assertEquals("oldName", redirection.getStringValue(
+            RedirectAttachmentClassDocumentInitializer.SOURCE_NAME_FIELD));
+        assertEquals(expectedTargetLocation, redirection.getStringValue(
+            RedirectAttachmentClassDocumentInitializer.TARGET_LOCATION_FIELD));
+        assertEquals("newName", redirection.getStringValue(
+            RedirectAttachmentClassDocumentInitializer.TARGET_NAME_FIELD));
+    }
+
+    private void assertAttachmentContent(XWikiDocument document, String attachmentName) throws Exception
+    {
+        XWikiAttachment attachment = document.getExactAttachment(attachmentName);
+        assertNotNull(attachment,
+            String.format("The attachment [%s] is missing from the document [%s].", attachmentName,
+                document.getDocumentReference()));
+        try (InputStream contentInputStream = attachment.getContentInputStream(this.oldcore.getXWikiContext())) {
+            assertEquals(ATTACHMENT_CONTENT, IOUtils.toString(contentInputStream, UTF_8));
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-test/xwiki-platform-attachment-test-docker/src/test/it/org/xwiki/attachment/test/ui/docker/MoveAttachmentIT.java
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-test/xwiki-platform-attachment-test-docker/src/test/it/org/xwiki/attachment/test/ui/docker/MoveAttachmentIT.java
@@ -23,6 +23,7 @@ import java.io.File;
 
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.xwiki.attachment.test.po.AttachmentPane;
 import org.xwiki.flamingo.skin.test.po.AttachmentsPane;
@@ -137,12 +138,19 @@ class MoveAttachmentIT
 
         setup.loginAsSuperAdmin();
         setup.deletePage(page);
-        setup.createPage(page, "");
 
-        setup.gotoPage(page);
+        // Create the page and upload the attachment with a first user U3, so that the rename below is performed by
+        // another user and we can tell the attachment author apart from the document author.
+        setup.createUserAndLogin("U3", "pU3");
+        setup.createPage(page, "");
         AttachmentsPane attachmentsPane = new AttachmentsViewPage().openAttachmentsDocExtraPane();
         attachmentsPane.setFileToUpload(buildMovemePath(testConfiguration, "v0"));
         attachmentsPane.waitForUploadToFinish(SOURCE_FILENAME);
+
+        // Switch to a second user U4 and come back to the attachment pane of the page.
+        setup.createUserAndLogin("U4", "pU4");
+        setup.gotoPage(page);
+        new AttachmentsViewPage().openAttachmentsDocExtraPane();
 
         // Rename the attachment without changing its location, i.e. move it inside the document it is already in.
         AttachmentPane movePane = AttachmentPane.moveAttachment(SOURCE_FILENAME);
@@ -151,20 +159,38 @@ class MoveAttachmentIT
         movePane.submit();
         movePane.waitForJobDone();
 
+        ViewPage viewPage = setup.gotoPage(page);
+
+        // Validate the history pane first because we'll move to the attachment history page when validating the
+        // attachment pane.
+        // The document was modified by the rename, so its current author is the user who performed it (U4), not the
+        // attachment author (U3).
+        assertEquals("U4", viewPage.openHistoryDocExtraPane().getCurrentAuthor());
+
         // The page must hold exactly one attachment, the renamed one, i.e. the attachment must not be lost by the
         // rename.
-        setup.gotoPage(page);
         AttachmentsPane attachmentsPaneAfterRename = new AttachmentsViewPage().openAttachmentsDocExtraPane();
         assertEquals(1, attachmentsPaneAfterRename.getNumberOfAttachments());
         assertEquals(TARGET_FILENAME, attachmentsPaneAfterRename.getAttachmentNameByIndex(1));
+        // Verify that the rename preserves the attachment author and version.
+        assertEquals("U3", attachmentsPaneAfterRename.getUploaderOfAttachment(TARGET_FILENAME));
+        assertEquals("1.1", attachmentsPaneAfterRename.getLatestVersionOfAttachment(TARGET_FILENAME));
 
-        // Verify that the content of the renamed attachment is preserved.
+        // Validate that the attachment history is still right after the rename.
         AttachmentHistoryPage attachmentHistoryPage = attachmentsPaneAfterRename.goToAttachmentHistory(TARGET_FILENAME);
+        assertEquals("1.1", attachmentHistoryPage.getVersion(1));
+        assertEquals(13, attachmentHistoryPage.getSize(1));
+        assertEquals("U3", attachmentHistoryPage.getAuthor(1));
         assertEquals("Move me (v0).", attachmentHistoryPage.geAttachmentContent(1));
 
         // Verify that the redirection object has been created on the page.
         Object object = setup.rest().object(page, setup.serializeReference(REFERENCE));
         assertNotNull(object);
+
+        // Verify that the redirection is effective and not just recorded: downloading the attachment under its old
+        // name must serve the renamed attachment.
+        setup.getDriver().get(setup.getURL(new AttachmentReference(SOURCE_FILENAME, page), "download", ""));
+        assertEquals("Move me (v0).", setup.getDriver().findElementWithoutWaiting(By.xpath("/*")).getText());
     }
 
     private String buildMovemePath(TestConfiguration testConfiguration, String dirName)

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-test/xwiki-platform-attachment-test-docker/src/test/it/org/xwiki/attachment/test/ui/docker/MoveAttachmentIT.java
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-test/xwiki-platform-attachment-test-docker/src/test/it/org/xwiki/attachment/test/ui/docker/MoveAttachmentIT.java
@@ -128,6 +128,45 @@ class MoveAttachmentIT
         assertEquals("[[attach:newname.txt]]", setup.rest().<Page>get(targetPage).getContent());
     }
 
+    @Test
+    @Order(2)
+    void renameAttachmentInSameDocument(TestUtils setup, TestReference testReference,
+        TestConfiguration testConfiguration) throws Exception
+    {
+        DocumentReference page = new DocumentReference("RenameSameDocument", testReference.getLastSpaceReference());
+
+        setup.loginAsSuperAdmin();
+        setup.deletePage(page);
+        setup.createPage(page, "");
+
+        setup.gotoPage(page);
+        AttachmentsPane attachmentsPane = new AttachmentsViewPage().openAttachmentsDocExtraPane();
+        attachmentsPane.setFileToUpload(buildMovemePath(testConfiguration, "v0"));
+        attachmentsPane.waitForUploadToFinish(SOURCE_FILENAME);
+
+        // Rename the attachment without changing its location, i.e. move it inside the document it is already in.
+        AttachmentPane movePane = AttachmentPane.moveAttachment(SOURCE_FILENAME);
+        movePane.setName(TARGET_FILENAME);
+        movePane.setRedirect(true);
+        movePane.submit();
+        movePane.waitForJobDone();
+
+        // The page must hold exactly one attachment, the renamed one, i.e. the attachment must not be lost by the
+        // rename.
+        setup.gotoPage(page);
+        AttachmentsPane attachmentsPaneAfterRename = new AttachmentsViewPage().openAttachmentsDocExtraPane();
+        assertEquals(1, attachmentsPaneAfterRename.getNumberOfAttachments());
+        assertEquals(TARGET_FILENAME, attachmentsPaneAfterRename.getAttachmentNameByIndex(1));
+
+        // Verify that the content of the renamed attachment is preserved.
+        AttachmentHistoryPage attachmentHistoryPage = attachmentsPaneAfterRename.goToAttachmentHistory(TARGET_FILENAME);
+        assertEquals("Move me (v0).", attachmentHistoryPage.geAttachmentContent(1));
+
+        // Verify that the redirection object has been created on the page.
+        Object object = setup.rest().object(page, setup.serializeReference(REFERENCE));
+        assertNotNull(object);
+    }
+
     private String buildMovemePath(TestConfiguration testConfiguration, String dirName)
     {
         return new File(new File(testConfiguration.getBrowser().getTestResourcesPath(), dirName), SOURCE_FILENAME)


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-24680

Renaming an attachment without moving it to another page deleted it instead of renaming it: the attachment disappeared from the page (visible in *Page Index > Deleted Attachments*) and no attachment was created under the new name.

### Cause

A regression of the fix of XWIKI-24555 (commit 2537fcdf6a7, backported as 874cdb541fa on `stable-18.4.x` and 30101ae8990 on `stable-17.10.x`), which made `MoveAttachmentJob` clone the documents it loads so as not to modify the cached ones:

```java
-  XWikiDocument sourceDocument = wiki.getDocument(source.getParent(), this.xcontextProvider.get());
-  XWikiDocument targetDocument = wiki.getDocument(destination.getParent(), this.xcontextProvider.get());
+  XWikiDocument sourceDocument = wiki.getDocument(source.getParent(), context).clone();
+  XWikiDocument targetDocument = wiki.getDocument(destination.getParent(), context).clone();
```

`XWikiCacheStore#loadXWikiDoc()` returns the cached instance itself, so when the source and the destination are the same document the two `getDocument()` calls used to return the same object and the rename worked by aliasing: the old attachment was removed from `sourceDocument`, the renamed one added to `targetDocument`, and only `sourceDocument` was saved. With a separate clone per call, the renamed attachment is added to a clone that is never saved, while the removal is.

Moving an attachment to another page is unaffected, since that path saves both documents.

Affected releases: 17.10.10+, 18.4.3+ and 18.6.0RC1+.

### Fix

Use a single document instance when the source and the destination are the same document, so that the removal and the addition happen on the instance that gets saved. This also avoids a redundant `getDocument()` + `clone()` in that case.

### Tests

Neither the unit nor the functional tests caught the regression, and both gaps are closed here:

* `MoveAttachmentIT` only ever renamed an attachment *while* moving it to another page, i.e. the path that saves both documents. A test renaming an attachment without changing its location is added.
* `MoveAttachmentJobTest` did cover the same-document rename, but the fix of XWIKI-24555 stubbed `clone()` as an identity function (`when(sourceDocument.clone()).thenReturn(sourceDocument)`), which reinstated in the test the aliasing the production code had just lost — so the assertions held vacuously. The test class is converted to `@OldcoreTest` (thanks @michitux for the suggestion): documents are now actual `XWikiDocument` instances loaded and saved through the test store, whose `loadXWikiDoc()` reproduces the cache store's same-instance-when-not-dirty behaviour, and the assertions are on what the job persists. Mocking of `XWikiDocument`, `XWiki`, `XWikiContext`, `Provider<XWikiContext>`, `DocumentAuthors`, `UserReference` and the reference serializers/resolvers is gone; the remaining mocks are the collaborators (`AttachmentsManager`, `ModelBridge`), the localization manager (no translation bundle is available, and it keeps the save comments assertable) and the `document` `UserReferenceResolver`.

Reverting the production change makes `MoveAttachmentJobTest#processRename` fail with `expected: <1> but was: <0>` attachments, i.e. the reported symptom is now reproduced by a unit test.

Verified: `MoveAttachmentJobTest` 7/7, the whole `xwiki-platform-attachment-api` module 49/49 with `-Plegacy,quality`, and `MoveAttachmentIT` green (both the pre-existing test and the new one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
