### PR TITLE
XCOMMONS-3743: Upgrade to Apache Commons Collections 4.6.0

### DIFF
--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/RightSetTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/RightSetTest.java
@@ -20,13 +20,15 @@
 package org.xwiki.security.authorization;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Set;
 
-import org.apache.commons.collections4.set.AbstractSetTest;
+import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test Set interface of RightSet.
@@ -34,7 +36,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * @version $Id$
  * @since 4.0M2
  */
-class RightSetTest extends AbstractSetTest<Right>
+// AbstractCollectionTest rather than AbstractSetTest: the set-specific tests of the latter feed a String to the
+// collection under test, which a RightSet cannot hold, and they are package private and therefore not overridable from
+// here. The two checks they bring are reproduced below, over Right elements.
+class RightSetTest extends AbstractCollectionTest<Right>
 {
     @Override
     public RightSet makeObject()
@@ -43,13 +48,13 @@ class RightSetTest extends AbstractSetTest<Right>
     }
 
     @Override
-    public Set<Right> makeConfirmedCollection()
+    public Collection<Right> makeConfirmedCollection()
     {
         return new RightSet();
     }
 
     @Override
-    public Set<Right> makeConfirmedFullCollection()
+    public Collection<Right> makeConfirmedFullCollection()
     {
         return new RightSet(Arrays.asList(getFullElements()));
     }
@@ -78,26 +83,45 @@ class RightSetTest extends AbstractSetTest<Right>
         return false;
     }
 
-    // Methods we need to override because AbstractSetTest use Strings to validate the Set
+    @Override
+    public boolean isEqualsCheckable()
+    {
+        return true;
+    }
+
+    /**
+     * Adds to the collection level verifications the set specific ones: the two collections are equal, they have the
+     * same hash code, and the iterator returns each element only once.
+     */
+    @Override
+    public void verify()
+    {
+        super.verify();
+
+        assertEquals(getConfirmed(), getCollection(), "Sets should be equal");
+        assertEquals(getConfirmed().hashCode(), getCollection().hashCode(), "Sets should have equal hashCodes");
+        Collection<Right> set = makeConfirmedCollection();
+        for (Right element : getCollection()) {
+            assertTrue(set.add(element), "Set.iterator should only return unique elements");
+        }
+    }
 
     /**
      * Tests {@link Set#equals(Object)}.
      */
     @Test
-    @Override
     // This method verifies the equals() contract itself, so the assertions deliberately call equals()
     // explicitly: the boolean form is what makes visible which set is the receiver and which argument it
     // gets. Using assertNotEquals() would move that into JUnit's internals and would invite a later
     // SonarQube S3415 "swap these arguments" change that silently stops testing the contract.
     @SuppressWarnings("java:S5785")
-    public void testSetEquals()
+    void setEquals()
     {
         resetEmpty();
         assertEquals(getCollection(), getConfirmed(), "Empty sets should be equal");
         verify();
 
-        final Set<Right> set2 = makeConfirmedCollection();
-        // CUSTOM: the standard #testSetEquals add a String here, which does not make any sense for RightSet
+        Collection<Right> set2 = makeConfirmedCollection();
         set2.add(Right.VIEW);
         assertFalse(getCollection().equals(set2), "Empty set shouldn't equal nonempty set");
 
@@ -108,5 +132,18 @@ class RightSetTest extends AbstractSetTest<Right>
         set2.clear();
         set2.addAll(Arrays.asList(getOtherElements()));
         assertFalse(getCollection().equals(set2), "Sets with different contents shouldn't be equal");
+    }
+
+    /**
+     * Tests {@link Set#hashCode()}.
+     */
+    @Test
+    void setHashCode()
+    {
+        resetEmpty();
+        assertEquals(getCollection().hashCode(), getConfirmed().hashCode(), "Empty sets have equal hashCodes");
+
+        resetFull();
+        assertEquals(getCollection().hashCode(), getConfirmed().hashCode(), "Equal sets have equal hashCodes");
     }
 }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XCOMMONS-3743

# Changes

## Description

* Fix the test compilation of `xwiki-platform-security-authorization-api`, which the Commons
  Collections 4.6.0 upgrade broke on `master`:

```
[ERROR] .../org/xwiki/security/authorization/RightSetTest.java:[87,5]
        method does not override or implement a method from a supertype
```

* In Commons Collections 4.5.0, `AbstractSetTest#testSetEquals()` was `public`. In 4.6.0 it became
  **package private** (as did `testSetHashCode()`, and the same treatment was applied to the JUnit 5
  test methods throughout the test-jar). `RightSetTest` lives in `org.xwiki.security.authorization`,
  not in `org.apache.commons.collections4.set`, so it can no longer override it.
* `RightSetTest` now extends `AbstractCollectionTest` instead of `AbstractSetTest`, and reproduces
  locally what the set level brought: the extra `verify()` assertions (equality, equal hash codes,
  iterator uniqueness) and the `setEquals` / `setHashCode` tests, written over `Right` elements.

## Clarifications

* **This PR is a proposal, not a decision** — @vmassol is opening it so the author of the upgrade
  can pick the option they prefer. Two simpler routes were tried and rejected:
  * *Just drop the `@Override`.* Compiles, but JUnit then runs the **parent's** `testSetEquals`,
    whose body does `set2.add((E) "foo")` →
    `ClassCastException: class java.lang.String cannot be cast to class org.xwiki.security.authorization.Right`.
    That inherited body is exactly why the override existed in the first place.
  * *Let `makeConfirmedCollection()` return the upstream default `HashSet`.* 14 tests then fail on
    "Sets should have equal hashCodes", because `RightSet#hashCode()` returns
    `Long.valueOf(rights).hashCode()` — a bitmask hash — rather than the sum of the element hash
    codes that the `Set#hashCode()` contract requires. Making `RightSet` contract-compliant would
    change production behaviour and deserves its own issue; it is deliberately **not** done here.
* `RightSetTest` is the only subclass of a Commons Collections `Abstract*Test` in all of
  xwiki-platform, so this is the full blast radius of the visibility change in this repo.
* The commit reuses the XCOMMONS-3743 summary line since this is fallout of that upgrade rather than
  a change with an issue of its own.

# Screenshots & Video

N/A — test-only change, no UI.

# Executed Tests

In `xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api`,
with Commons Collections 4.6.0 resolved (`mvn -U`):

```
mvn clean install -Pquality
```

Green: 128 tests, 0 failures, 0 errors, all coverage checks met. `RightSetTest` still runs 29 tests,
the same number as before the upgrade. The same command on `master` without this change fails to
compile the test sources.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None — `master` only, the upgrade is not on the stable branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
