### PR TITLE
XWIKI-24702: Create/check for automated tests for "Deny Edit Rights for an user"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
@@ -770,6 +770,35 @@ class DefaultAuthorizationManagerIntegrationTest extends AbstractAuthorizationTe
     }
 
     /**
+     * Check that denying the edit right to a user on a document, typically from the page administration, takes that
+     * right away from that user on that document only, leaving the other rights of that user and the other users
+     * untouched.
+     */
+    @Test
+    void userDenyEditAtDocumentLevel() throws Exception
+    {
+        initialiseWikiMock("userDenyEditAtDocumentLevel");
+
+        // Without any rule, userA can edit the documents of the wiki.
+        assertAccessTrue("userA should have edit access on a document without rules", EDIT, getXUser("userA"),
+            getXDoc("any document", "space"));
+
+        // The document level deny takes the edit right away from userA on that document...
+        assertAccessFalse("userA should not have edit access on the document denying it", EDIT, getXUser("userA"),
+            getXDoc("docDenyEditToUserA", "space"));
+
+        // ...without touching its other rights.
+        assertAccessTrue("userA should have view access on the document denying it the edit right", VIEW,
+            getXUser("userA"), getXDoc("docDenyEditToUserA", "space"));
+        assertAccessTrue("userA should have comment access on the document denying it the edit right", COMMENT,
+            getXUser("userA"), getXDoc("docDenyEditToUserA", "space"));
+
+        // The deny only targets userA: userB keeps the edit right on that document.
+        assertAccessTrue("userB should have edit access on the document denying the edit right to userA", EDIT,
+            getXUser("userB"), getXDoc("docDenyEditToUserA", "space"));
+    }
+
+    /**
      * Check that the rules set on a document, typically by its creator, cannot take a right away from a user having
      * the admin right at wiki level: the admin right implies the view right and, contrary to the view right itself, it
      * is not overridden by the rules defined at a lower level.

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/resources/testwikis/userDenyEditAtDocumentLevel.xml
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/resources/testwikis/userDenyEditAtDocumentLevel.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<!-- Used by DefaultAuthorizationManagerIntegrationTest#userDenyEditAtDocumentLevel() -->
+<wikis>
+  <wiki name="wiki" mainWiki="true" alt="Main Wiki without any rule">
+    <user name="userA" alt="the user the edit right is denied to on the document below" />
+    <user name="userB" alt="a user no rule is targeting" />
+
+    <space name="space" alt="a space without any rule">
+      <document name="any document" />
+
+      <document name="docDenyEditToUserA" alt="a document denying the edit right to userA">
+        <denyUser name="userA" type="edit" />
+      </document>
+    </space>
+  </wiki>
+</wikis>


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24702

# Changes

## Description

* Add `DefaultAuthorizationManagerIntegrationTest#userDenyEditAtDocumentLevel` and its `testwikis`
  fixture, automating the [Deny Edit Rights For An User](https://test.xwiki.org/xwiki/bin/view/Security%20Tests/Deny%20Edit%20Rights%20For%20An%20User)
  manual test: denying the edit right to a user on a document takes that right away from that user
  on that document only, leaving its other rights and the other users untouched.

## Clarifications

* No existing test covered this. The closest one, `groupAccess()`, denies **all** rights to a group
  at document level (`docDenyGroupA`), which never isolates the edit right and asserts nothing about
  the users the rule is not targeting. `allowGroupRightsAtPageLevelWhenUserRightDeniedAtWikiLevel`
  in `UsersGroupsRightsManagementIT` denies the edit right at *wiki* level, not at page level.
* The test is written at the `AuthorizationManager` level rather than as a functional test, like the
  one added for XWIKI-24701, so that the three assertions the manual test implies but doesn't state
  (the right is gone, the other rights survive, the other users are unaffected) are all covered at a
  cost of a few milliseconds.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

```
mvn test -Pquality -Dtest=DefaultAuthorizationManagerIntegrationTest
mvn clean install -Pquality
```
in `xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api`.
Both green. The module JaCoCo instruction ratio is unchanged (0.7669 with and without this change),
so `xwiki.jacoco.instructionRatio` stays at 0.76.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * stable-18.4.x
  * stable-17.10.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)
