### PR TITLE
XWIKI-24693: Add automated tests for "Base Colors Brand Danger"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker/src/test/it/org/xwiki/flamingo/test/ui/FlamingoThemeIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker/src/test/it/org/xwiki/flamingo/test/ui/FlamingoThemeIT.java
@@ -29,7 +29,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.openqa.selenium.By;
 import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.support.Color;
 import org.xwiki.administration.test.po.AdministrablePage;
 import org.xwiki.administration.test.po.AdministrationPage;
 import org.xwiki.administration.test.po.ThemesAdministrationSectionPage;
@@ -63,6 +65,16 @@ class FlamingoThemeIT
     private static final String COLOR_THEME_PREFERENCE = "colorTheme";
 
     private static final String LOGO_NAME = "logo.png";
+
+    /**
+     * The brand colors set by {@link #changeBaseBrandColors}. They are dark enough to keep a proper contrast with the
+     * light backgrounds and texts they are combined with.
+     */
+    private static final String BRAND_PRIMARY = "#1a4d80";
+
+    private static final String BRAND_INFO = "#0b5c73";
+
+    private static final String BRAND_DANGER = "#a11212";
 
     @AfterEach
     void verify(LogCaptureConfiguration logCaptureConfiguration)
@@ -155,6 +167,49 @@ class FlamingoThemeIT
             // The logo URL also carries the revision of the attachment, which is not relevant here.
             assertEquals(setup.getURL(logoReference, "download", null),
                 StringUtils.substringBefore(viewPage.getLogoImageURL(), "?"));
+        } finally {
+            // Restore the color theme that was in use so that this test doesn't affect the other tests.
+            setup.setWikiPreference(COLOR_THEME_PREFERENCE, Objects.toString(previousColorTheme, ""));
+        }
+    }
+
+    @Test
+    @Order(3)
+    void changeBaseBrandColors(TestUtils setup, TestInfo info) throws Exception
+    {
+        setup.loginAsSuperAdmin();
+
+        // First make sure the theme we'll create doesn't exist
+        String themeName = info.getTestMethod().get().getName();
+        setup.deletePage(THEMES_SPACE, themeName);
+
+        // Set the brand colors of the "Base colors" category in a new theme.
+        EditThemePage editThemePage = ThemeApplicationWebHomePage.gotoPage().createNewTheme(themeName);
+        // Disable the auto refresh of the preview because it slows down the test.
+        editThemePage.setAutoRefresh(false);
+        editThemePage.selectVariableCategory("Base colors");
+        editThemePage.setVariableValue("brand-primary", BRAND_PRIMARY);
+        editThemePage.setVariableValue("brand-info", BRAND_INFO);
+        editThemePage.setVariableValue("brand-danger", BRAND_DANGER);
+        editThemePage.clickSaveAndView();
+
+        // The brand info and brand danger colors are exposed to wiki pages through the color theme variables they are
+        // mapped to, so use these variables to color some text. The brand primary color is not exposed as a color theme
+        // variable, but the skin uses it for the "text-primary" style.
+        DocumentReference testPage =
+            new DocumentReference("xwiki", info.getTestClass().get().getSimpleName(), themeName);
+        setup.createPage(testPage, "{{velocity}}\n"
+            + "(% id=\"brandPrimary\" class=\"text-primary\" %)brand primary\n\n"
+            + "(% id=\"brandInfo\" style=\"color: $theme.notificationInfoColor\" %)brand info\n\n"
+            + "(% id=\"brandDanger\" style=\"color: $theme.notificationErrorColor\" %)brand danger\n"
+            + "{{/velocity}}");
+
+        String previousColorTheme = setup.setWikiPreference(COLOR_THEME_PREFERENCE, THEMES_SPACE + '.' + themeName);
+        try {
+            ViewPage viewPage = setup.gotoPage(testPage);
+            assertColor(BRAND_PRIMARY, viewPage.getElementCSSValue(By.id("brandPrimary"), "color"));
+            assertColor(BRAND_INFO, viewPage.getElementCSSValue(By.id("brandInfo"), "color"));
+            assertColor(BRAND_DANGER, viewPage.getElementCSSValue(By.id("brandDanger"), "color"));
         } finally {
             // Restore the color theme that was in use so that this test doesn't affect the other tests.
             setup.setWikiPreference(COLOR_THEME_PREFERENCE, Objects.toString(previousColorTheme, ""));
@@ -278,6 +333,16 @@ class FlamingoThemeIT
         // Test 'lessCode' is correctly handled, the title being inside the ".main" block it colors.
         assertColor(0, 0, 255, page.getTitleColor());
         assertEquals("monospace", page.getTitleFontFamily().toLowerCase());
+    }
+
+    /**
+     * @param expectedColor the expected color, in any CSS notation (e.g. {@code #1a4d80})
+     * @param obtainedColor the obtained color, in any CSS notation (e.g. {@code rgb(26, 77, 128)})
+     */
+    private void assertColor(String expectedColor, String obtainedColor)
+    {
+        assertEquals(Color.fromString(expectedColor), Color.fromString(obtainedColor),
+            String.format("Wrong color [expected = %s | obtained = %s]", expectedColor, obtainedColor));
     }
 
     private void assertColor(int red, int green, int blue, String obtainedValue)

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
@@ -394,9 +394,15 @@ public class ViewPage extends BasePage
         return getElementCSSValue(By.tagName("body"), "color");
     }
 
-    private String getElementCSSValue(By locator, String attribute)
+    /**
+     * @param locator the locator of an element of the page
+     * @param propertyName the name of a CSS property, e.g. {@code color}
+     * @return the computed value of that CSS property for that element
+     * @since 18.7.0RC1
+     */
+    public String getElementCSSValue(By locator, String propertyName)
     {
-        return getDriver().findElement(locator).getCssValue(attribute);
+        return getDriver().findElement(locator).getCssValue(propertyName);
     }
 
     /**


### PR DESCRIPTION
# Jira URL

* https://jira.xwiki.org/browse/XWIKI-24693
* https://jira.xwiki.org/browse/XWIKI-24694
* https://jira.xwiki.org/browse/XWIKI-24695

# Changes

## Description

* Added `FlamingoThemeIT#changeBaseBrandColors`, automating the 3 `testneeded` manual tests [Base Colors Brand Danger](https://test.xwiki.org/xwiki/bin/view/Color%20Themes%20Tests/Base%20Colors%20Brand%20Danger), [Base Colors Brand Info](https://test.xwiki.org/xwiki/bin/view/Color%20Themes%20Tests/Base%20Colors%20Brand%20Info) and [Base Colors Brand Primary](https://test.xwiki.org/xwiki/bin/view/Color%20Themes%20Tests/Base%20Colors%20Brand%20Primary). The test sets the `brand-primary`, `brand-info` and `brand-danger` variables of the "Base colors" category in a new color theme, applies that theme to the wiki, and verifies that the 3 colors reach the browser.
* Made `ViewPage#getElementCSSValue()` public (`@since 18.7.0RC1`) so that a test can read the color of an element without reaching for the `WebDriver` itself.

## Clarifications

* **Why a single test for 3 issues.** The 3 manual tests exercise 3 variables of the same "Base colors" category and share the same expensive create-theme-then-apply-it flow. Splitting them into 3 tests would triple the wall-clock cost of the module for no extra coverage.
* **No prior coverage.** `FlamingoThemeIT` already exercised the "Base colors" category, but only `link-color`, `xwiki-page-content-bg` and `text-color`. Grepping the repository for `brand-primary` / `brand-info` / `brand-danger` / `notificationErrorColor` / `notificationInfoColor` in `*.java` returned nothing, so none of the 3 variables was covered.
* **How each color is observed.** `flamingo/less/colorThemeMappingOutput.vm` maps `@brand-info` to the `notificationInfoColor` color theme variable and `@brand-danger` to `notificationErrorColor`, so the test asserts those two exactly as the manual tests prescribe — through `$theme.notificationInfoColor` / `$theme.notificationErrorColor` in a wiki page. `@brand-primary` has no such mapping (`buttonPrimaryBackgroundColor` maps to `@btn-primary-bg`, which the skin gives its own default), so it is observed through the skin's `.text-primary` style, which resolves to `@brand-primary` in `bootstrap/type.less`.
* **Colors are compared as colors, not as strings**, using Selenium's `Color`, so that a hex value from LESS and an `rgb(…)` computed value from the browser compare equal.
* The 3 colors are dark enough to keep a proper contrast with the light backgrounds and text they are combined with, consistent with the existing tests in this class.

# Screenshots & Video

N/A — test-only change.

# Executed Tests

* Full test class, on the equivalent revision (3/3 green, 282s):
  `mvn -B -ntp verify -Dit.test=FlamingoThemeIT` in `xwiki-platform-flamingo-theme-test-docker`
* The new test on the final revision (1/1 green, 149s):
  `mvn -B -ntp verify -Dit.test='FlamingoThemeIT#changeBaseBrandColors'`
* Checkstyle and Revapi clean on the changed `xwiki-platform-test-ui` module:
  `mvn -B -ntp install -Pquality -DskipTests`

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None for now — the change depends on a new `ViewPage` API, so backporting requires that API on the target branches too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)