### PR TITLE
[stable-17.10.x] XWIKI-24702: Create/check for automated tests for "Deny Edit Rights for an user" (#6168)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
@@ -771,6 +771,35 @@ class DefaultAuthorizationManagerIntegrationTest extends AbstractAuthorizationTe
     }
 
     /**
+     * Check that denying the edit right to a user on a document, typically from the page administration, takes that
+     * right away from that user on that document only, leaving the other rights of that user and the other users
+     * untouched.
+     */
+    @Test
+    void userDenyEditAtDocumentLevel() throws Exception
+    {
+        initialiseWikiMock("userDenyEditAtDocumentLevel");
+
+        // Without any rule, userA can edit the documents of the wiki.
+        assertAccessTrue("userA should have edit access on a document without rules", EDIT, getXUser("userA"),
+            getXDoc("any document", "space"));
+
+        // The document level deny takes the edit right away from userA on that document...
+        assertAccessFalse("userA should not have edit access on the document denying it", EDIT, getXUser("userA"),
+            getXDoc("docDenyEditToUserA", "space"));
+
+        // ...without touching its other rights.
+        assertAccessTrue("userA should have view access on the document denying it the edit right", VIEW,
+            getXUser("userA"), getXDoc("docDenyEditToUserA", "space"));
+        assertAccessTrue("userA should have comment access on the document denying it the edit right", COMMENT,
+            getXUser("userA"), getXDoc("docDenyEditToUserA", "space"));
+
+        // The deny only targets userA: userB keeps the edit right on that document.
+        assertAccessTrue("userB should have edit access on the document denying the edit right to userA", EDIT,
+            getXUser("userB"), getXDoc("docDenyEditToUserA", "space"));
+    }
+
+    /**
      * Check that the rules set on a document, typically by its creator, cannot take a right away from a user having
      * the admin right at wiki level: the admin right implies the view right and, contrary to the view right itself, it
      * is not overridden by the rules defined at a lower level.

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/resources/testwikis/userDenyEditAtDocumentLevel.xml
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/resources/testwikis/userDenyEditAtDocumentLevel.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<!-- Used by DefaultAuthorizationManagerIntegrationTest#userDenyEditAtDocumentLevel() -->
+<wikis>
+  <wiki name="wiki" mainWiki="true" alt="Main Wiki without any rule">
+    <user name="userA" alt="the user the edit right is denied to on the document below" />
+    <user name="userB" alt="a user no rule is targeting" />
+
+    <space name="space" alt="a space without any rule">
+      <document name="any document" />
+
+      <document name="docDenyEditToUserA" alt="a document denying the edit right to userA">
+        <denyUser name="userA" type="edit" />
+      </document>
+    </space>
+  </wiki>
+</wikis>


### PR DESCRIPTION
# Backport

This backports the following commit from `master` to `stable-17.10.x`:
 - [XWIKI-24702: Create/check for automated tests for "Deny Edit Rights for an user" (#6168)](https://github.com/xwiki/xwiki-platform/pull/6168)

Manual backport: the automated one failed with merge conflicts because the commit's diff context depends on `groupRightsAtSpaceLevelVersusUserDenyAtWikiLevel()`, added by XWIKI-24587 (46c1457a746), which had not been backported. XWIKI-24587 has now been applied to this branch, so `0b87cfd53df` cherry-picks cleanly here (same stat as the original: 2 files, 45 insertions).

# Executed Tests

```
mvn test -Dtest=DefaultAuthorizationManagerIntegrationTest
```
in `xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api`: 20 tests, all green (Checkstyle/license/enforcer enabled).