### PR TITLE
XWIKI-23253: Java StackOverflowError in code macro when choosing js language

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/java/org/xwiki/rendering/internal/macro/code/CodeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/java/org/xwiki/rendering/internal/macro/code/CodeMacro.java
@@ -34,6 +34,7 @@ import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentLookupException;
@@ -163,14 +164,9 @@ public class CodeMacro extends AbstractBoxMacro<CodeMacroParameters>
         List<Block> result;
         try {
             if (LANGUAGE_NONE.equalsIgnoreCase(parameters.getLanguage())) {
-                if (StringUtils.isEmpty(source.getContent())) {
-                    result = Collections.emptyList();
-                } else {
-                    result = this.plainTextParser.parse(new StringReader(source.getContent())).getChildren().get(0)
-                        .getChildren();
-                }
+                result = parsePlainText(source.getContent());
             } else {
-                result = highlight(parameters, source);
+                result = highlightOrFallbackToPlainText(parameters, source);
             }
         } catch (Exception e) {
             throw new MacroExecutionException("Failed to highlight content", e);
@@ -196,9 +192,44 @@ public class CodeMacro extends AbstractBoxMacro<CodeMacroParameters>
         return result;
     }
 
+    private List<Block> parsePlainText(String content) throws ParseException
+    {
+        if (StringUtils.isEmpty(content)) {
+            return Collections.emptyList();
+        }
+
+        return this.plainTextParser.parse(new StringReader(content)).getChildren().get(0).getChildren();
+    }
+
+    /**
+     * Highlighting is a best effort: displaying the code unhighlighted is a much better outcome than failing the whole
+     * macro and thus breaking the page it's on. Some lexers recurse once per character of the content and give up on
+     * long inputs, and the language is not always under the control of the user reading the page, so there isn't
+     * necessarily a workaround.
+     *
+     * @param parameters the code macro parameters
+     * @param source the source to highlight
+     * @return the highlighted content, or the plain text content when highlighting failed
+     * @throws ParseException when even parsing the content as plain text failed
+     */
+    private List<Block> highlightOrFallbackToPlainText(CodeMacroParameters parameters, CodeMacroSource source)
+        throws ParseException
+    {
+        try {
+            return highlight(parameters, source);
+        } catch (Exception e) {
+            // Only log the root cause message: the failure can come from a very deep recursion in the lexer, whose
+            // stack trace is thousands of frames long, and the page may be rendered often.
+            this.logger.warn("Failed to highlight the content with language [{}], displaying it unhighlighted."
+                + " Cause: [{}]", parameters.getLanguage(), ExceptionUtils.getRootCauseMessage(e));
+
+            return parsePlainText(source.getContent());
+        }
+    }
+
     /**
      * Return a highlighted version of the provided content.
-     * 
+     *
      * @param parameters the code macro parameters.
      * @param source the source to highlight.
      * @return the highlighted version of the provided content.

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/test/java/org/xwiki/rendering/internal/macro/code/CodeMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/test/java/org/xwiki/rendering/internal/macro/code/CodeMacroTest.java
@@ -19,24 +19,34 @@
  */
 package org.xwiki.rendering.internal.macro.code;
 
+import java.io.Reader;
 import java.util.List;
 import java.util.Map;
 
 import javax.inject.Named;
+import javax.script.ScriptException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.GroupBlock;
 import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.block.ParagraphBlock;
+import org.xwiki.rendering.block.WordBlock;
+import org.xwiki.rendering.block.XDOM;
 import org.xwiki.rendering.internal.code.layout.CodeLayoutHandler;
 import org.xwiki.rendering.macro.MacroExecutionException;
 import org.xwiki.rendering.macro.MacroPreparationException;
 import org.xwiki.rendering.macro.code.CodeMacroLayout;
 import org.xwiki.rendering.macro.code.CodeMacroParameters;
 import org.xwiki.rendering.parser.HighlightParser;
+import org.xwiki.rendering.parser.ParseException;
+import org.xwiki.rendering.parser.Parser;
 import org.xwiki.rendering.transformation.MacroTransformationContext;
+import org.xwiki.test.LogLevel;
+import org.xwiki.test.junit5.LogCaptureExtension;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectComponentManager;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
@@ -46,6 +56,8 @@ import org.xwiki.test.mockito.MockitoComponentManager;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 /**
  * Validate {@link CodeMacro}.
@@ -67,6 +79,13 @@ class CodeMacroTest
     @MockComponent
     @Named(CodeMacroLayout.Constants.PLAIN_HINT)
     private CodeLayoutHandler codeLayoutHandler;
+
+    @MockComponent
+    @Named("plain/1.0")
+    private Parser plainTextParser;
+
+    @RegisterExtension
+    private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.WARN);
 
     @BeforeEach
     void beforeEach() throws Exception
@@ -96,5 +115,45 @@ class CodeMacroTest
 
         assertEquals(prepared.get(0), result.get(0).getChildren().get(0));
         assertNotSame(prepared.get(0), result.get(0).getChildren().get(0));
+    }
+
+    @Test
+    void executeWhenHighlightParserFailsFallsBackToPlainText() throws Exception
+    {
+        // The shape a lexer recursing too deeply takes once it reaches the code macro: the script engine reports it as
+        // a ScriptException, which the Pygments parser wraps into a ParseException.
+        ScriptException scriptException = new ScriptException("RuntimeError: maximum recursion limit exceeded");
+        assertFallbackToPlainText(new ParseException("Failed to highlight code", scriptException),
+            "Failed to highlight the content with language [groovy], displaying it unhighlighted. "
+                + "Cause: [ScriptException: RuntimeError: maximum recursion limit exceeded]");
+    }
+
+    @Test
+    void executeWhenHighlightParserThrowsRuntimeExceptionFallsBackToPlainText() throws Exception
+    {
+        assertFallbackToPlainText(new IllegalStateException("Unexpected failure"),
+            "Failed to highlight the content with language [groovy], displaying it unhighlighted. "
+                + "Cause: [IllegalStateException: Unexpected failure]");
+    }
+
+    private void assertFallbackToPlainText(Throwable highlightFailure, String expectedLog) throws Exception
+    {
+        WordBlock plainTextBlock = new WordBlock("content");
+        when(this.plainTextParser.parse(any(Reader.class)))
+            .thenReturn(new XDOM(List.of(new ParagraphBlock(List.of(plainTextBlock)))));
+        when(this.highlightParser.highlight(any(), any())).thenThrow(highlightFailure);
+        // Return the blocks unchanged so that the assertion below is about the fallback and not about the layout.
+        when(this.codeLayoutHandler.layout(any(), any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CodeMacroParameters parameters = new CodeMacroParameters();
+        parameters.setLanguage("groovy");
+        MacroTransformationContext context = new MacroTransformationContext();
+        context.setCurrentMacroBlock(new MacroBlock("code", Map.of("language", "groovy"), "content", false));
+
+        List<Block> result = this.macro.execute(parameters, "content", context);
+
+        assertEquals(new GroupBlock(List.of(plainTextBlock), Map.of("class", "code")),
+            result.get(0).getChildren().get(0));
+        assertEquals(expectedLog, this.logCapture.getMessage(0));
     }
 }


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-23253

## Problem

A `{{code}}` macro fails to render entirely — the page shows a macro error box instead of the content — when the Pygments lexer for the chosen language recurses too deeply on the content.

Reported twice: originally with `language="js"`, and again on a scheduler job page with `language="groovy"`.

## Root cause

The code macro highlights server-side with Pygments 2.4.2 running on Jython. Several lexers match string and regex literals with a `(alternation)*` rule:

```python
# GroovyLexer, 'base' state
(r'/(\\\\|\\"|[^/])*/', String)
# JavascriptLexer, 'slashstartsregex' state
(r'/(\\.|[^[/\\\n]|\[(\\.|[^\]\\\n])*])+/([gimuy]+\b|\B)', String.Regex)
```

That is not a `REPEAT_ONE`, so Jython's `sre` port recurses once per repetition — one stack frame per character. Measured on Jython 2.7.4, matching `/` + N×`a` + `/`, all of those patterns give up at exactly N=2499 on an otherwise-empty stack; inside a real servlet and rendering call stack the threshold is lower.

What reaches Java is an ordinary exception, not an `Error`: Jython's `sre` has its own recursion counter, and `Py.JavaError` (Py.java:537-538) converts a genuine `StackOverflowError` into a Python `RuntimeError`. Either way the code macro sees a `ScriptException` wrapped by `PygmentsParser` into a `ParseException`.

Note this is **not** fixed by upgrading Pygments:

* The post-2.7.4 ReDoS hardening (`/(\\\\|\\[^\\]|[^/\\])*/`) makes the alternatives disjoint, which fixes exponential *backtracking* but not the *recursion depth*. It gives up at the same N=2499.
* Pygments >= 2.6.0 declares `requires_python >= 3.5` and so cannot run on Jython (Python 2.7) at all. XWIKI-17107 therefore cannot resolve this.

## Fix

Highlighting is a best effort. When the highlight parser fails, display the content unhighlighted and log a warning, rather than failing the macro and breaking the page.

Only the root cause message is logged, not the stack trace — a deep recursion produces thousands of frames and the page may be rendered often.

This matters particularly because the language is not always under the reader's control: `XWiki.SchedulerJobSheet` hardcodes `{{code language='groovy' source="script:schedulerScript"/}}`, so a job whose script contains a slashy regex breaks its own job page with no workaround available to the user.

Removing the root cause means getting server-side highlighting off Jython and Pygments, which is a separate and much larger change.

## Tests

Two unit tests added to `CodeMacroTest`, covering the checked `ParseException` the Pygments parser raises and an unchecked exception from the highlight parser. Both assert the plain text fallback blocks and the logged warning. Verified that both fail without the production change.

`mvn install -Plegacy,quality` on the module: 28 tests pass, 0 Checkstyle violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
