### PR TITLE
XWIKI-24710: Add script APIs to count distinct active installs globally and per extension

### DIFF
--- a/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/pom.xml
@@ -33,7 +33,7 @@
   <description>API to send XWiki instance ping data and query it</description>
   <properties>
     <!-- See the overridden value in the integration-tests profile -->
-    <xwiki.jacoco.instructionRatio>0.07</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.10</xwiki.jacoco.instructionRatio>
     <!-- Name to display by the Extension Manager -->
     <xwiki.extension.name>Active Installs 2 API</xwiki.extension.name>
     <!-- We want only a single ActiveInstalls extension on the root namespace (only a single ping thread per XWiki
@@ -99,7 +99,7 @@
         <!-- Functional tests are allowed to output content to the console -->
         <xwiki.surefire.captureconsole.skip>true</xwiki.surefire.captureconsole.skip>
         <!-- Overridden to include coverage from IT tests -->
-        <xwiki.jacoco.instructionRatio>0.90</xwiki.jacoco.instructionRatio>
+        <xwiki.jacoco.instructionRatio>0.91</xwiki.jacoco.instructionRatio>
       </properties>
       <build>
         <plugins>

--- a/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/DataManager.java
+++ b/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/DataManager.java
@@ -20,9 +20,11 @@
 package org.xwiki.activeinstalls2;
 
 import java.util.List;
+import java.util.SequencedMap;
 
 import org.xwiki.activeinstalls2.internal.data.Ping;
 import org.xwiki.component.annotation.Role;
+import org.xwiki.stability.Unstable;
 
 /**
  * Provides access to stored ping data.
@@ -39,7 +41,7 @@ public interface DataManager
      * @param jsonQuery the Elastic Search JSON query used to search for installs. For example:
      *        <pre>{@code
      *            {
-     *                "term": { "distributionVersion" : "5.2" }
+     *                "term": { "distribution.extension.version" : "5.2" }
      *            }
      *        }</pre>
      * @return the parsed JSON result coming from Elastic Search, as a list of {@link Ping} object. Passing an empty
@@ -50,7 +52,9 @@ public interface DataManager
     List<Ping> searchInstalls(String jsonQuery) throws Exception;
 
     /**
-     * Executes a Count query for Active Installs.
+     * Executes a Count query for Active Installs. Note that this counts matching pings and not matching instances,
+     * despite its name: an instance sends a ping every day but also every time it's restarted, and thus matches
+     * several pings. Use {@link #countDistinctInstalls(String)} to count instances.
      *
      * @param jsonQuery the Elastic Search JSON query used to search for installs. Passing an empty
      *      or null json string results in returning a count of all data in the index (i.e no query constraint)
@@ -59,4 +63,74 @@ public interface DataManager
      * @since 14.4RC1
      */
     long countInstalls(String jsonQuery) throws Exception;
+
+    /**
+     * Counts the distinct XWiki instances having sent a matching ping. Contrary to {@link #countInstalls(String)},
+     * which counts pings, this counts installs: an instance sends a ping every day but also every time it's
+     * restarted, and thus matches several pings.
+     *
+     * @param jsonQuery the Elastic Search JSON query used to search for installs. Note that counting over the whole
+     *      index counts every instance that ever pinged, so restricting to the instances that are actually active is
+     *      a matter of passing a query on the ping date. For example:
+     *        <pre>{@code
+     *            {
+     *                "range": { "date.current": { "gte": "now-1d" } }
+     *            }
+     *        }</pre>
+     *      Passing an empty or null json string results in counting the instances found in the whole index (i.e no
+     *      query constraint)
+     * @return the number of distinct instances. Implementations are allowed to return an approximation for large
+     *      counts, and document the count above which they do
+     * @throws Exception when an error happens while retrieving the data, or when the implementation doesn't support
+     *      counting distinct installs
+     * @since 18.8.0RC1
+     */
+    @Unstable
+    default long countDistinctInstalls(String jsonQuery) throws Exception
+    {
+        throw new Exception(String.format("[%s] doesn't support counting distinct installs",
+            getClass().getName()));
+    }
+
+    /**
+     * Counts, for each extension, the distinct XWiki instances having that extension installed and having sent a
+     * matching ping. This is computed with a single query, and is thus much cheaper than calling
+     * {@link #countDistinctInstalls(String)} once per extension.
+     * <p>
+     * The counts are keyed by the id under which each extension is installed, and are not resolved through the
+     * features an extension provides. Thus an extension that has been renamed, and whose former id is a feature of
+     * its new id, is reported as two separate entries.
+     * <p>
+     * Note that a query on the extensions themselves does not restrict the extensions being counted: a nested query
+     * selects the pings holding a matching extension, and every extension of those pings is then counted. So counting
+     * the instances of a single extension is a matter of reading its entry from the returned map, not of querying for
+     * it.
+     *
+     * @param jsonQuery the Elastic Search JSON query used to search for installs. Note that counting over the whole
+     *      index counts every instance that ever pinged, so restricting to the instances that are actually active is
+     *      a matter of passing a query on the ping date. For example:
+     *        <pre>{@code
+     *            {
+     *                "range": { "date.current": { "gte": "now-1d" } }
+     *            }
+     *        }</pre>
+     *      Passing an empty or null json string results in counting the instances found in the whole index (i.e no
+     *      query constraint)
+     * @return the number of distinct instances, keyed by extension id, ordered by descending number of matching
+     *      pings (which is close to, but not exactly, ordering by the returned counts). Implementations are allowed
+     *      to return an approximation for the extensions installed on a large number of instances, and document the
+     *      count above which they do
+     * @throws TooManyExtensionsException when there are more extensions than can be returned in a single query. Note
+     *      that this is a subclass of the {@link Exception} below, and is thus not listed separately in the throws
+     *      clause, where it would be redundant
+     * @throws Exception when an error happens while retrieving the data, or when the implementation doesn't support
+     *      counting distinct installs
+     * @since 18.8.0RC1
+     */
+    @Unstable
+    default SequencedMap<String, Long> countDistinctInstallsByExtension(String jsonQuery) throws Exception
+    {
+        throw new Exception(String.format("[%s] doesn't support counting distinct installs per extension",
+            getClass().getName()));
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/TooManyExtensionsException.java
+++ b/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/TooManyExtensionsException.java
@@ -1,0 +1,45 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.activeinstalls2;
+
+import org.xwiki.stability.Unstable;
+
+/**
+ * Raised when {@link DataManager#countDistinctInstallsByExtension(String)} finds more extensions than it can count at
+ * once. It is a distinct type so that a caller can tell that case apart from the generic {@link Exception} that a
+ * failure to reach the data raises.
+ *
+ * @version $Id$
+ * @since 18.8.0RC1
+ */
+@Unstable
+public class TooManyExtensionsException extends Exception
+{
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @param maxExtensionCountPerQuery the maximum number of extensions that can be counted at once
+     */
+    public TooManyExtensionsException(int maxExtensionCountPerQuery)
+    {
+        super(String.format("Found more extensions than the [%d] that can be counted at once.",
+            maxExtensionCountPerQuery));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/internal/DefaultDataManager.java
+++ b/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/internal/DefaultDataManager.java
@@ -19,18 +19,27 @@
  */
 package org.xwiki.activeinstalls2.internal;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.SequencedMap;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.apache.commons.lang3.StringUtils;
 import org.xwiki.activeinstalls2.DataManager;
+import org.xwiki.activeinstalls2.TooManyExtensionsException;
+import org.xwiki.activeinstalls2.internal.data.DistributionPingDataProvider;
+import org.xwiki.activeinstalls2.internal.data.ExtensionPingDataProvider;
 import org.xwiki.activeinstalls2.internal.data.Ping;
 import org.xwiki.component.annotation.Component;
 
+import co.elastic.clients.elasticsearch._types.aggregations.StringTermsAggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.CountRequest;
 import co.elastic.clients.elasticsearch.core.CountResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
@@ -47,22 +56,43 @@ import co.elastic.clients.elasticsearch.core.search.Hit;
 @Singleton
 public class DefaultDataManager implements DataManager
 {
+    /**
+     * The maximum number of extensions {@link #countDistinctInstallsByExtension(String)} reports, above which it
+     * raises a {@link TooManyExtensionsException} rather than under-reporting. Counting one extension costs 2
+     * Elasticsearch aggregation buckets, so this keeps a query well within Elasticsearch's own search.max_buckets
+     * (65536 by default).
+     */
+    static final int MAX_EXTENSION_COUNT_PER_QUERY = 10000;
+
+    /**
+     * The number of distinct instances up to which a count is exact, above which it becomes a HyperLogLog++ estimate.
+     * This is the highest precision threshold Elasticsearch supports, and the whole instance population is well
+     * below it, so the counts are exact in practice. HyperLogLog++ keeps its sparse representation until the observed
+     * count approaches the threshold, so the memory a count actually uses follows that count rather than this bound.
+     */
+    static final int PRECISION_THRESHOLD = 40000;
+
+    private static final String DISTINCT_INSTALLS_AGGREGATION = "distinctInstalls";
+
+    private static final String NESTED_EXTENSIONS_AGGREGATION = "nestedExtensions";
+
+    private static final String EXTENSION_IDS_AGGREGATION = "extensionIds";
+
+    private static final String ROOT_AGGREGATION = "root";
+
     @Inject
     private ElasticsearchClientManager clientManager;
 
     @Override
     public long countInstalls(String jsonQuery) throws Exception
     {
-        CountRequest request;
-        if (StringUtils.isEmpty(jsonQuery)) {
-            request = CountRequest.of(s -> s
-                .index(ElasticsearchClientManager.INDEX));
-        } else {
-            request = CountRequest.of(s -> s
-                .index(ElasticsearchClientManager.INDEX)
-                .query(b0 -> b0.wrapper(b1 -> b1
-                    .query(encodeJSON(jsonQuery)))));
-        }
+        CountRequest request = CountRequest.of(s -> {
+            s.index(ElasticsearchClientManager.INDEX);
+            if (!StringUtils.isEmpty(jsonQuery)) {
+                s.query(toQuery(jsonQuery));
+            }
+            return s;
+        });
         CountResponse count = this.clientManager.getClient().count(request);
         return count.count();
     }
@@ -70,16 +100,10 @@ public class DefaultDataManager implements DataManager
     @Override
     public List<Ping> searchInstalls(String jsonQuery) throws Exception
     {
-        SearchRequest request;
-        if (StringUtils.isEmpty(jsonQuery)) {
-            request = SearchRequest.of(s -> s
-                .index(ElasticsearchClientManager.INDEX));
-        } else {
-            request = SearchRequest.of(s -> s
-                .index(ElasticsearchClientManager.INDEX)
-                .query(b0 -> b0.wrapper(b1 -> b1
-                    .query(encodeJSON(jsonQuery)))));
-        }
+        SearchRequest request = SearchRequest.of(s -> {
+            s.index(ElasticsearchClientManager.INDEX);
+            return applyQuery(s, jsonQuery);
+        });
         SearchResponse<Ping> search = this.clientManager.getClient().search(request, Ping.class);
 
         List<Ping> results = new ArrayList<>();
@@ -91,8 +115,98 @@ public class DefaultDataManager implements DataManager
         return results;
     }
 
+    @Override
+    public long countDistinctInstalls(String jsonQuery) throws Exception
+    {
+        SearchRequest request = SearchRequest.of(s -> {
+            s.index(ElasticsearchClientManager.INDEX)
+                // Only the aggregation result is needed, so don't pay for fetching any hit.
+                .size(0)
+                .aggregations(DISTINCT_INSTALLS_AGGREGATION, b0 -> b0
+                    .cardinality(b1 -> b1
+                        .field(DistributionPingDataProvider.FIELD_INSTANCE_ID)
+                        .precisionThreshold(PRECISION_THRESHOLD)));
+            return applyQuery(s, jsonQuery);
+        });
+        SearchResponse<Ping> search = this.clientManager.getClient().search(request, Ping.class);
+
+        return search.aggregations().get(DISTINCT_INSTALLS_AGGREGATION).cardinality().value();
+    }
+
+    @Override
+    public SequencedMap<String, Long> countDistinctInstallsByExtension(String jsonQuery) throws Exception
+    {
+        // Ask the terms aggregation for one extension more than can be reported, so that getting that extra one back
+        // is what tells that there are more extensions than the maximum. This is exact whatever the number of shards
+        // of the index: when the index holds no more extensions than the maximum, every shard holds fewer of them
+        // than the shard_size Elasticsearch derives from the requested size, and thus reports all of the ones it
+        // holds, so nothing can be missing from the merged result.
+        int requestedExtensionCount = MAX_EXTENSION_COUNT_PER_QUERY + 1;
+        SearchRequest request = SearchRequest.of(s -> {
+            s.index(ElasticsearchClientManager.INDEX)
+                .size(0)
+                .aggregations(NESTED_EXTENSIONS_AGGREGATION, b0 -> b0
+                    .nested(b1 -> b1.path(ExtensionPingDataProvider.PROPERTY_EXTENSIONS))
+                    .aggregations(EXTENSION_IDS_AGGREGATION, b1 -> b1
+                        .terms(b2 -> b2
+                            .field(ExtensionPingDataProvider.FIELD_EXTENSION_ID)
+                            .size(requestedExtensionCount))
+                        // The instance id is on the root document and not on the nested extension, so step back out
+                        // of the nested context before counting the distinct instances.
+                        .aggregations(ROOT_AGGREGATION, b2 -> b2
+                            .reverseNested(b3 -> b3)
+                            .aggregations(DISTINCT_INSTALLS_AGGREGATION, b3 -> b3
+                                .cardinality(b4 -> b4
+                                    .field(DistributionPingDataProvider.FIELD_INSTANCE_ID)
+                                    .precisionThreshold(PRECISION_THRESHOLD))))));
+            return applyQuery(s, jsonQuery);
+        });
+        SearchResponse<Ping> search = this.clientManager.getClient().search(request, Ping.class);
+
+        StringTermsAggregate extensionIds = search.aggregations().get(NESTED_EXTENSIONS_AGGREGATION).nested()
+            .aggregations().get(EXTENSION_IDS_AGGREGATION).sterms();
+        List<StringTermsBucket> buckets = extensionIds.buckets().array();
+        // Report the failure rather than only some of the extensions, which the caller has no way of telling apart
+        // from a complete answer.
+        if (buckets.size() > MAX_EXTENSION_COUNT_PER_QUERY) {
+            throw new TooManyExtensionsException(MAX_EXTENSION_COUNT_PER_QUERY);
+        }
+
+        // The terms aggregation returns its buckets ordered by descending number of matching pings, so use a map
+        // preserving that order rather than losing it. Note that this is not exactly the order of the counts below,
+        // since a ping count is not a distinct instance count.
+        SequencedMap<String, Long> counts = new LinkedHashMap<>();
+        for (StringTermsBucket bucket : buckets) {
+            counts.put(bucket.key().stringValue(), bucket.aggregations().get(ROOT_AGGREGATION).reverseNested()
+                .aggregations().get(DISTINCT_INSTALLS_AGGREGATION).cardinality().value());
+        }
+        return counts;
+    }
+
+    /**
+     * Restricts a search to the pings matching the passed query. Note that the query is the only part of the request
+     * the caller controls: it cannot alter the aggregations computed on top of it.
+     */
+    private SearchRequest.Builder applyQuery(SearchRequest.Builder builder, String jsonQuery)
+    {
+        if (StringUtils.isEmpty(jsonQuery)) {
+            return builder;
+        }
+        return builder.query(toQuery(jsonQuery));
+    }
+
+    /**
+     * Wraps a caller-provided JSON query into an Elasticsearch query. The JSON is base64-encoded whole into a
+     * {@code wrapper} query rather than concatenated into a larger document, so that it cannot escape the slot it is
+     * given and reshape the rest of the request.
+     */
+    private Query toQuery(String jsonQuery)
+    {
+        return Query.of(b0 -> b0.wrapper(b1 -> b1.query(encodeJSON(jsonQuery))));
+    }
+
     private String encodeJSON(String json)
     {
-        return Base64.getEncoder().encodeToString(json.getBytes());
+        return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/internal/data/DatePingDataProvider.java
+++ b/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/internal/data/DatePingDataProvider.java
@@ -131,7 +131,7 @@ public class DatePingDataProvider extends AbstractPingDataProvider
                 .index(ElasticsearchClientManager.INDEX)
                 .query(q -> q
                     .term(t -> t
-                        .field(getDistributionKey(DistributionPingDataProvider.PROPERTY_INSTANCE_ID))
+                        .field(DistributionPingDataProvider.FIELD_INSTANCE_ID)
                         .value(v -> v.stringValue(this.instanceIdManager.getInstanceId().toString()))
                     ))
                 .aggregations(getDateKey(PROPERTY_SERVER_TIME), a1 -> a1
@@ -172,11 +172,6 @@ public class DatePingDataProvider extends AbstractPingDataProvider
     private String getDateKey(String suffix)
     {
         return getKey(PROPERTY_DATE, suffix);
-    }
-
-    private String getDistributionKey(String suffix)
-    {
-        return getKey(DistributionPingDataProvider.PROPERTY_DISTRIBUTION, suffix);
     }
 
     private String getKey(String prefix, String suffix)

--- a/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/internal/data/DistributionPingDataProvider.java
+++ b/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/internal/data/DistributionPingDataProvider.java
@@ -49,9 +49,23 @@ import co.elastic.clients.elasticsearch._types.mapping.Property;
 @Singleton
 public class DistributionPingDataProvider extends AbstractPingDataProvider
 {
-    static final String PROPERTY_INSTANCE_ID = "instanceId";
+    /**
+     * The name of the mapping property holding the distribution data, and thus the first segment of the paths of the
+     * fields nested under it.
+     */
+    public static final String PROPERTY_DISTRIBUTION = "distribution";
 
-    static final String PROPERTY_DISTRIBUTION = "distribution";
+    /**
+     * The name of the mapping property holding the id uniquely identifying an XWiki instance across its pings.
+     */
+    public static final String PROPERTY_INSTANCE_ID = "instanceId";
+
+    /**
+     * The path of the field holding the id uniquely identifying an XWiki instance across its pings, to be used when
+     * querying the index. Assembled from the mapping property names above so that it cannot drift from the mapping
+     * declared in {@link #provideMapping()}.
+     */
+    public static final String FIELD_INSTANCE_ID = PROPERTY_DISTRIBUTION + "." + PROPERTY_INSTANCE_ID;
 
     private static final String PROPERTY_DISTRIBUTION_VERSION = "version";
 

--- a/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/internal/data/ExtensionPingDataProvider.java
+++ b/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/internal/data/ExtensionPingDataProvider.java
@@ -47,13 +47,29 @@ import co.elastic.clients.elasticsearch._types.mapping.Property;
 @Singleton
 public class ExtensionPingDataProvider extends AbstractPingDataProvider
 {
-    private static final String PROPERTY_ID = "id";
+    /**
+     * The name of the mapping property holding the installed extensions, mapped as a nested type so that each
+     * entry's id, version and features stay indexed together. Being a root property, this is also the path of the
+     * field to be used when querying the index, for example as the path of a nested aggregation.
+     */
+    public static final String PROPERTY_EXTENSIONS = "extensions";
+
+    /**
+     * The name of the mapping property holding an extension's id, and thus the last segment of
+     * {@link #FIELD_EXTENSION_ID}.
+     */
+    public static final String PROPERTY_ID = "id";
+
+    /**
+     * The path of the field holding an extension's id, to be used when querying the index, for example to group the
+     * pings per extension. Assembled from the mapping property names above so that it cannot drift from the mapping
+     * declared in {@link #provideMapping()}.
+     */
+    public static final String FIELD_EXTENSION_ID = PROPERTY_EXTENSIONS + "." + PROPERTY_ID;
 
     private static final String PROPERTY_VERSION = "version";
 
     private static final String PROPERTY_FEATURES = "features";
-
-    private static final String PROPERTY_EXTENSIONS = "extensions";
 
     @Inject
     private InstalledExtensionRepository extensionRepository;

--- a/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/script/ActiveInstallsScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/script/ActiveInstallsScriptService.java
@@ -20,15 +20,18 @@
 package org.xwiki.activeinstalls2.script;
 
 import java.util.List;
+import java.util.SequencedMap;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.xwiki.activeinstalls2.DataManager;
+import org.xwiki.activeinstalls2.TooManyExtensionsException;
 import org.xwiki.activeinstalls2.internal.data.Ping;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.script.service.ScriptService;
+import org.xwiki.stability.Unstable;
 
 /**
  * Provides Scripting APIs for the Active Installs module.
@@ -48,7 +51,9 @@ public class ActiveInstallsScriptService implements ScriptService
     private DataManager dataManager;
 
     /**
-     * Executes a Count query for Active Installs.
+     * Executes a Count query for Active Installs. Note that this counts matching pings and not matching instances,
+     * despite its name: an instance sends a ping every day but also every time it's restarted, and thus matches
+     * several pings. Use {@link #countDistinctInstalls(String)} to count instances.
      *
      * @param jsonQuery the Elastic Search JSON query used to search for installs.
      * @return the count number
@@ -66,7 +71,7 @@ public class ActiveInstallsScriptService implements ScriptService
      * @param jsonQuery the Elastic Search JSON query used to search for installs. For example:
      *        <pre>{@code
      *            {
-     *                "term": { "distributionVersion" : "5.2" }
+     *                "term": { "distribution.extension.version" : "5.2" }
      *            }
      *        }</pre>
      * @return the parsed JSON result coming from Elastic Search, as a list of {@link Ping} object.
@@ -76,5 +81,53 @@ public class ActiveInstallsScriptService implements ScriptService
     public List<Ping> searchInstalls(String jsonQuery) throws Exception
     {
         return this.dataManager.searchInstalls(jsonQuery);
+    }
+
+    /**
+     * Counts the distinct XWiki instances having sent a matching ping. Contrary to {@link #countInstalls(String)},
+     * which counts pings, this counts installs: an instance sends a ping every day but also every time it's
+     * restarted, and thus matches several pings. For example:
+     * <pre>{@code
+     *     {
+     *         "range": { "date.current": { "gte": "now-1d" } }
+     *     }
+     * }</pre>
+     *
+     * @param jsonQuery the Elastic Search JSON query used to search for installs
+     * @return the number of distinct instances. With the default implementation, this is expected to be accurate up
+     *      to 40000 distinct instances, and an approximation above that
+     * @throws Exception when an error happens while retrieving the data
+     * @see DataManager#countDistinctInstalls(String)
+     * @since 18.8.0RC1
+     */
+    @Unstable
+    public long countDistinctInstalls(String jsonQuery) throws Exception
+    {
+        return this.dataManager.countDistinctInstalls(jsonQuery);
+    }
+
+    /**
+     * Counts, for each extension, the distinct XWiki instances having that extension installed and having sent a
+     * matching ping. This is computed with a single query, and is thus much cheaper than calling
+     * {@link #countDistinctInstalls(String)} once per extension. See
+     * {@link DataManager#countDistinctInstallsByExtension(String)} for how the counts are keyed and for why a query
+     * on the extensions doesn't restrict the extensions being counted.
+     *
+     * @param jsonQuery the Elastic Search JSON query used to search for installs
+     * @return the number of distinct instances, keyed by extension id, ordered by descending number of matching
+     *      pings (which is close to, but not exactly, ordering by the returned counts). With the default
+     *      implementation, each count is expected to be accurate up to 40000 distinct instances, and an
+     *      approximation above that
+     * @throws TooManyExtensionsException when there are more extensions than can be returned in a single query. Note
+     *      that this is a subclass of the {@link Exception} below, and is thus not listed separately in the throws
+     *      clause, where it would be redundant
+     * @throws Exception when an error happens while retrieving the data
+     * @see DataManager#countDistinctInstallsByExtension(String)
+     * @since 18.8.0RC1
+     */
+    @Unstable
+    public SequencedMap<String, Long> countDistinctInstallsByExtension(String jsonQuery) throws Exception
+    {
+        return this.dataManager.countDistinctInstallsByExtension(jsonQuery);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/test/it/org/xwiki/activeinstalls2/internal/PingSenderIT.java
+++ b/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/test/it/org/xwiki/activeinstalls2/internal/PingSenderIT.java
@@ -23,11 +23,14 @@ import java.sql.DatabaseMetaData;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.SequencedMap;
 import java.util.UUID;
 
 import javax.inject.Inject;
 import javax.servlet.ServletContext;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
@@ -91,6 +94,10 @@ import static org.mockito.Mockito.when;
 })
 class PingSenderIT
 {
+    private static final String EXTENSION_ID1 = "extensionId1";
+
+    private static final String EXTENSION_ID2 = "extensionId2";
+
     @InjectComponentManager
     private MockitoComponentManager componentManager;
 
@@ -133,6 +140,12 @@ class PingSenderIT
     @InjectElasticSearchContainer
     private ElasticsearchContainer container;
 
+    private String activeInstanceId;
+
+    private InstalledExtension extension1;
+
+    private InstalledExtension extension2;
+
     @BeforeComponent
     void beforeComponentInitialize()
     {
@@ -142,15 +155,15 @@ class PingSenderIT
             String.format("http://%s", this.container.getHttpHostAddress()));
     }
 
-    @Test
-    void sendPingData() throws Exception
+    @BeforeEach
+    void setUp() throws Exception
     {
         // Configure the Ping Sender to perform the ES setup since the ES instance is virgin at this stage.
         this.pingSetup.setup();
 
         // Distribution Ping Data Provider setup
-        String activeInstanceId = UUID.randomUUID().toString();
-        when(this.instanceIdManager.getInstanceId()).thenReturn(new InstanceId(activeInstanceId));
+        this.activeInstanceId = UUID.randomUUID().toString();
+        when(this.instanceIdManager.getInstanceId()).thenReturn(new InstanceId(this.activeInstanceId));
 
         // Servlet Container Ping Data Provider setup
         ServletContext servletContext = mock(ServletContext.class);
@@ -181,13 +194,15 @@ class PingSenderIT
         ec.setProperty(XWikiContext.EXECUTIONCONTEXT_KEY, xcontext);
 
         // Extension Ping Data Provider setup
-        InstalledExtension extension1 = mock(InstalledExtension.class);
-        when(extension1.getId()).thenReturn(new ExtensionId("extensionId1", "extensionVersion1"));
-        when(extension1.getExtensionFeatures()).thenReturn(List.of(new ExtensionId("featureId1", "featureVersion1")));
-        InstalledExtension extension2 = mock(InstalledExtension.class);
-        when(extension2.getId()).thenReturn(new ExtensionId("extensionId2", "extensionVersion2"));
-        when(extension2.getExtensionFeatures()).thenReturn(List.of(new ExtensionId("featureId2", "featureVersion2")));
-        Collection<InstalledExtension> installedExtensions = List.of(extension1, extension2);
+        this.extension1 = mock(InstalledExtension.class);
+        when(this.extension1.getId()).thenReturn(new ExtensionId(EXTENSION_ID1, "extensionVersion1"));
+        when(this.extension1.getExtensionFeatures())
+            .thenReturn(List.of(new ExtensionId("featureId1", "featureVersion1")));
+        this.extension2 = mock(InstalledExtension.class);
+        when(this.extension2.getId()).thenReturn(new ExtensionId(EXTENSION_ID2, "extensionVersion2"));
+        when(this.extension2.getExtensionFeatures())
+            .thenReturn(List.of(new ExtensionId("featureId2", "featureVersion2")));
+        Collection<InstalledExtension> installedExtensions = List.of(this.extension1, this.extension2);
         when(this.installedExtensionRepository.getInstalledExtensions()).thenReturn(installedExtensions);
 
         // Users Ping Data Provider setup (and Wikis Ping Data Provider)
@@ -217,7 +232,11 @@ class PingSenderIT
             .thenReturn(List.of(10000L))
             // For wiki2
             .thenReturn(List.of(100000L));
+    }
 
+    @Test
+    void sendPingData() throws Exception
+    {
         // Send a ping
         this.pingSender.sendPing();
 
@@ -240,7 +259,7 @@ class PingSenderIT
         assertEquals(2, this.dataManager.countInstalls(null));
 
         // Verify that a count query works with an non-empty json
-        String jsonString = "{ \"term\" : { \"distribution.instanceId\" : \"" + activeInstanceId + "\" } }";
+        String jsonString = "{ \"term\" : { \"distribution.instanceId\" : \"" + this.activeInstanceId + "\" } }";
         assertEquals(2, this.dataManager.countInstalls(jsonString));
 
         // Verify that a search query works with an empty json
@@ -250,6 +269,8 @@ class PingSenderIT
         // Verify that a search query works with an non-empty json
         pings = this.dataManager.searchInstalls(jsonString);
         assertEquals(2, pings.size());
+
+        assertDistinctInstallCountsForASingleInstance(jsonString);
 
         Ping ping = pings.get(0);
 
@@ -280,7 +301,7 @@ class PingSenderIT
         assertEquals(0, ping.getDate().getSince());
 
         // Distribution Ping Data Provider tests
-        assertEquals(activeInstanceId, ping.getDistribution().getInstanceId());
+        assertEquals(this.activeInstanceId, ping.getDistribution().getInstanceId());
         assertEquals("distributionId", ping.getDistribution().getExtension().getId());
         assertEquals("distributionVersion", ping.getDistribution().getExtension().getVersion());
         assertEquals(1, ping.getDistribution().getExtension().getFeatures().size());
@@ -320,5 +341,52 @@ class PingSenderIT
         assertEquals(2, ping.getDocuments().getWikis().size());
         assertEquals(1000, ping.getDocuments().getWikis().get(0));
         assertEquals(100000, ping.getDocuments().getWikis().get(1));
+
+        assertDistinctInstallCountsForASecondInstance();
+    }
+
+    private void assertDistinctInstallCountsForASecondInstance() throws Exception
+    {
+        // Send a third ping, from a second instance having only the second extension installed. The two extensions
+        // then differ both in the number of pings holding them (2 for the first one, 3 for the second) and in the
+        // number of instances having them installed (1 and 2), which is what the assertions below need. This
+        // invalidates the single-instance fixture the phases above rely on, so it comes last.
+        when(this.instanceIdManager.getInstanceId()).thenReturn(new InstanceId(UUID.randomUUID().toString()));
+        when(this.installedExtensionRepository.getInstalledExtensions()).thenReturn(List.of(this.extension2));
+        this.pingSender.sendPing();
+        this.clientManager.getClient().indices().refresh();
+
+        // Verify that the second instance is counted as a separate install, and that this is precisely what
+        // countInstalls() fails to report since it counts pings.
+        assertEquals(3, this.dataManager.countInstalls(null));
+        assertEquals(2, this.dataManager.countDistinctInstalls(null));
+
+        // Verify that only the instances having an extension installed are counted for it, and that the entries come
+        // back ordered by descending number of matching pings rather than in a hash order. Note that this is not the
+        // order of the counts: the two would differ if the first extension had been installed on more instances that
+        // ping less often.
+        SequencedMap<String, Long> countsByExtension = this.dataManager.countDistinctInstallsByExtension(null);
+        assertEquals(Map.of(EXTENSION_ID1, 1L, EXTENSION_ID2, 2L), countsByExtension);
+        assertEquals(List.of(EXTENSION_ID2, EXTENSION_ID1), List.copyOf(countsByExtension.sequencedKeySet()));
+    }
+
+    private void assertDistinctInstallCountsForASingleInstance(String jsonString) throws Exception
+    {
+        // Verify that the 2 pings sent so far are counted as a single install since they come from the same instance,
+        // with and without a query.
+        assertEquals(1, this.dataManager.countDistinctInstalls(null));
+        assertEquals(1, this.dataManager.countDistinctInstalls(jsonString));
+
+        // Verify that the distinct installs are also counted per extension, and that an extension is not counted
+        // twice when the same instance pings several times.
+        assertEquals(Map.of(EXTENSION_ID1, 1L, EXTENSION_ID2, 1L),
+            this.dataManager.countDistinctInstallsByExtension(null));
+        assertEquals(Map.of(EXTENSION_ID1, 1L, EXTENSION_ID2, 1L),
+            this.dataManager.countDistinctInstallsByExtension(jsonString));
+
+        // Verify that a query not matching any ping leads to no count at all.
+        String noMatchJsonString = "{ \"term\" : { \"distribution.instanceId\" : \"nomatch\" } }";
+        assertEquals(0, this.dataManager.countDistinctInstalls(noMatchJsonString));
+        assertEquals(Map.of(), this.dataManager.countDistinctInstallsByExtension(noMatchJsonString));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/test/java/org/xwiki/activeinstalls2/DataManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/test/java/org/xwiki/activeinstalls2/DataManagerTest.java
@@ -1,0 +1,76 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.activeinstalls2;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.activeinstalls2.internal.data.Ping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for the default methods of {@link DataManager}, which are what an implementation not supporting the
+ * distinct counts inherits.
+ *
+ * @version $Id$
+ */
+class DataManagerTest
+{
+    /**
+     * A {@link DataManager} implementing only the methods that have no default implementation.
+     */
+    private static class MinimalDataManager implements DataManager
+    {
+        @Override
+        public List<Ping> searchInstalls(String jsonQuery)
+        {
+            return List.of();
+        }
+
+        @Override
+        public long countInstalls(String jsonQuery)
+        {
+            return 0;
+        }
+    }
+
+    private final DataManager dataManager = new MinimalDataManager();
+
+    @Test
+    void countDistinctInstalls()
+    {
+        Exception exception = assertThrows(Exception.class, () -> this.dataManager.countDistinctInstalls(null));
+
+        assertEquals(String.format("[%s] doesn't support counting distinct installs",
+            MinimalDataManager.class.getName()), exception.getMessage());
+    }
+
+    @Test
+    void countDistinctInstallsByExtension()
+    {
+        Exception exception =
+            assertThrows(Exception.class, () -> this.dataManager.countDistinctInstallsByExtension(null));
+
+        assertEquals(String.format("[%s] doesn't support counting distinct installs per extension",
+            MinimalDataManager.class.getName()), exception.getMessage());
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/test/java/org/xwiki/activeinstalls2/script/ActiveInstallsScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/test/java/org/xwiki/activeinstalls2/script/ActiveInstallsScriptServiceTest.java
@@ -1,0 +1,113 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.activeinstalls2.script;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SequencedMap;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.activeinstalls2.DataManager;
+import org.xwiki.activeinstalls2.TooManyExtensionsException;
+import org.xwiki.activeinstalls2.internal.data.Ping;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ActiveInstallsScriptService}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+class ActiveInstallsScriptServiceTest
+{
+    private static final String QUERY = "{ \"term\" : { \"distribution.instanceId\" : \"id\" } }";
+
+    @InjectMockComponents
+    private ActiveInstallsScriptService scriptService;
+
+    @MockComponent
+    private DataManager dataManager;
+
+    @Test
+    void countInstalls() throws Exception
+    {
+        when(this.dataManager.countInstalls(QUERY)).thenReturn(42L);
+
+        assertEquals(42L, this.scriptService.countInstalls(QUERY));
+    }
+
+    @Test
+    void searchInstalls() throws Exception
+    {
+        List<Ping> pings = List.of(new Ping());
+        when(this.dataManager.searchInstalls(QUERY)).thenReturn(pings);
+
+        assertSame(pings, this.scriptService.searchInstalls(QUERY));
+    }
+
+    @Test
+    void countDistinctInstalls() throws Exception
+    {
+        when(this.dataManager.countDistinctInstalls(QUERY)).thenReturn(7L);
+
+        assertEquals(7L, this.scriptService.countDistinctInstalls(QUERY));
+    }
+
+    @Test
+    void countDistinctInstallsByExtension() throws Exception
+    {
+        SequencedMap<String, Long> counts = new LinkedHashMap<>(Map.of("extensionId", 3L));
+        when(this.dataManager.countDistinctInstallsByExtension(QUERY)).thenReturn(counts);
+
+        assertSame(counts, this.scriptService.countDistinctInstallsByExtension(QUERY));
+    }
+
+    @Test
+    void countDistinctInstallsWhenError() throws Exception
+    {
+        when(this.dataManager.countDistinctInstalls(QUERY)).thenThrow(new Exception("error"));
+
+        Exception exception = assertThrows(Exception.class, () -> this.scriptService.countDistinctInstalls(QUERY));
+
+        assertEquals("error", exception.getMessage());
+    }
+
+    @Test
+    void countDistinctInstallsByExtensionWhenTooManyExtensions() throws Exception
+    {
+        when(this.dataManager.countDistinctInstallsByExtension(QUERY))
+            .thenThrow(new TooManyExtensionsException(42));
+
+        // Verify that the typed exception reaches the caller as is, so that it can tell that case apart from a
+        // failure to reach the data.
+        TooManyExtensionsException exception = assertThrows(TooManyExtensionsException.class,
+            () -> this.scriptService.countDistinctInstallsByExtension(QUERY));
+
+        assertEquals("Found more extensions than the [42] that can be counted at once.", exception.getMessage());
+    }
+}


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-24710

## Problem

`services.activeinstalls2` cannot produce the number Active Installs exists to provide: how many distinct XWiki instances are running.

* `countInstalls()` returns a *document* count, i.e. a number of pings. An instance pings once a day but also on every restart, so the value is inflated. Measured on extensions.xwiki.org over one day, `org.xwiki.platform:xwiki-platform-dashboard-ui` matched 8486 pings but only 7054 distinct instances (+20%).
* `searchInstalls()` returns raw hits, capped by Elasticsearch's default page size of 10, and the JSON it accepts is only the `query` part of the body, so no `aggs` can be attached.

As a consequence the scheduler job on extensions.xwiki.org that refreshes the installed count shown on every extension page still queries the Active Installs 1 instance only, since that is the only one it can get a distinct count out of. It reports around 1200 instances a day where the real total is above 9000.

## Changes

Two methods on `DataManager`, exposed through the script service:

* `countDistinctInstalls(jsonQuery)` — a `cardinality` aggregation on `distribution.instanceId`.
* `countDistinctInstallsByExtension(jsonQuery)` — the same count per extension id, in a **single** request. This one also hides a detail that is easy to get wrong: `extensions` is mapped as a `nested` type, so reaching the instance id from an extension bucket needs a `reverse_nested` aggregation.

On extensions.xwiki.org's data the per-extension query returns 2516 extensions in ~0.7s, replacing what is otherwise one request per extension.

## Accuracy

`cardinality` is a HyperLogLog++ estimate, not an exact count: it is accurate below its `precision_threshold` and approximate above it. Since the whole point here is to report a *real* number of instances, and extensions.xwiki.org is above 9000, neither method relies on Elasticsearch's default of 3000. Both use **40000**, the maximum Elasticsearch supports, so every count is exact for the current install base with a wide margin.

The cost usually quoted for that threshold — roughly 8 bytes per unit, i.e. ~320KB per aggregation — is a *worst case* that isn't actually paid. A HyperLogLog++ counter stays in its sparse representation until the observed count approaches the threshold, so the memory a count really uses follows that count rather than the bound. That holds per bucket too, which is what makes the same 40000 affordable for the per-extension count: the long tail of extensions installed on few instances each costs a fraction of it, and the total instance population is ~9000 to begin with.

Three limits are documented on the API rather than left to be discovered:

* The counts are keyed by the id an extension is **installed under**, and are not resolved through the features it provides. An extension that has been renamed, and whose former id is a feature of its new id, comes back as two entries.
* A query on the extensions themselves **does not restrict the extensions being counted**. A `nested` query selects the pings holding a matching extension, and every extension of those pings is then counted — so getting the instance count of one extension is a matter of reading its entry from the returned map, not of querying for it.
* Counting over the whole index counts every instance that **ever** pinged, not the ones that are currently active. Restricting to those is a matter of passing a query on the ping date, which both methods carry as their Javadoc example.

## Ordering

The per-extension map is returned in the order Elasticsearch returns the buckets (descending number of matching pings, which is close to — but not exactly — ordering by the returned counts) rather than in a hash order. Since that ordering is part of what the method promises, it is expressed in the **return type**: both methods return a `SequencedMap<String, Long>` rather than a `Map`.

## Backward compatibility

Both `DataManager` methods are **default methods** throwing their declared checked `Exception`, so existing implementations of that role keep compiling and working. This follows the [documented exception](https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HBackwardCompatibility) to the "a default method should not throw" rule: *"if the new method throws a checked exception in its signature then it's fine to throw it in the default method's implementation"*. Revapi passes with **no ignore added**.

Both new API methods and `TooManyExtensionsException` are marked **`@Unstable`**. Two questions below are genuinely still open, and an unstable API can be reshaped within the cycle instead of going through a deprecation.

## Design notes

**The caller controls only the `query`, never the aggregations** — deliberately narrower than the Active Installs 1 API, which took the whole request body. A generic "pass the full body" aggregation API was considered and rejected for that reason; the narrow slot is what makes "the caller cannot reshape the request" a property of the code rather than of the caller.

**The per-extension count is bounded** to 10000 extension buckets and raises an error (rather than silently under-counting) if it would report only some of the extensions. Counting one extension costs 2 Elasticsearch aggregation buckets (`terms` + `reverse_nested`), so that bound keeps a query comfortably inside Elasticsearch's own `search.max_buckets` (65536 by default), and those buckets are created by the extensions actually counted rather than by the bound itself.

**A truncation is detected by over-requesting by one, not by `sum_other_doc_count`.** The query asks the `terms` aggregation for `maximum + 1` extensions, and refuses the count when that extra one comes back. This is exact whatever the number of shards of the index: when the index holds no more extensions than the maximum, every shard holds fewer of them than the `shard_size` Elasticsearch derives from the requested size, so every shard reports all of the ones it holds and nothing can be missing from the merged result. `sum_other_doc_count` would have been simpler but it also collects the buckets that a shard did not report because they fell below *that shard's* `shard_size`, so on an index sharded beyond the one shard Elasticsearch creates by default it would refuse counts whose extensions all fit.

**Exceeding the bound raises a typed `TooManyExtensionsException`** rather than a generic `Exception`, so that the caller that matters here — the extensions.xwiki.org scheduler job — can tell that case apart from "Elasticsearch is unreachable" without matching on a message. The **type** is what carries that distinction. It is documented with `@throws` but **not** listed in the `throws` clause next to `Exception`, where it would be redundant with the exception it extends (and flagged as such by Sonar); a caller can catch it either way.

**Field paths are assembled from the mapping.** `"distribution.instanceId"` and `"extensions.id"` are not spelled out on the query side: the ping data providers that declare the mapping now also expose the paths built from their own property names (`DistributionPingDataProvider.FIELD_INSTANCE_ID`, `ExtensionPingDataProvider.FIELD_EXTENSION_ID`, plus the `PROPERTY_*` names they are derived from), so a rename in a mapping cannot leave a query behind. `DatePingDataProvider` already assembled `distribution.instanceId` for its own query and now uses the shared path too. Both providers follow the same convention: `PROPERTY_*` for a mapping property name, `FIELD_*` for a multi-segment path derived from them. They are in an `internal` package, so their visibility is not an API commitment.

## Tests

`PingSenderIT` extended and run against a real Elasticsearch 8.14.3 container. Its fixture sends two pings from the same instance, which is exactly the case that separates pings from installs, and then a third from a second instance:

* `countInstalls` = 2 but `countDistinctInstalls` = 1, with and without a query.
* `countDistinctInstallsByExtension` = `{extensionId1: 1, extensionId2: 1}` — an extension is not counted twice when the same instance pings repeatedly.
* A non-matching query yields 0 and an empty map.
* A final phase sends a **third ping from a second instance**, having only the second extension installed. This makes the two extensions differ both in the number of pings holding them (2 and 3) and in the number of instances having them installed (1 and 2), which is what pins the remaining claims: `countInstalls` = 3 while `countDistinctInstalls` = 2 (the discrepancy this issue is about), the map is `{extensionId1: 1, extensionId2: 2}`, and its key order is `[extensionId2, extensionId1]` — the reverse of alphabetical order, so the assertion genuinely proves the documented descending-`doc_count` ordering rather than passing on a tie-break.

The issue's phases are extracted out of `sendPingData()` into named private methods. They stay **one** test rather than several `@Order`ed ones: they share the index by construction, so splitting them would have made the later ones fail on their own and turned a single real failure into a cascade.

Two unit test classes cover what the IT structurally cannot reach:

* `DataManagerTest` — the new default methods on an implementation that overrides neither of them. That default-method behaviour *is* the backward-compatibility contract this PR rests on, so it is pinned by a test rather than only by the Javadoc.
* `ActiveInstallsScriptServiceTest` — delegation for the four script service methods, generic exception propagation, and that `TooManyExtensionsException` reaches the caller as its own type. This class had no coverage at all before.

The two `xwiki.jacoco.instructionRatio` values are raised to **0.91** with the integration tests and **0.10** without, to lock in the gain.

One branch is deliberately left uncovered: the `TooManyExtensionsException` throw. Reaching it requires an index holding more than 10000 extensions, which the IT's fixture cannot produce and which a unit test could only fake by mocking the Elasticsearch client and hand-building 10001 `terms` buckets. That is a large, brittle test for a two-line guard, so the guard is verified by reading rather than by a test — which is why the IT-profile ratio lands at 0.91 rather than higher.

Verified in both build modes — `-Pquality` and `-Pintegration-tests,quality`: 12 unit tests + 1 IT green, 0 Checkstyle violations, coverage checks met, Revapi clean with no ignore added.

## Security considerations

Reachability: `ActiveInstallsScriptService` does no internal rights check, so these methods are callable with **Script right** (Groovy, by contrast, requires Programming right unless the Secure Groovy Customizer is enabled, which it isn't by default).

What does *not* change: the caller controls only the `query` slot. Aggregations, `size`, the precision thresholds and the index are fixed in Java, and the JSON is base64-encoded whole into an ES `wrapper` query rather than concatenated into a larger document, so there is no way to escape it and reshape the request. The arbitrary-query surface (an ES `script` query where the cluster allows inline scripts, or a deliberately expensive wildcard/regex query) is pre-existing via `countInstalls()`/`searchInstalls()` and is neither widened nor narrowed here.

What does change: `countDistinctInstallsByExtension()` is a materially heavier operation than anything previously reachable at Script right — a `terms` aggregation with a `cardinality` sub-aggregation per bucket, versus a plain count. It measures ~0.7s over the 8.2M documents on extensions.xwiki.org, and it is bounded both by the 10000-extension maximum above and by Elasticsearch's own `search.max_buckets`.

It is *not* gated behind a rights check: that would be inconsistent with `countInstalls()`/`searchInstalls()`, which already let a Script-right user run an arbitrary Elasticsearch query, and it would block the extensions.xwiki.org use case this exists for. Say the word if you'd rather have the check anyway — that is one of the two reasons the API is `@Unstable`.

## Drive-by

* The Javadoc example on the existing `searchInstalls()` used `"distributionVersion"`, a field that does not exist in the mapping. Corrected to `"distribution.extension.version"` on both `DataManager` and the script service, while adding the examples on the new methods just below it.
* The JSON query was base64-encoded with the platform default charset (`String#getBytes()`) before going into the ES `wrapper` query. It is now encoded as UTF-8, so a query holding a non-ASCII character survives a JVM whose default charset isn't UTF-8. The wrapping itself is now built in one place shared by `countInstalls()` and the search requests.
* `countInstalls()` counts pings, not installs, which reads badly next to `countDistinctInstalls()`. Its Javadoc now says so and points at the new method. It is not renamed: `countInstalls()` is abstract on `DataManager`, so a deprecation would have to keep it as the method every implementation still has to implement while a new `countPings()` default delegated *to* it — which is worse than the name.

## Still open

* Whether `countDistinctInstallsByExtension()` should be rights-gated (see above).
* Whether the extension bound belongs on the call as a "top N" parameter. Not done here because it serves neither known caller — an extension page needs its own entry out of the map, not the most-pinged N, and the scheduler job needs all of them — so it would be API added on speculation. `@Unstable` keeps it cheap to add if a caller turns up that wants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
