### PR TITLE
[Misc] Fix the two NullPointerExceptions reported by SonarCloud in XWikiDocument

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -3641,7 +3641,15 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         XWikiContext context)
     {
         try {
-            PropertyClass pclass = (PropertyClass) obj.getXClass(context).get(fieldname);
+            BaseClass xclass = obj.getXClass(context);
+            PropertyClass pclass = xclass == null ? null : (PropertyClass) xclass.get(fieldname);
+
+            // The xclass is null when its document cannot be resolved, and the property is null when the field is
+            // not part of the xclass. In both cases there is no pretty name to display.
+            if (pclass == null) {
+                return "";
+            }
+
             String dprettyName = "";
             if (showMandatory) {
                 dprettyName = context.getWiki().addMandatory(context);
@@ -5918,6 +5926,12 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         }
 
         BaseClass xclass = xobject.getXClass(xcontext);
+
+        // The xclass is null when its document cannot be resolved, in which case there is no property definition
+        // telling which fields hold wiki content.
+        if (xclass == null) {
+            return;
+        }
 
         for (Object fieldClass : xclass.getProperties()) {
             // Wiki content stored in xobjects


### PR DESCRIPTION
## Issues fixed

The two open `javabugs:S2259` reliability bugs on new code in `xwiki-platform-oldcore`:

- [`AaAPhatIyezmGMmr0i4C`](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&open=AaAPhatIyezmGMmr0i4C) — `XWikiDocument.java:3644`
- [`AaAPhatIyezmGMmr0i4D`](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&open=AaAPhatIyezmGMmr0i4D) — `XWikiDocument.java:5922`

## Root cause

Both SonarCloud flows converge on the same indirection: `BaseCollection#getXClass(XWikiContext)`
(`BaseCollection.java:288-307`) returns `null` in three cases — a `null` context or `null`
`context.getWiki()`, a `null` xclass reference, or an exception while loading the xclass document.
Both call sites dereferenced its result without a check.

## Changes

**`displayPrettyName(String, boolean, boolean, BaseObject, XWikiContext)`** — the `NullPointerException`
was already swallowed by the method's `catch (Exception e) { return ""; }`, so this is
behaviour-preserving; it just makes the empty result explicit rather than a side effect of the
catch-all. The property lookup two lines below has the same shape (`xclass.get(fieldname)` returns
`null` for a field absent from the xclass), so both are covered by a single guard. Reordering the
guard ahead of `XWiki#addMandatory` is safe: that method is a pure preference read
(`XWiki.java:7379-7384`).

**`getUniqueLinkedEntityReferences(BaseObject, …)`** — this one was a real defect. The method
guarded `xobject == null` but not the xclass, and has no surrounding try/catch, so the
`NullPointerException` propagated out of the per-xobject loop
(`XWikiDocument.java:5900-5903`) and aborted link extraction for the entire document. An
unresolvable xclass now skips that one xobject, consistent with the `xobject == null` guard above it.

## Verification

`mvn -B -ntp install -Plegacy,quality -pl xwiki-platform-core/xwiki-platform-oldcore` — BUILD
SUCCESS: 1145 tests run, 0 failures, 0 Checkstyle violations, `jacoco:check` and Revapi pass.

No module was excluded from the change.