### PR TITLE
XWIKI-18448: Add automated test for "Create Wiki From A Template With Extensions Installed'

### DIFF
--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-utils/src/main/java/org/xwiki/extension/test/AbstractExtensionTestUtils.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-utils/src/main/java/org/xwiki/extension/test/AbstractExtensionTestUtils.java
@@ -131,15 +131,32 @@ public abstract class AbstractExtensionTestUtils
     }
 
     /**
-     * Installs the specified extension.
-     * 
+     * Installs the specified extension on the main wiki.
+     *
      * @param extensionId the id of the extension to install
      */
     public void install(ExtensionId extensionId) throws Exception
     {
+        install(extensionId, null);
+    }
+
+    /**
+     * Installs the specified extension on the passed namespace.
+     *
+     * @param extensionId the id of the extension to install
+     * @param namespace the namespace on which to install the extension, {@code null} to install it on the main wiki
+     *     and {@link Namespace#ROOT} to install it on the root namespace
+     * @since 18.7.0RC1
+     */
+    public void install(ExtensionId extensionId, Namespace namespace) throws Exception
+    {
         Map<String, String> parameters = new HashMap<>();
         parameters.put("extensionId", extensionId.getId());
         parameters.put("extensionVersion", extensionId.getVersion().getValue());
+        if (namespace != null) {
+            String namespaceString = namespace.serialize();
+            parameters.put("extensionNamespace", namespaceString != null ? namespaceString : "");
+        }
 
         doAction("install", parameters);
     }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-utils/src/main/resources/extensionTestService.wiki
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-utils/src/main/resources/extensionTestService.wiki
@@ -50,7 +50,7 @@ if (request.action == 'is_installed') {
     }
 
   } else if (request.action == 'install') {
-    def installRequest = services.extension.createInstallRequest(request.extensionId, request.extensionVersion, 'wiki:xwiki')
+    def installRequest = services.extension.createInstallRequest(request.extensionId, request.extensionVersion, extensionNamespace)
     installRequest.setInteractive(false)
     job = services.extension.install(installRequest)
     job.join()

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/pom.xml
@@ -80,8 +80,22 @@
       <version>${project.version}</version>
       <scope>runtime</scope>
     </dependency>
+    <!-- The ExtensionTest.Service page, used by ExtensionTestUtils to install extensions and to query the installed
+         ones, is written in Groovy -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-rendering-macro-groovy</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
 
     <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-extension-test-utils</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-test-docker</artifactId>

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/it/org/xwiki/wiki/test/ui/WikiTemplateIT.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/it/org/xwiki/wiki/test/ui/WikiTemplateIT.java
@@ -21,7 +21,13 @@ package org.xwiki.wiki.test.ui;
 
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.xwiki.extension.ExtensionId;
+import org.xwiki.extension.test.junit5.ExtensionTestUtils;
 import org.xwiki.livedata.test.po.TableLayoutElement;
+import org.xwiki.model.namespace.WikiNamespace;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.LocalDocumentReference;
+import org.xwiki.model.reference.WikiReference;
 import org.xwiki.test.docker.junit5.ExtensionOverride;
 import org.xwiki.test.docker.junit5.UITest;
 import org.xwiki.test.integration.junit.LogCaptureConfiguration;
@@ -50,12 +56,18 @@ import static org.xwiki.wiki.test.po.WikiIndexPage.WIKI_NAME_COLUMN_LABEL;
  * @version $Id$
  */
 @UITest(
+    // Make the extensions declared in src/test/resources available to the instance, so that the test can install one
+    // of them on the template wiki.
+    testExtensionRepository = true,
     properties = {
         // The Notifications module contributes a Hibernate mapping that needs to be added to hibernate.cfg.xml.
         "xwikiDbHbmCommonExtraMappings=notification-filter-preferences.hbm.xml",
         // Deleting a wiki through a script service currently requires that the document hold the script
         // has programming rights, see https://tinyurl.com/2p8u5mhu
-        "xwikiPropertiesAdditionalProperties=test.prchecker.excludePattern=.*:WikiManager\\.DeleteWiki"
+        // The page used by ExtensionTestUtils to query the installed extensions executes a script which needs
+        // programming right too.
+        "xwikiPropertiesAdditionalProperties=test.prchecker.excludePattern="
+            + ".*:(WikiManager\\.DeleteWiki|ExtensionTest\\.Service)"
     },
     extraJARs = {
         // It's currently not possible to install a JAR contributing a Hibernate mapping file as an Extension. Thus,
@@ -91,21 +103,42 @@ class WikiTemplateIT
 {
     private static final String TEMPLATE_WIKI_ID = "mynewtemplate";
 
+    private static final String WIKI_ID = "mynewwiki";
+
     private static final String TEMPLATE_CONTENT = "Content of the template";
+
+    /**
+     * Extension generated from the {@code packagefile/templateextension} test resources and made available to XWiki
+     * through the test extension repository.
+     */
+    private static final ExtensionId EXTENSION_ID = new ExtensionId("maven:templateextension", "1.0");
+
+    /**
+     * The page brought by {@link #EXTENSION_ID}.
+     */
+    private static final LocalDocumentReference EXTENSION_PAGE =
+        new LocalDocumentReference("TemplateExtension", "TestPage");
 
     @Test
     @Order(1)
-    void createWikiFromTemplateTest(TestUtils setup, LogCaptureConfiguration logCaptureConfiguration) throws Exception
+    void createWikiFromTemplateTest(TestUtils setup, LogCaptureConfiguration logCaptureConfiguration,
+        ExtensionTestUtils extensionUtils) throws Exception
     {
         setup.loginAsSuperAdmin();
 
         // Create the template.
         createTemplateWiki(setup);
 
+        // Install an extension on the template wiki, so that we also verify that the extensions installed on a
+        // template are installed on the wikis created from that template.
+        extensionUtils.install(EXTENSION_ID, new WikiNamespace(TEMPLATE_WIKI_ID));
+        assertTrue(extensionUtils.isInstalled(EXTENSION_ID, new WikiNamespace(TEMPLATE_WIKI_ID)),
+            "The extension was not installed on the template wiki.");
+
         // Create the wiki from the template
-        createWikiFromTemplate();
+        createWikiFromTemplate(setup, extensionUtils);
         // Do it twice to check if we can create a wiki with the name of a deleted one.
-        createWikiFromTemplate();
+        createWikiFromTemplate(setup, extensionUtils);
 
         // Delete the template wiki.
         deleteTemplateWiki();
@@ -176,7 +209,7 @@ class WikiTemplateIT
         assertNull(wikiIndexPage.getWikiLink("My new template", false));
     }
 
-    private void createWikiFromTemplate()
+    private void createWikiFromTemplate(TestUtils setup, ExtensionTestUtils extensionUtils) throws Exception
     {
         // Go to the wiki creation wizard.
         WikiIndexPage wikiIndexPage = WikiIndexPage.gotoPage();
@@ -185,7 +218,7 @@ class WikiTemplateIT
         // First step.
         createWikiPage.setPrettyName("My new wiki");
         String wikiName = createWikiPage.getComputedName();
-        assertEquals("mynewwiki", wikiName);
+        assertEquals(WIKI_ID, wikiName);
         createWikiPage.setTemplate(TEMPLATE_WIKI_ID);
         createWikiPage.setIsTemplate(false);
         createWikiPage.setDescription("My first wiki");
@@ -199,8 +232,17 @@ class WikiTemplateIT
         // Go the created subwiki and verify the content of the main page is the same than in the template.
         assertEquals(TEMPLATE_CONTENT, wikiHomePage.getContent());
 
-        // Delete the wiki
-        DeleteWikiPage deleteWikiPage = wikiHomePage.deleteWiki("My new wiki");
+        // Verify that the extension installed on the template wiki is also installed on the wiki created from it,
+        // and that the page it brings has been copied.
+        assertTrue(extensionUtils.isInstalled(EXTENSION_ID, new WikiNamespace(WIKI_ID)),
+            "The extension installed on the template wiki was not installed on the wiki created from that template.");
+        assertTrue(setup.rest().exists(new DocumentReference(EXTENSION_PAGE, new WikiReference(WIKI_ID))),
+            "The page brought by the extension was not copied to the wiki created from the template.");
+
+        // Delete the wiki. Note that we go to the wiki index explicitly rather than through the home page of the new
+        // wiki, because querying the installed extensions above navigated the browser to the ExtensionTestUtils
+        // service page.
+        DeleteWikiPage deleteWikiPage = WikiIndexPage.gotoPage().deleteWiki("My new wiki");
         deleteWikiPage = deleteWikiPage.confirm("");
         assertTrue(deleteWikiPage.hasUserErrorMessage());
         assertTrue(deleteWikiPage.hasWikiDeleteConfirmationInput(""));
@@ -209,7 +251,7 @@ class WikiTemplateIT
         assertTrue(deleteWikiPage.hasUserErrorMessage());
         assertTrue(deleteWikiPage.hasWikiDeleteConfirmationInput("My new wiki"));
 
-        deleteWikiPage = deleteWikiPage.confirm("mynewwiki");
+        deleteWikiPage = deleteWikiPage.confirm(WIKI_ID);
         assertTrue(deleteWikiPage.hasSuccessMessage());
 
         // Verify the wiki has been deleted.

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/resources/packagefile/templateextension/TemplateExtension/TestPage.xml
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/resources/packagefile/templateextension/TemplateExtension/TestPage.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xwikidoc>
+  <web>TemplateExtension</web>
+  <name>TestPage</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <parent>Main.WebHome</parent>
+  <creator>xwiki:XWiki.Admin</creator>
+  <author>xwiki:XWiki.Admin</author>
+  <customClass/>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <creationDate>1341237176000</creationDate>
+  <date>1341237322000</date>
+  <contentUpdateDate>1341237322000</contentUpdateDate>
+  <version>1.1</version>
+  <title>Template Extension Test Page</title>
+  <template/>
+  <defaultTemplate/>
+  <validationScript/>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>false</hidden>
+  <content>Content brought by the test extension.</content>
+</xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/resources/packagefile/templateextension/package.xml
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/resources/packagefile/templateextension/package.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package>
+<infos/>
+<name>TemplateExtension.TestPage</name>
+<description></description>
+<licence>LGPL</licence>
+<author>XWiki</author>
+<version>1.0</version>
+<backupPack>false</backupPack>
+<preserveVersion>false</preserveVersion>
+<files>
+<file defaultAction="0" language="">TemplateExtension.TestPage</file>
+</files>
+</package>

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/resources/packagefile/templateextension/packagefile.properties
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/resources/packagefile/templateextension/packagefile.properties
@@ -1,0 +1,3 @@
+version=1.0
+type=xar
+repository=maven

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/resources/repository/maven/maven/templateextension/1.0/templateextension-1.0.pom
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/resources/repository/maven/maven/templateextension/1.0/templateextension-1.0.pom
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>maven</groupId>
+  <artifactId>templateextension</artifactId>
+  <version>1.0</version>
+  <packaging>xar</packaging>
+  <name>Template Extension</name>
+  <description>Test extension installed on a template wiki to verify it's also installed on the wikis created from that template.</description>
+</project>


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-18448

# Changes

## Description

Automates the manual test [Create Wiki From A Template With Extensions Installed](https://test.xwiki.org/xwiki/bin/view/Wiki%20Tests/Create%20Wiki%20From%20A%20Template%20With%20Extensions%20Installed).

* Extend `WikiTemplateIT#createWikiFromTemplateTest` to install an extension on the template wiki and verify that, on the wikis created from that template, the extension is registered as installed and the page it brings has been copied.
* Add the test extension (a XAR under `src/test/resources/packagefile`) and its test extension repository descriptor, and enable `testExtensionRepository` on the test.
* Add to `xwiki-platform-wiki-test-docker` the dependencies needed by `ExtensionTestUtils`: the Groovy rendering macro (the `ExtensionTest.Service` page it drives is written in Groovy) and `xwiki-platform-extension-test-utils` itself.
* Add an `install(ExtensionId, Namespace)` overload to `AbstractExtensionTestUtils` and make the install branch of `extensionTestService.wiki` honour the requested namespace, so that an extension can be installed on a subwiki.

## Clarifications

* **There was no existing coverage.** `WikiTemplateIT#createWikiFromTemplateTest` covered template creation, creation from a template, content copy and deletion, but never installed an extension. The behaviour the manual test exercises is `WikiEventListener#onWikiCopied()` in `xwiki-platform-extension-handler-xar`, which on a `WikiCopiedEvent` re-registers every extension installed on the template's namespace onto the new wiki's namespace. It only had a unit test (`WikiEventListenerTest`), never an end-to-end one.
* **Why extend the existing test rather than add a second `@Test`.** A separate test would add one more template-wiki creation *and* one more subwiki creation, each copying the 800+ page `xwiki-platform-wiki-ui-wiki` flavor (the existing code waits up to 5 minutes for it); the extension install is a small XAR by comparison. It also comes with a bonus: `createWikiFromTemplate()` is deliberately called twice (to check a wiki can be created with the name of a deleted one), so the extension assertions cover delete-then-recreate too, i.e. `onWikiDeleted()` unregistering and `onWikiCopied()` re-registering.
* **Why `ExtensionTestUtils` rather than the REST job API.** Extension jobs log failures into the job log rather than setting the job error field, and `JobsResourceImpl` serializes the status with `log=false` — so `PUT /rest/jobs?jobType=install` returns HTTP 200 whatever goes wrong and the test cannot see why. `ExtensionTestUtils` checks the job log and reports the root cause.
* **Backward compatibility of the shared change.** `extensionTestService.wiki` already computed an `extensionNamespace` variable defaulting to `'wiki:xwiki'` when the parameter is absent; only the install branch ignored it and used the literal instead. The existing `install(ExtensionId)` now delegates with a `null` namespace, which sends no parameter, so its behaviour is unchanged.
* `test.prchecker.excludePattern` had to be merged into a single alternation (`.*:(WikiManager\.DeleteWiki|ExtensionTest\.Service)`) because `@UITest(properties = …)` is a map and a second `xwikiPropertiesAdditionalProperties` entry would clash with the existing one.

# Screenshots & Video

N/A — test-only change, no UI change.

# Executed Tests

* The new test, on `xwiki-platform-wiki-test-docker`:
  ```
  mvn -B -ntp verify -Dit.test=WikiTemplateIT -Dfailsafe.failIfNoSpecifiedTests=false
  ```
  → `Tests run: 1, Failures: 0, Errors: 0` (method 79.9s).
* `ExtensionIT`, the only other consumer of the changed install branch of `extensionTestService.wiki`, on `xwiki-platform-extension-test-docker`:
  ```
  mvn -B -ntp verify
  ```
  → `Tests run: 15, Failures: 0, Errors: 0` (368.9s). Note that `ExtensionIT` only calls the one-argument `install(ExtensionId)`, so this confirms the shared change is not a regression rather than exercising the new namespace path — the latter is covered by `WikiTemplateIT`.
* Style/licence on both modules: `mvn -B -ntp verify -DskipITs -DskipTests` → success.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * The issue carries the `testneeded` label, so the test is expected to be backported to the supported stable branches. Not requested in this PR — to be done as a follow-up once this is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
