### PR TITLE
XWIKI-24685: When the move of an attachment fails, a redirection to an attachment that was never created is left behind

### DIFF
--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/main/java/org/xwiki/attachment/internal/refactoring/job/MoveAttachmentJob.java
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/main/java/org/xwiki/attachment/internal/refactoring/job/MoveAttachmentJob.java
@@ -180,7 +180,7 @@ public class MoveAttachmentJob
                         source.getName(), destination.getName()), context);
             } else {
                 transactionalMove(wiki, sourceDocument, targetDocument, sourceAttachment.getFilename(),
-                    destination.getName());
+                    destination.getName(), autoRedirect);
             }
         } catch (XWikiException | IOException e) {
             this.logger.warn("Failed to move attachment [{}] to [{}]. Cause: [{}]", source, destination,
@@ -197,12 +197,14 @@ public class MoveAttachmentJob
      * @param targetDocument the target document, in which to move the attachment
      * @param sourceFileName the file name of the source attachment
      * @param targetFileName the file name of the target attachment
+     * @param autoRedirect whether a redirection was added to the source document, and therefore needs to be removed
+     *     if the move is rolled back
      * @throws XWikiException in case of error when save the document
      * @throws IOException in case of error when putting back the attachment in the source document during the
      *     rollback
      */
     private void transactionalMove(XWiki wiki, XWikiDocument sourceDocument, XWikiDocument targetDocument,
-        String sourceFileName, String targetFileName) throws XWikiException, IOException
+        String sourceFileName, String targetFileName, boolean autoRedirect) throws XWikiException, IOException
     {
         String sourceSerialized = this.referenceSerializer.serialize(sourceDocument.getDocumentReference());
         String destinationSerialized = this.referenceSerializer.serialize(targetDocument.getDocumentReference());
@@ -222,6 +224,11 @@ public class MoveAttachmentJob
             XWikiAttachment attachment = targetDocument.getExactAttachment(targetFileName);
             addAttachment(sourceDocument, attachment, sourceFileName);
             targetDocument.removeAttachment(attachment);
+            if (autoRedirect) {
+                // Remove the redirection added to the source document before this method was called: the target
+                // attachment it points to was never created, since the save of the target document failed.
+                this.attachmentsManager.removeExistingRedirection(sourceFileName, sourceDocument);
+            }
             String historyMessageRollbackTarget =
                 this.contextualLocalizationManager.getTranslationPlain("attachment.job.rollbackDocument.target",
                     sourceFileName, sourceSerialized);

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/test/java/org/xwiki/attachment/internal/refactoring/job/MoveAttachmentJobTest.java
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/test/java/org/xwiki/attachment/internal/refactoring/job/MoveAttachmentJobTest.java
@@ -209,7 +209,7 @@ class MoveAttachmentJobTest
         verifySave(TARGET_LOCATION, TARGET_SAVE_COMMENT);
 
         verify(this.modelBridge).setContextUserReference(AUTHOR_REFERENCE);
-        verifyRemoveExistingRedirection(TARGET_LOCATION);
+        verifyRemoveExistingRedirection(TARGET_LOCATION, "newName");
         assertCachedSourceDocumentNotModified();
     }
 
@@ -231,10 +231,42 @@ class MoveAttachmentJobTest
 
         XWikiDocument sourceDocument = getDocument(SOURCE_LOCATION);
         assertAttachment(sourceDocument, "oldName");
-        assertRedirection(sourceDocument, "xwiki:Space.Target");
         assertNull(getDocument(TARGET_LOCATION).getExactAttachment("newName"),
             "The attachment has been added to the target document even though its save failed.");
-        verifyRemoveExistingRedirection(TARGET_LOCATION);
+        verifyRemoveExistingRedirection(TARGET_LOCATION, "newName");
+        // The redirection added to the source document before the failed save of the target document must be
+        // removed on rollback, since it would otherwise point to a target attachment that was never created.
+        verifyRemoveExistingRedirection(SOURCE_LOCATION, "oldName");
+        assertCachedSourceDocumentNotModified();
+
+        assertEquals(1, this.logCapture.size());
+        assertEquals(Level.WARN, this.logCapture.getLogEvent(0).getLevel());
+        assertEquals(
+            "Failed to move attachment [Attachment xwiki:Space.Source@oldName] to "
+                + "[Attachment xwiki:Space.Target@newName]. Cause: [XWikiException: Error number 0 in 0]",
+            this.logCapture.getMessage(0));
+    }
+
+    @Test
+    void processTargetSaveFailWithoutAutoRedirect() throws Exception
+    {
+        initializeRequest(TARGET_ATTACHMENT_LOCATION, AUTHOR_REFERENCE, false);
+        doThrow(new XWikiException()).when(this.oldcore.getSpyXWiki())
+            .saveDocument(argThat(document -> TARGET_LOCATION.equals(document.getDocumentReference())), anyString(),
+                any(XWikiContext.class));
+
+        this.job.process(SOURCE_ATTACHMENT_LOCATION);
+
+        XWikiDocument sourceDocument = getDocument(SOURCE_LOCATION);
+        assertAttachment(sourceDocument, "oldName");
+        assertNull(sourceDocument.getXObject(RedirectAttachmentClassDocumentInitializer.REFERENCE),
+            "A redirection has been added even though auto-redirect is disabled.");
+        assertNull(getDocument(TARGET_LOCATION).getExactAttachment("newName"),
+            "The attachment has been added to the target document even though its save failed.");
+        verifyRemoveExistingRedirection(TARGET_LOCATION, "newName");
+        // Auto-redirect is disabled, so the job never added a redirection to the source document, and none must be
+        // removed from it on rollback.
+        verify(this.attachmentsManager, never()).removeExistingRedirection(eq("oldName"), any(XWikiDocument.class));
         assertCachedSourceDocumentNotModified();
 
         assertEquals(1, this.logCapture.size());
@@ -270,7 +302,7 @@ class MoveAttachmentJobTest
             any(XWikiContext.class));
 
         verify(this.modelBridge).setContextUserReference(AUTHOR_REFERENCE);
-        verifyRemoveExistingRedirection(SOURCE_LOCATION);
+        verifyRemoveExistingRedirection(SOURCE_LOCATION, "newName");
         assertCachedSourceDocumentNotModified();
     }
 
@@ -315,9 +347,15 @@ class MoveAttachmentJobTest
 
     private void initializeRequest(AttachmentReference destination, DocumentReference userReference)
     {
+        initializeRequest(destination, userReference, true);
+    }
+
+    private void initializeRequest(AttachmentReference destination, DocumentReference userReference,
+        boolean autoRedirect)
+    {
         this.request.setEntityReferences(singletonList(SOURCE_ATTACHMENT_LOCATION));
         this.request.setProperty(MoveAttachmentRequest.DESTINATION, destination);
-        this.request.setProperty(MoveAttachmentRequest.AUTO_REDIRECT, true);
+        this.request.setProperty(MoveAttachmentRequest.AUTO_REDIRECT, autoRedirect);
         this.request.setInteractive(false);
         this.request.setUserReference(userReference);
         this.request.setAuthorReference(AUTHOR_REFERENCE);
@@ -335,10 +373,10 @@ class MoveAttachmentJobTest
             any(XWikiContext.class));
     }
 
-    private void verifyRemoveExistingRedirection(DocumentReference documentReference)
+    private void verifyRemoveExistingRedirection(DocumentReference documentReference, String attachmentName)
     {
         ArgumentCaptor<XWikiDocument> documentCaptor = ArgumentCaptor.forClass(XWikiDocument.class);
-        verify(this.attachmentsManager).removeExistingRedirection(eq("newName"), documentCaptor.capture());
+        verify(this.attachmentsManager).removeExistingRedirection(eq(attachmentName), documentCaptor.capture());
         assertEquals(documentReference, documentCaptor.getValue().getDocumentReference());
     }
 


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24685

# Changes

## Description

`MoveAttachmentJob#initializeAutoRedirection` adds the redirection object to `sourceDocument` before `transactionalMove` is called. If the save of the target document then fails, the rollback branch of `transactionalMove` restores the attachment on `sourceDocument` and re-saves it, but never removes that redirection - so the rolled-back document ends up with both the restored attachment and a redirection pointing to a target attachment that was never created.

Fix: remove the redirection from `sourceDocument` in the rollback branch, using the same `AttachmentsManager#removeExistingRedirection` the class already calls elsewhere for the target document. The removal only happens when `autoRedirect` is true, i.e. when the job actually added a redirection to remove - otherwise it could remove an unrelated, pre-existing redirection for that attachment name.

## Clarifications

`MoveAttachmentJobTest#processTargetSaveFail` was asserting the redirection was still present on the rolled-back source document (`assertRedirection(sourceDocument, "xwiki:Space.Target")`), i.e. it was asserting the bug as if it were the expected behavior. Updated it to verify `removeExistingRedirection` is called for the source document instead, following the same pattern already used for the target document's own redirection removal in this test class. Added `processTargetSaveFailWithoutAutoRedirect` covering the case @vmassol raised - a failed move with auto-redirect disabled - asserting nothing is removed from the source document in that case.

# Executed Tests

`mvn verify` on `xwiki-platform-attachment-api`: 50/50 tests pass, 0 checkstyle violations, license/revapi/spoon checks clean.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * Not sure which stable branches this should go to - leaving that to maintainer judgment.