### PR TITLE
XWIKI-23180: The color pickers from Theme customization are not always loading

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/colorPicker.js
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/colorPicker.js
@@ -34,7 +34,7 @@ require.config({
   }
 });
 
-require(['jquery', 'colpick'], function($, Colpick) {
+require(['jquery', 'colpick', 'xwiki-events-bridge'], function($, Colpick) {
   var initColorPicker = function() {
     var input = $(this);
     var parent = input.parent();
@@ -91,7 +91,10 @@ require(['jquery', 'colpick'], function($, Colpick) {
     }, 0);
   });
 
-  $(document).on('xwiki:dom:updated', init);
+  // This module can be loaded either before or after the DOM is ready, so we both listen for the event and check the
+  // flag: 'xwiki:dom:loaded' is fired only once and never again after XWiki.domIsLoaded becomes true, so there's no
+  // risk of initializing the color pickers twice.
+  $(document).on('xwiki:dom:loaded xwiki:dom:updated', init);
   return XWiki.domIsLoaded && init();
 });
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/localePicker.js
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/localePicker.js
@@ -164,7 +164,10 @@ require(['jquery', 'xwiki-locale-picker', 'xwiki-events-bridge'], function($) {
     container.find('input[data-type="locale"]').localePicker();
   }
 
-  $(document).on('xwiki:dom:updated', init);
+  // This module can be loaded either before or after the DOM is ready, so we both listen for the event and check the
+  // flag: 'xwiki:dom:loaded' is fired only once and never again after XWiki.domIsLoaded becomes true, so there's no
+  // risk of initializing the locale pickers twice.
+  $(document).on('xwiki:dom:loaded xwiki:dom:updated', init);
   return XWiki.domIsLoaded && init();
 });
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker/src/test/it/org/xwiki/flamingo/test/ui/FlamingoThemeIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker/src/test/it/org/xwiki/flamingo/test/ui/FlamingoThemeIT.java
@@ -188,9 +188,18 @@ class FlamingoThemeIT
         // Disable the auto refresh of the preview because it slows down the test.
         editThemePage.setAutoRefresh(false);
         editThemePage.selectVariableCategory("Base colors");
-        editThemePage.setVariableValue("brand-primary", BRAND_PRIMARY);
+        // Set the first color with the color picker, to check that the picker is there and works, and the remaining
+        // ones by typing their value directly, which is faster.
+        editThemePage.pickVariableColor("brand-primary", BRAND_PRIMARY);
         editThemePage.setVariableValue("brand-info", BRAND_INFO);
         editThemePage.setVariableValue("brand-danger", BRAND_DANGER);
+
+        // The preview box next to each input is only filled in by the color picker, so these assertions also verify
+        // that the picker is initialized for the variables whose value was typed directly.
+        assertColor(BRAND_PRIMARY, editThemePage.getColorPreview("brand-primary"));
+        assertColor(BRAND_INFO, editThemePage.getColorPreview("brand-info"));
+        assertColor(BRAND_DANGER, editThemePage.getColorPreview("brand-danger"));
+
         editThemePage.clickSaveAndView();
 
         // The brand info and brand danger colors are exposed to wiki pages through the color theme variables they are

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-pageobjects/src/main/java/org/xwiki/flamingo/test/po/EditThemePage.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-pageobjects/src/main/java/org/xwiki/flamingo/test/po/EditThemePage.java
@@ -29,6 +29,7 @@ import org.openqa.selenium.support.FindBy;
 import org.xwiki.test.ui.po.editor.EditPage;
 
 import static org.openqa.selenium.support.ui.ExpectedConditions.elementToBeClickable;
+import static org.openqa.selenium.support.ui.ExpectedConditions.invisibilityOf;
 
 public class EditThemePage extends EditPage
 {
@@ -81,6 +82,59 @@ public class EditThemePage extends EditPage
         variableField.sendKeys(Keys.chord(Keys.CONTROL, "a"), Keys.BACK_SPACE);
         // Write the new one
         variableField.sendKeys(value);
+    }
+
+    /**
+     * Set the value of a color variable with its color picker: click the input to display the picker, type the color in
+     * the picker's hexadecimal field and submit it.
+     *
+     * @param variableName the name of the color variable (e.g. {@code brand-primary})
+     * @param color the color to set, as a hexadecimal value (e.g. {@code #1a4d80})
+     * @since 18.7.0RC1
+     */
+    public void pickVariableColor(String variableName, String color)
+    {
+        // The color picker marks the input it is attached to as active when it gets displayed.
+        getDriver().findElement(By.id("var-" + variableName)).click();
+        getDriver().waitUntilElementIsVisible(By.cssSelector("input#var-" + variableName + ".active"));
+
+        WebElement colorPicker = getDisplayedColorPicker();
+        WebElement hexField = colorPicker.findElement(By.cssSelector(".colpick_hex_field input"));
+        hexField.sendKeys(Keys.chord(Keys.CONTROL, "a"), Keys.BACK_SPACE);
+        // The picker's field holds the hexadecimal digits alone, and it takes the new color into account when it fires
+        // a change event, which Enter triggers.
+        hexField.sendKeys(color.startsWith("#") ? color.substring(1) : color, Keys.ENTER);
+        colorPicker.findElement(By.cssSelector(".colpick_submit")).click();
+
+        // Submitting the color hides the picker.
+        getDriver().waitUntilCondition(invisibilityOf(colorPicker));
+    }
+
+    /**
+     * @param variableName the name of a color variable (e.g. {@code brand-primary})
+     * @return the background color of the preview box displayed next to the variable's input, which is only filled in
+     *         by the color picker, and thus tells whether the color picker got initialized
+     * @since 18.7.0RC1
+     */
+    public String getColorPreview(String variableName)
+    {
+        return getDriver()
+            .findElementWithoutWaiting(By.xpath("//input[@id = 'var-" + variableName
+                + "']/following-sibling::span//span[@class = 'color-preview']"))
+            .getCssValue("background-color");
+    }
+
+    /**
+     * @return the color picker that is currently displayed; the color pickers of all the color variables are appended
+     *         to the body, but only one of them is displayed at a time
+     */
+    private WebElement getDisplayedColorPicker()
+    {
+        return getDriver().waitUntilCondition(driver -> getDriver()
+            .findElementsWithoutWaiting(By.cssSelector("body > div.colpick")).stream()
+            .filter(WebElement::isDisplayed)
+            .findFirst()
+            .orElse(null));
     }
 
     /**


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-23180

## Problem

`colorPicker.js` never listened for `xwiki:dom:loaded`; it only checked `XWiki.domIsLoaded` once, when its RequireJS callback resolved:

```js
$(document).on('xwiki:dom:updated', init);
return XWiki.domIsLoaded && init();
```

Every other initialization in the code base keeps the fallback branch (e.g. `uicomponents/lock/lock.js`):

```js
(XWiki.domIsLoaded && init()) || document.observe('xwiki:dom:loaded', init);
```

Without it, when the callback resolves *before* `xwiki:dom:loaded` has fired, `init()` is never called and nothing calls it again: the inputs render as plain text fields with an empty swatch, with no error in the console.

That window is real and varies from one page load to the next. `colorPicker.js` is a deferred skin extension emitted inside `#javaScriptExtensionHooks` (`flamingo/javascript.vm`), and deferred scripts run in order *as they arrive*, while `DOMContentLoaded` — and therefore `XWiki.domIsLoaded` — only comes after the last one (`compatibility.js`, `markerScript.js` and the theme page's own JSX all follow). Meanwhile `require(['jquery', 'colpick'], ...)` is already loading, and with a warm HTTP cache it can easily win that race. Hence the dependency on the cache, on the page's script weight and on the browser's scheduler (easy to reproduce on Chrome/Edge, rare on Firefox).

`localePicker.js` had the identical defect.

## Changes

* Register the listener unconditionally in both files: `$(document).on('xwiki:dom:loaded xwiki:dom:updated', init)`. This is safe — `xwiki:dom:loaded` is fired once and never again once `XWiki.domIsLoaded` is true, so the pickers cannot be initialized twice.
* Require `xwiki-events-bridge` in `colorPicker.js`. It listens for `xwiki:dom:updated` with jQuery, and the bridge is what forwards Prototype-fired `xwiki:*` events to jQuery listeners. It was only mapped as a RequireJS path, never loaded, so that fallback worked only when another module happened to pull the bridge in (`localePicker.js` already required it).

## Tests

`FlamingoThemeIT.changeBaseBrandColors` now sets the first brand color through the color picker itself — click the input, type the color in the picker's hexadecimal field, submit — and asserts the color preview box of all three variables, which only the picker fills in. Two page-object methods back this: `EditThemePage.pickVariableColor` and `EditThemePage.getColorPreview`.

To be explicit about the limits: this verifies the picker is present and functional, it does not reproduce the race — that would need control over the script load ordering. It does mean the editor can no longer regress to "no picker at all" unnoticed, which the previous test could not detect since `setVariableValue` types into the input directly and succeeds on a plain text field.

`FlamingoThemeIT` passes locally (3/3, Chrome, Docker).

## Notes

The `Effect is not defined` error and the `scriptaculous.js` 404 visible in the issue's screenshots are unrelated to this fix and left alone. Prototype fires custom events through `dispatchEvent`, so that exception is isolated by the browser and does not prevent `XWiki.initialize` from running; `ModalBox` is not part of xwiki-platform either. A slow or failing request in the deferred script chain does widen the window this fix closes, though.

Also worth knowing for later: colpick's `hidePicker` (called by our `onSubmit`) hides the picker without invoking its `onHide` callback, so the input keeps the `active` class after a color is submitted. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
