### PR TITLE
XWIKI-24699: Clicking "Add" in the class editor with empty property name goes to the preview

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editclass.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editclass.vm
@@ -140,7 +140,10 @@ $xwiki.jsfx.use('js/xwiki/editors/dataeditors.js', true)##
       </select>
     </div>
     <span class="buttonwrapper">
-      <input type="submit" class="button" value="$services.localization.render('core.editors.class.addProperty.submit')" name="action_propadd"/>
+      ## The button is disabled by default because adding a property is only supported through JavaScript: submitting
+      ## the form without it would leave the class editor. It is enabled again by the class editor JavaScript, once the
+      ## click handler performing the actual addition has been bound.
+      <input type="submit" class="button" value="$services.localization.render('core.editors.class.addProperty.submit')" name="action_propadd" disabled="disabled"/>
     </span>
   </div>
 #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editobject.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editobject.vm
@@ -234,7 +234,10 @@
     })
     #classPicker($classPickerParameters)
     <span class="buttonwrapper">
-      <input type="submit" name="action_objectadd" class="button xobject-add-control"
+      ## The button is disabled by default because adding an object is only supported through JavaScript: submitting the
+      ## form without it would leave the object editor. It is enabled again by the object editor JavaScript, once the
+      ## click handler performing the actual addition has been bound.
+      <input type="submit" name="action_objectadd" class="button xobject-add-control" disabled="disabled"
         value="$services.localization.render('core.editors.object.add.submit')"/>
     </span>
   </div>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsIT.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsIT.java
@@ -131,11 +131,12 @@ class NotificationsIT
     }
 
     @AfterEach
-    public void tearDown(TestUtils setup)
+    public void tearDown(TestUtils setup) throws Exception
     {
-        setup.loginAsSuperAdmin();
-        setup.deletePage("XWiki", FIRST_USER_NAME);
-        setup.deletePage("XWiki", SECOND_USER_NAME);
+        // Clean up through REST: it's faster.
+        setup.setDefaultCredentials(TestUtils.SUPER_ADMIN_CREDENTIALS);
+        setup.rest().deletePage("XWiki", FIRST_USER_NAME);
+        setup.rest().deletePage("XWiki", SECOND_USER_NAME);
         setup.forceGuestUser();
     }
 
@@ -417,9 +418,11 @@ class NotificationsIT
             NotificationsTrayPage tray = new NotificationsTrayPage();
             assertEquals("This is a test template", tray.getNotificationRawContent(0));
         } finally {
-            setup.loginAsSuperAdmin();
-            setup.deletePage(testReference.getLastSpaceReference().getName(), "NotificationDisplayerClassTest");
-            setup.deletePage(testReference.getLastSpaceReference().getName(), "ARandomPageThatShouldBeModified");
+            // Clean up through REST so that the browser stays on the page on which the test failed, which makes the
+            // screenshot taken on failure useful.
+            setup.setDefaultCredentials(TestUtils.SUPER_ADMIN_CREDENTIALS);
+            setup.rest().deletePage(testReference.getLastSpaceReference().getName(), "NotificationDisplayerClassTest");
+            setup.rest().deletePage(testReference.getLastSpaceReference().getName(), "ARandomPageThatShouldBeModified");
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/editor/ClassEditPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/editor/ClassEditPage.java
@@ -25,6 +25,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.test.ui.po.FormContainerElement;
 
@@ -92,6 +93,8 @@ public class ClassEditPage extends EditPage
     {
         getForm().setFieldValue(this.propertyNameField, propertyName);
         getForm().setFieldValue(this.propertyTypeField, propertyType);
+        // The button is only enabled once the class editor JavaScript has bound the handler that adds the property.
+        getDriver().waitUntilCondition(ExpectedConditions.elementToBeClickable(this.propertySubmit));
         this.propertySubmit.click();
     }
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/editor/ObjectEditPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/editor/ObjectEditPage.java
@@ -29,6 +29,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.test.ui.po.SuggestInputElement;
 
@@ -77,6 +78,8 @@ public class ObjectEditPage extends EditPage
 
         final By objectsLocator = By.cssSelector("[id='xclass_" + className + "'] .xobject");
         final int initialObjectCount = getDriver().findElementsWithoutWaiting(objectsLocator).size();
+        // The button is only enabled once the object editor JavaScript has bound the handler that adds the object.
+        getDriver().waitUntilCondition(ExpectedConditions.elementToBeClickable(this.classNameSubmit));
         this.classNameSubmit.click();
 
         // Make sure we wait for the element to appear since there's no page refresh.

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.js
@@ -416,6 +416,10 @@
             }
           });
         });
+
+        // The add button is disabled in the template as adding an object requires JavaScript. Now that the click
+        // handler performing the addition is bound, the button can be enabled.
+        element.find('input.xobject-add-control').prop('disabled', false);
       }
 
       // ------------------------------------
@@ -529,6 +533,8 @@
             let proptype = $('#proptype').val();
             item.blur();
             event.stopPropagation();
+            // The property is added through AJAX below, submitting the form would leave the class editor.
+            event.preventDefault();
             if (!item.prop('disabled') && propname !== '' && proptype !== '') {
               let editURL = self.editedDocument.getURL(xm.action, Object.toQueryString({
                 xpage: 'editclass',
@@ -563,6 +569,10 @@
               });
             }
           });
+
+          // The add button is disabled in the template as adding a property requires JavaScript. Now that the click
+          // handler performing the addition is bound, the button can be enabled.
+          item.prop('disabled', false);
         });
       }
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24699

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Disable both buttons in editobject.vm and editclass.vm and enable them from dataeditors.js once the handler performing the AJAX addition has been bound.
* Call event.preventDefault() when adding a property. The form submit was so far only suppressed as a side effect of disabling the button inside the handler, which does not happen when the property name or type is empty.
* Wait for the buttons to be enabled in ClassEditPage and ObjectEditPage.
* Clean up through REST in NotificationsIT so that a failing test keeps the browser on the page it failed on, which makes the screenshot taken on failure useful.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This was supposed to be a fix for some flickering/failing tests. However, it turns out that in most cases, the root cause was actually https://jira.xwiki.org/browse/XWIKI-24691. However, as part of what was supposed a test-only fix, Claude Code also found a real product bug, which is what this change is now about. The initial disabling might matter for tests but not for actual users.
* I believe that normally page ready should already wait enough for the buttons to be enabled. However, Claude Code convinced me this might not always be the case - in l10n loading and also in patterns like `$(init)` there are calls to `setTimeout` hidden that could lead to page ready firing before the page is actually ready. If nobody else is faster, I'll probably make a proposal at some point to fix that. Until then, I guess the additional wait won't hurt (it should normally be instant).

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No real UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

I assume the changed modules were built with quality profile but I should re-run them in the final version.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * Unless this should turn out to be a bigger problem, I would say no.