### PR TITLE
XWIKI-24701: Create/check for automated tests for "Access Rights for a page creator"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
@@ -769,6 +769,35 @@ class DefaultAuthorizationManagerIntegrationTest extends AbstractAuthorizationTe
             getXUser("userB"), getXDoc("any document", "spaceAllowGroupA"));
     }
 
+    /**
+     * Check that the rules set on a document, typically by its creator, cannot take a right away from a user having
+     * the admin right at wiki level: the admin right implies the view right and, contrary to the view right itself, it
+     * is not overridden by the rules defined at a lower level.
+     */
+    @Test
+    void documentDenyVersusAdminRightAtWikiLevel() throws Exception
+    {
+        initialiseWikiMock("documentDenyVersusAdminRightAtWikiLevel");
+
+        // The document level deny takes the view right away from userB, which is a simple user...
+        assertAccessTrue("userB should have view access on a document of a space without rules", VIEW,
+            getXUser("userB"), getXDoc("any document", "any space"));
+        assertAccessFalse("userB should not have view access on the document denying it", VIEW,
+            getXUser("userB"), getXDoc("docDenyingView", "space"));
+
+        // ...but not from userAdmin, whose admin right at wiki level implies the view right.
+        assertAccessTrue("userAdmin should have view access on the document denying it", VIEW,
+            getXUser("userAdmin"), getXDoc("docDenyingView", "space"));
+
+        // Restricting the view right to the creator of the document doesn't lock userAdmin out either.
+        assertAccessTrue("userA should have view access on the document it created", VIEW,
+            getXUser("userA"), getXDoc("docAllowingCreatorOnly", "space"));
+        assertAccessFalse("userB should not have view access on the document allowing view to userA only", VIEW,
+            getXUser("userB"), getXDoc("docAllowingCreatorOnly", "space"));
+        assertAccessTrue("userAdmin should have view access on the document allowing view to userA only", VIEW,
+            getXUser("userAdmin"), getXDoc("docAllowingCreatorOnly", "space"));
+    }
+
     @Test
     void documentCreator() throws Exception
     {

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/resources/testwikis/documentDenyVersusAdminRightAtWikiLevel.xml
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/resources/testwikis/documentDenyVersusAdminRightAtWikiLevel.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<!-- Used by DefaultAuthorizationManagerIntegrationTest#documentDenyVersusAdminRightAtWikiLevel() -->
+<wikis>
+  <wiki name="wiki" mainWiki="true" alt="Main Wiki granting the admin right to userAdmin">
+    <user name="userA" alt="a simple user, creator of the documents below" />
+    <user name="userB" alt="a simple user" />
+    <user name="userAdmin" alt="a user having the admin right at wiki level" />
+
+    <allowUser name="userAdmin" type="admin" />
+
+    <space name="any space" alt="a space without any rule">
+      <document name="any document" />
+    </space>
+
+    <space name="space" alt="any space">
+      <document name="docDenyingView" creator="userA"
+        alt="a document created by userA, denying the view right to userAdmin and to userB">
+        <denyUser name="userAdmin" type="view" />
+        <denyUser name="userB" type="view" />
+      </document>
+
+      <document name="docAllowingCreatorOnly" creator="userA"
+        alt="a document created by userA, allowing the view right to userA and denying it to userAdmin">
+        <allowUser name="userA" type="view" />
+        <denyUser name="userAdmin" type="view" />
+      </document>
+    </space>
+  </wiki>
+</wikis>


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24701

# Changes

## Description

* Add `DefaultAuthorizationManagerIntegrationTest#documentDenyVersusAdminRightAtWikiLevel` and its `testwikis/documentDenyVersusAdminRightAtWikiLevel.xml` fixture, automating the [Access Rights for a page creator](https://test.xwiki.org/xwiki/bin/view/Security%20Tests/Access%20Rights%20for%20a%20page%20creator) manual test: the rules a creator sets on its document cannot take a right away from a user having the `admin` right at wiki level.

The fixture grants `admin` at wiki level to `userAdmin`, and gives `userA` two documents: one denying `view` to `userAdmin` and to `userB`, one allowing `view` to `userA` only and denying it to `userAdmin`. The same deny rule strips `view` from the simple user `userB` but leaves `userAdmin` with it — the contrast is what makes the assertion meaningful rather than vacuous.

## Clarifications

* No test covered this. The closest existing ones are `groupRightsAtSpaceLevelVersusUserDenyAtWikiLevel` (page-level allow winning over a wiki-level deny) and `documentCreator` (which rights a creator gets on its own document); neither asserts that a document-level deny has no effect on a wiki admin.
* The behaviour comes from `Right.ADMIN` being declared with `inheritanceOverridePolicy = false` and implying `VIEW`, so the wiki-level implied `view` is not overridden by the rules defined at document level.
* **Why not a functional test.** The manual test's expected result ("even as the page creator, U1 can't Deny any rights to that page to the Admin") is pure authorization-engine behaviour, and this suite pins it in under a second instead of a few minutes of browser time. The engine has no notion of who authored a rule, so the "as the page creator" framing is not representable here — but the rights-editor path it refers to is already exercised by `UsersGroupsRightsManagementIT` (`setExtensionRightsForPage*`, `allowGroupRightsAtPageLevelWhenUserRightDeniedAtWikiLevel`).

# Screenshots & Video

N/A — no UI change.

# Executed Tests

```
mvn clean install -B -ntp -Pquality
```

in `xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api` — green, 19/19 tests in `DefaultAuthorizationManagerIntegrationTest`.

JaCoCo instruction ratio is 0.7669 against the module's `0.76` floor; unchanged at the repo's 2-decimal convention, so `xwiki.jacoco.instructionRatio` is left as is.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
