### PR TITLE
XWIKI-24704: Create/check for automated tests for "Deny Comment Rights for an user"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
@@ -813,6 +813,35 @@ class DefaultAuthorizationManagerIntegrationTest extends AbstractAuthorizationTe
             getXDoc("userBdoc", "space"));
     }
 
+    /**
+     * Check that denying the comment right to a user on a document, typically from the page administration, takes that
+     * right away from that user on that document only, leaving the other rights of that user and the other users
+     * untouched. In particular, the edit right, which the user keeps, doesn't imply the comment right.
+     */
+    @Test
+    void userDenyCommentAtDocumentLevel() throws Exception
+    {
+        initialiseWikiMock("userDenyCommentAtDocumentLevel");
+
+        // Without any rule, userA can comment the documents of the wiki.
+        assertAccessTrue("userA should have comment access on a document without rules", COMMENT, getXUser("userA"),
+            getXDoc("any document", "space"));
+
+        // The document level deny takes the comment right away from userA on that document...
+        assertAccessFalse("userA should not have comment access on the document denying it", COMMENT,
+            getXUser("userA"), getXDoc("docDenyCommentToUserA", "space"));
+
+        // ...without touching its other rights, the edit right included.
+        assertAccessTrue("userA should have view access on the document denying it the comment right", VIEW,
+            getXUser("userA"), getXDoc("docDenyCommentToUserA", "space"));
+        assertAccessTrue("userA should have edit access on the document denying it the comment right", EDIT,
+            getXUser("userA"), getXDoc("docDenyCommentToUserA", "space"));
+
+        // The deny only targets userA: userB keeps the comment right on that document.
+        assertAccessTrue("userB should have comment access on the document denying the comment right to userA",
+            COMMENT, getXUser("userB"), getXDoc("docDenyCommentToUserA", "space"));
+    }
+
     @Test
     void ownerAccess() throws Exception
     {

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/resources/testwikis/userDenyCommentAtDocumentLevel.xml
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/resources/testwikis/userDenyCommentAtDocumentLevel.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<!-- Used by DefaultAuthorizationManagerIntegrationTest#userDenyCommentAtDocumentLevel() -->
+<wikis>
+  <wiki name="wiki" mainWiki="true" alt="Main Wiki without any rule">
+    <user name="userA" alt="the user the comment right is denied to on the document below" />
+    <user name="userB" alt="a user no rule is targeting" />
+
+    <space name="space" alt="a space without any rule">
+      <document name="any document" />
+
+      <document name="docDenyCommentToUserA" alt="a document denying the comment right to userA">
+        <denyUser name="userA" type="comment" />
+      </document>
+    </space>
+  </wiki>
+</wikis>


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24704

# Changes

## Description

* Add `DefaultAuthorizationManagerIntegrationTest#userDenyCommentAtDocumentLevel` and its
  `testwikis` fixture, automating the [Deny Comment Rights For An User](https://test.xwiki.org/xwiki/bin/view/Security%20Tests/Deny%20Comment%20Rights%20For%20An%20User)
  manual test: denying the comment right to a user on a document takes that right away from that
  user on that document only, leaving its other rights and the other users untouched.

## Clarifications

* Nothing covered the comment right at document level so far: no `testwikis` fixture had a
  document level rule targeting it.
* The test also pins that the edit right, which the user keeps, doesn't give the comment right back:
  `Right.EDIT` only implies `Right.VIEW`.
* The test is written at the `AuthorizationManager` level rather than as a functional test, like the
  one added for XWIKI-24701, so that the three assertions the manual test implies but doesn't state
  (the right is gone, the other rights survive, the other users are unaffected) are all covered at a
  cost of a few milliseconds.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

```
mvn test -Pquality -Dtest=DefaultAuthorizationManagerIntegrationTest
mvn clean install -Pquality
```
in `xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api`.
Both green. The module JaCoCo instruction ratio is unchanged (0.7669 with and without this change),
so `xwiki.jacoco.instructionRatio` stays at 0.76.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * stable-18.4.x
  * stable-17.10.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)
