### PR TITLE
XWIKI-22126: Attachment upload units should be localized

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/AttachmentIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/AttachmentIT.java
@@ -116,8 +116,6 @@ class AttachmentIT
         AttachmentsPane attachmentsPane = new AttachmentsViewPage().openAttachmentsDocExtraPane();
 
         // Upload two attachments and check them
-        // Also assert the localized size displayed in the upload notification (see XWIKI-22126), using the known
-        // size of the fixture files (27 and 33 bytes).
         attachmentsPane.setFileToUpload(getFileToUpload(testConfiguration, FIRST_ATTACHMENT).getAbsolutePath());
         attachmentsPane.waitForUploadToFinish(FIRST_ATTACHMENT, "27B");
         attachmentsPane.clickHideProgress();

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/AttachmentIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/AttachmentIT.java
@@ -116,11 +116,13 @@ class AttachmentIT
         AttachmentsPane attachmentsPane = new AttachmentsViewPage().openAttachmentsDocExtraPane();
 
         // Upload two attachments and check them
+        // Also assert the localized size displayed in the upload notification (see XWIKI-22126), using the known
+        // size of the fixture files (27 and 33 bytes).
         attachmentsPane.setFileToUpload(getFileToUpload(testConfiguration, FIRST_ATTACHMENT).getAbsolutePath());
-        attachmentsPane.waitForUploadToFinish(FIRST_ATTACHMENT);
+        attachmentsPane.waitForUploadToFinish(FIRST_ATTACHMENT, "27B");
         attachmentsPane.clickHideProgress();
         attachmentsPane.setFileToUpload(getFileToUpload(testConfiguration, SECOND_ATTACHMENT).getAbsolutePath());
-        attachmentsPane.waitForUploadToFinish(SECOND_ATTACHMENT);
+        attachmentsPane.waitForUploadToFinish(SECOND_ATTACHMENT, "33B");
         attachmentsPane.clickHideProgress();
         assertEquals(2, attachmentsPane.getNumberOfAttachments());
         assertTrue(attachmentsPane.attachmentExistsByFileName(FIRST_ATTACHMENT));

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/skin/test/po/AttachmentsPane.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/skin/test/po/AttachmentsPane.java
@@ -188,7 +188,7 @@ public class AttachmentsPane extends BaseElement
      * @param fileName the name of the attachment
      * @param expectedSize the expected localized size displayed in the upload notification (e.g. {@code "27B"}), or
      *     {@code null} to not check the size
-     * @since 18.7.0RC1
+     * @since 18.8.0RC1
      */
     public void waitForUploadToFinish(String fileName, String expectedSize)
     {

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/skin/test/po/AttachmentsPane.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/skin/test/po/AttachmentsPane.java
@@ -182,6 +182,19 @@ public class AttachmentsPane extends BaseElement
     }
 
     /**
+     * Wait for the upload of a specific file to be finished, also asserting the localized size displayed next to the
+     * file name.
+     *
+     * @param fileName the name of the attachment
+     * @param expectedSize the expected localized size displayed in the upload notification (e.g. {@code "27B"})
+     * @since 18.7.0RC1
+     */
+    public void waitForUploadToFinish(String fileName, String expectedSize)
+    {
+        waitForNotificationSuccessMessage(String.format("Attachment uploaded: %s (%s)", fileName, expectedSize));
+    }
+
+    /**
      * Close the progress displayed after uploading one or multiple files.
      */
     public void clickHideProgress()

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/skin/test/po/AttachmentsPane.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/skin/test/po/AttachmentsPane.java
@@ -178,7 +178,7 @@ public class AttachmentsPane extends BaseElement
      */
     public void waitForUploadToFinish(String fileName)
     {
-        waitForNotificationSuccessMessage("Attachment uploaded: " + fileName);
+        waitForUploadToFinish(fileName, null);
     }
 
     /**
@@ -186,12 +186,16 @@ public class AttachmentsPane extends BaseElement
      * file name.
      *
      * @param fileName the name of the attachment
-     * @param expectedSize the expected localized size displayed in the upload notification (e.g. {@code "27B"})
+     * @param expectedSize the expected localized size displayed in the upload notification (e.g. {@code "27B"}), or
+     *     {@code null} to not check the size
      * @since 18.7.0RC1
      */
     public void waitForUploadToFinish(String fileName, String expectedSize)
     {
-        waitForNotificationSuccessMessage(String.format("Attachment uploaded: %s (%s)", fileName, expectedSize));
+        String message = expectedSize != null
+            ? String.format("Attachment uploaded: %s (%s)", fileName, expectedSize)
+            : "Attachment uploaded: " + fileName;
+        waitForNotificationSuccessMessage(message);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
@@ -82,11 +82,11 @@ define('xwiki-upload', ['xwiki-l10n!upload-translations'], function(l10n) {
      * Convert bytes to a human-readable, localized size format.
      *
      * @param bytes the number of bytes to convert
-     * @param perSecond whether the value represents a data rate (appends a localized "per second" unit)
+     * @param isRate whether the value represents a data rate (appends a localized "per second" unit)
      * @return a string representing the size (or rate) in bytes, kilobytes, megabytes or gigabytes, localized using
      *         the page language, with 1 decimal precision
      */
-    static bytesToSize(bytes, perSecond = false)
+    static bytesToSize(bytes, isRate = false)
     {
       if (bytes === 0) return 'N/A';
       let units = ['byte', 'kilobyte', 'megabyte', 'gigabyte'];
@@ -96,7 +96,7 @@ define('xwiki-upload', ['xwiki-l10n!upload-translations'], function(l10n) {
         value /= 1000;
         unitIndex++;
       }
-      let unit = units[unitIndex] + (perSecond ? '-per-second' : '');
+      let unit = units[unitIndex] + (isRate ? '-per-second' : '');
       return new Intl.NumberFormat(document.documentElement.lang || undefined,
           {style: 'unit', unit, unitDisplay: 'narrow', maximumFractionDigits: 1}).format(value);
     }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
@@ -90,9 +90,12 @@ define('xwiki-upload', ['xwiki-l10n!upload-translations'], function(l10n) {
     {
       if (bytes === 0) return 'N/A';
       let units = ['byte', 'kilobyte', 'megabyte', 'gigabyte'];
-      let unitIndex = Math.min(Math.max(0,
-          Number.parseInt(Math.floor(Math.log(bytes) / Math.log(1000)))), units.length - 1);
-      let value = bytes / Math.pow(1000, unitIndex);
+      let unitIndex = 0;
+      let value = bytes;
+      while (value >= 1000 && unitIndex < units.length - 1) {
+        value /= 1000;
+        unitIndex++;
+      }
       let unit = units[unitIndex] + (perSecond ? '-per-second' : '');
       return new Intl.NumberFormat(document.documentElement.lang || undefined,
           {style: 'unit', unit, unitDisplay: 'narrow', maximumFractionDigits: 1}).format(value);

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
@@ -79,18 +79,23 @@ define('xwiki-upload', ['xwiki-l10n!upload-translations'], function(l10n) {
     }
 
     /**
-     * Convert bytes to human-readable size format.
+     * Convert bytes to a human-readable, localized size (or data rate) format.
      *
      * @param bytes the number of bytes to convert
-     * @return a string representing the size in bytes, kilobytes or megabytes, with 1 decimal precision
+     * @param perSecond whether the value represents a data rate (appends a localized "per second" unit)
+     * @return a string representing the size (or rate) in bytes, kilobytes, megabytes or gigabytes, localized using
+     *         the page language, with 1 decimal precision
      */
-    static bytesToSize(bytes)
+    static bytesToSize(bytes, perSecond = false)
     {
       if (bytes === 0) return 'N/A';
-      let sizes = ['B', 'KB', 'MB'];
-      let unitIndex = Number.parseInt(Math.floor(Math.log(bytes) / Math.log(1024)));
-      return (bytes / Math.pow(1024, unitIndex)).toFixed(1) +
-          sizes[Math.min(unitIndex, sizes.length - 1)];
+      let units = ['byte', 'kilobyte', 'megabyte', 'gigabyte'];
+      let unitIndex = Math.min(Math.max(0,
+          Number.parseInt(Math.floor(Math.log(bytes) / Math.log(1000)))), units.length - 1);
+      let value = bytes / Math.pow(1000, unitIndex);
+      let unit = units[unitIndex] + (perSecond ? '-per-second' : '');
+      return new Intl.NumberFormat(document.documentElement.lang || undefined,
+          {style: 'unit', unit, unitDisplay: 'narrow', maximumFractionDigits: 1}).format(value);
     }
 
     /**
@@ -355,7 +360,7 @@ define('xwiki-upload', ['xwiki-l10n!upload-translations'], function(l10n) {
       let crtBytesPerSecond = diff * this.progressData.updatesPerSecond;
 
       // update speed info
-      let speed = UploadUtils.bytesToSize(crtBytesPerSecond) + '/s';
+      let speed = UploadUtils.bytesToSize(crtBytesPerSecond, true);
       this.progressData.latestSpeed = speed;
       this.statusUI.PROGRESS_SPEED.update(`(${speed})`);
       this.statusUI.PROGRESS_REMAINING.update(UploadUtils.secondsToTime(secondsRemaining));
@@ -418,7 +423,7 @@ define('xwiki-upload', ['xwiki-l10n!upload-translations'], function(l10n) {
         this.statusUI.PROGRESS_REMAINING.update('00:00:00');
         this.statusUI.PROGRESS_TRANSFERED.update(UploadUtils.bytesToSize(this.file.size));
         if (this.progressData.latestSpeed === 0) {
-          this.statusUI.PROGRESS_SPEED.update('(' + UploadUtils.bytesToSize(this.file.size) + '/s)');
+          this.statusUI.PROGRESS_SPEED.update('(' + UploadUtils.bytesToSize(this.file.size, true) + ')');
         }
       }
       this.formData.input.fire('xwiki:html5upload:message', {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
@@ -79,7 +79,7 @@ define('xwiki-upload', ['xwiki-l10n!upload-translations'], function(l10n) {
     }
 
     /**
-     * Convert bytes to a human-readable, localized size (or data rate) format.
+     * Convert bytes to a human-readable, localized size format.
      *
      * @param bytes the number of bytes to convert
      * @param perSecond whether the value represents a data rate (appends a localized "per second" unit)


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22126

# Changes

## Description

* Replaced the hardcoded B/KB/MB size suffixes in the HTML5 upload widget (`upload.js`) with `Intl.NumberFormat` unit formatting, localized using the page language
* Switched the size ladder to decimal (1000-based) units to match the kilobyte/megabyte/gigabyte names `Intl.NumberFormat` uses, and added gigabyte
* Reused the same formatting, with a per-second compound unit, for the upload speed display
* Fixed a latent bug where sub-1-byte-per-second values produced `undefined` in the speed label
* Added a `waitForUploadToFinish(fileName, expectedSize)` overload to `AttachmentsPane` and reused it in the existing `AttachmentIT#uploadAttachments` Docker test to assert the localized byte size of the two fixture files it already uploads

## Clarifications

* Using the native API for localization (unit names, decimal separator, and even the "per second" wording, e.g. `Mo/s` in French, `MB/秒` in Japanese) meant switching the underlying math from 1024-based to 1000-based so the displayed unit name actually matches the computed value, instead of adding IEC labels. This approach was suggested by michitux on a related PR: https://github.com/xwiki/xwiki-platform/pull/5001#discussion_r2987088238

# Screenshots & Video

<img width="2120" height="2889" alt="XWIKI-22126-comparison" src="https://github.com/user-attachments/assets/dc9b93f8-e315-4e1c-9766-97de8dcf11a6" />


# Executed Tests

* No JS unit test harness exists for this widget (`xwiki-platform-web-war` has no Jest/Jasmine setup wired into CI), so coverage for `bytesToSize` is via the Docker functional test below rather than a new isolated unit test.
* Extended the existing `AttachmentIT#uploadAttachments` Docker test (no new IT class, no extra container) to assert the exact localized size shown in the upload notification for its two existing fixture files (27 and 33 bytes → `27B` / `33B`).
* Manually verified against a locally hot-deployed instance: uploaded files in English (`Attachment uploaded: testfile3.txt (26B)`) and in French (`Téléchargement terminé : testfile4.txt (34o)`), confirming the unit is correctly localized end-to-end, not just the surrounding message.
* Before/after comparison above was reproduced against a live instance by swapping `upload.js` between the pre-fix commit and this branch, covering both the upload-finished notification and the live progress speed indicator, in English and French.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None.
