### PR TITLE
[stable-17.10.x] XWIKI-24701: Create/check for automated tests for "Access Rights for a page creator"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
@@ -735,6 +735,35 @@ class DefaultAuthorizationManagerIntegrationTest extends AbstractAuthorizationTe
             getWiki("wikiGroupUserDenyAllowNoAdmin"));
     }
 
+    /**
+     * Check that the rules set on a document, typically by its creator, cannot take a right away from a user having
+     * the admin right at wiki level: the admin right implies the view right and, contrary to the view right itself, it
+     * is not overridden by the rules defined at a lower level.
+     */
+    @Test
+    void documentDenyVersusAdminRightAtWikiLevel() throws Exception
+    {
+        initialiseWikiMock("documentDenyVersusAdminRightAtWikiLevel");
+
+        // The document level deny takes the view right away from userB, which is a simple user...
+        assertAccessTrue("userB should have view access on a document of a space without rules", VIEW,
+            getXUser("userB"), getXDoc("any document", "any space"));
+        assertAccessFalse("userB should not have view access on the document denying it", VIEW,
+            getXUser("userB"), getXDoc("docDenyingView", "space"));
+
+        // ...but not from userAdmin, whose admin right at wiki level implies the view right.
+        assertAccessTrue("userAdmin should have view access on the document denying it", VIEW,
+            getXUser("userAdmin"), getXDoc("docDenyingView", "space"));
+
+        // Restricting the view right to the creator of the document doesn't lock userAdmin out either.
+        assertAccessTrue("userA should have view access on the document it created", VIEW,
+            getXUser("userA"), getXDoc("docAllowingCreatorOnly", "space"));
+        assertAccessFalse("userB should not have view access on the document allowing view to userA only", VIEW,
+            getXUser("userB"), getXDoc("docAllowingCreatorOnly", "space"));
+        assertAccessTrue("userAdmin should have view access on the document allowing view to userA only", VIEW,
+            getXUser("userAdmin"), getXDoc("docAllowingCreatorOnly", "space"));
+    }
+
     @Test
     void documentCreator() throws Exception
     {

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/resources/testwikis/documentDenyVersusAdminRightAtWikiLevel.xml
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/resources/testwikis/documentDenyVersusAdminRightAtWikiLevel.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<!-- Used by DefaultAuthorizationManagerIntegrationTest#documentDenyVersusAdminRightAtWikiLevel() -->
+<wikis>
+  <wiki name="wiki" mainWiki="true" alt="Main Wiki granting the admin right to userAdmin">
+    <user name="userA" alt="a simple user, creator of the documents below" />
+    <user name="userB" alt="a simple user" />
+    <user name="userAdmin" alt="a user having the admin right at wiki level" />
+
+    <allowUser name="userAdmin" type="admin" />
+
+    <space name="any space" alt="a space without any rule">
+      <document name="any document" />
+    </space>
+
+    <space name="space" alt="any space">
+      <document name="docDenyingView" creator="userA"
+        alt="a document created by userA, denying the view right to userAdmin and to userB">
+        <denyUser name="userAdmin" type="view" />
+        <denyUser name="userB" type="view" />
+      </document>
+
+      <document name="docAllowingCreatorOnly" creator="userA"
+        alt="a document created by userA, allowing the view right to userA and denying it to userAdmin">
+        <allowUser name="userA" type="view" />
+        <denyUser name="userAdmin" type="view" />
+      </document>
+    </space>
+  </wiki>
+</wikis>


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24701

# Changes

## Description

* Backport of `c5640e2580c` (#6165) to `stable-17.10.x`, cherry-picked with `-x`. Adds `DefaultAuthorizationManagerIntegrationTest#documentDenyVersusAdminRightAtWikiLevel` and its `testwikis/documentDenyVersusAdminRightAtWikiLevel.xml` fixture, automating the [Access Rights for a page creator](https://test.xwiki.org/xwiki/bin/view/Security%20Tests/Access%20Rights%20for%20a%20page%20creator) manual test: the rules set on a document, typically by its creator, cannot take a right away from a user having the admin right at wiki level.

## Clarifications

* **The cherry-pick conflicted**, because on master the new method sits next to `groupRightsAtSpaceLevelVersusUserDenyAtWikiLevel`, which does not exist on this branch. Resolved by keeping only what this commit introduces — that neighbouring test was deliberately **not** pulled in. The result reproduces the original commit's `--stat` (2 files, 58 insertions).
* **No `@since` work:** the change adds no reusable test tool (no page object, no test-framework class), only a test method and its fixture, so nothing carries `@since` on any branch.
* No new module or `pom.xml` (no pom-version adaptation needed), and no Java-21-only API in the cherry-picked code.
* The `assertAccessTrue`/`assertAccessFalse` helpers the test relies on already exist on this branch.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

```
mvn -B -ntp test -Plegacy -Dtest=DefaultAuthorizationManagerIntegrationTest
```

in `xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api` on this branch — 18/18 green.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: n/a — this is the backport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
