### PR TITLE
XWIKI-24703: Create/check for automated tests for "Deny Edit Rights for a group"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
@@ -906,6 +906,35 @@ class DefaultAuthorizationManagerIntegrationTest extends AbstractAuthorizationTe
         assertNotNull(securityCache.get(userA));
     }
 
+    /**
+     * Check that denying the edit right to a group on a document, typically from the page administration, takes that
+     * right away from the members of that group on that document only, leaving their other rights and the users which
+     * are not members of that group untouched.
+     */
+    @Test
+    void groupDenyEditAtDocumentLevel() throws Exception
+    {
+        initialiseWikiMock("groupDenyEditAtDocumentLevel");
+
+        // Without any rule, userA, a member of groupA, can edit the documents of the wiki.
+        assertAccessTrue("userA should have edit access on a document without rules", EDIT, getXUser("userA"),
+            getXDoc("any document", "space"));
+
+        // The document level deny takes the edit right away from userA, as a member of groupA, on that document...
+        assertAccessFalse("userA should not have edit access on the document denying it to its group", EDIT,
+            getXUser("userA"), getXDoc("docDenyEditToGroupA", "space"));
+
+        // ...without touching its other rights.
+        assertAccessTrue("userA should have view access on the document denying its group the edit right", VIEW,
+            getXUser("userA"), getXDoc("docDenyEditToGroupA", "space"));
+        assertAccessTrue("userA should have comment access on the document denying its group the edit right", COMMENT,
+            getXUser("userA"), getXDoc("docDenyEditToGroupA", "space"));
+
+        // The deny only targets the members of groupA: userB keeps the edit right on that document.
+        assertAccessTrue("userB should have edit access on the document denying the edit right to groupA", EDIT,
+            getXUser("userB"), getXDoc("docDenyEditToGroupA", "space"));
+    }
+
     @Test
     void checkAccess() throws Exception
     {

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/resources/testwikis/groupDenyEditAtDocumentLevel.xml
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/resources/testwikis/groupDenyEditAtDocumentLevel.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<!-- Used by DefaultAuthorizationManagerIntegrationTest#groupDenyEditAtDocumentLevel() -->
+<wikis>
+  <wiki name="wiki" mainWiki="true" alt="Main Wiki without any rule">
+    <user name="userA" alt="a member of groupA" />
+    <user name="userB" alt="a user which is not a member of groupA" />
+    <group name="groupA">
+      <user name="userA" />
+    </group>
+
+    <space name="space" alt="a space without any rule">
+      <document name="any document" />
+
+      <document name="docDenyEditToGroupA" alt="a document denying the edit right to groupA">
+        <denyGroup name="groupA" type="edit" />
+      </document>
+    </space>
+  </wiki>
+</wikis>


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24703

# Changes

## Description

* Add `DefaultAuthorizationManagerIntegrationTest#groupDenyEditAtDocumentLevel` and its `testwikis`
  fixture, automating the [Deny Edit Rights For A Group](https://test.xwiki.org/xwiki/bin/view/Security%20Tests/Deny%20Edit%20Rights%20For%20A%20Group)
  manual test: denying the edit right to a group on a document takes that right away from the
  members of that group on that document only, leaving their other rights and the users which are
  not members of that group untouched.

## Clarifications

* The closest existing test, `groupAccess()`, denies **all** rights to a group at document level
  (`docDenyGroupA`), so the edit right is only covered incidentally: nothing isolates it and nothing
  asserts that a user outside the group keeps it.
* The test is written at the `AuthorizationManager` level rather than as a functional test, like the
  one added for XWIKI-24701, so that the three assertions the manual test implies but doesn't state
  (the right is gone, the other rights survive, the non members are unaffected) are all covered at a
  cost of a few milliseconds.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

```
mvn test -Pquality -Dtest=DefaultAuthorizationManagerIntegrationTest
mvn clean install -Pquality
```
in `xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api`.
Both green. The module JaCoCo instruction ratio is unchanged (0.7669 with and without this change),
so `xwiki.jacoco.instructionRatio` stays at 0.76.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * stable-18.4.x
  * stable-17.10.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)
