### PR TITLE
[Misc] Fix Compare with undefined directly instead of typeof (SonarQube javascript:S7741)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/importer/import.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/importer/import.js
@@ -79,7 +79,7 @@ var XWiki = (function(XWiki){
       /** Attach the HTML5 uploader, if available */
       var form = $('AddAttachment');
       require(['xwiki-upload'], function(FileUploader) {
-        if (form && typeof (FileUploader) != 'undefined') {
+        if (form && FileUploader !== undefined) {
           var input = form.down("input[type='file']");
           var html5Uploader = new FileUploader(input, {
             'progressAutohide': true,

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/viewers/attachments.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/viewers/attachments.js
@@ -80,7 +80,7 @@ require(['jquery', 'xwiki-upload', 'xwiki-events-bridge'], function($, FileUploa
     }
     /** If available in the current browser, enable HTML5 upload for a given file input */
     attachHTML5Uploader(input) {
-      if (typeof(FileUploader) != 'undefined') {
+      if (FileUploader !== undefined) {
         input.attr('multiple','');
         // Since the attachments liveData is refreshed on file upload, we skip updating the attachments container.
         return new FileUploader(input[0], {


### PR DESCRIPTION
## Jira URL
None — this is a `[Misc]` SonarQube cleanup commit.

## Description

Fixes 2 open SonarCloud `javascript:S7741` issues ("Compare with `undefined` directly instead of using `typeof`"), both assigned to me:

| Issue | File | Introduced by |
|---|---|---|
| [AZ8eesVBewCGJePZKDMm](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&open=AZ8eesVBewCGJePZKDMm) | `import.js:82` | e8153c694b, [XWIKI-22125](https://jira.xwiki.org/browse/XWIKI-22125) ([#5695](https://github.com/xwiki/xwiki-platform/pull/5695)) |
| [AZ7imhJD8lbwoM_tj_bU](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&open=AZ7imhJD8lbwoM_tj_bU) | `attachments.js:83` | c0b36b6496, [XWIKI-22125](https://jira.xwiki.org/browse/XWIKI-22125) ([#5001](https://github.com/xwiki/xwiki-platform/pull/5001)) |

Both sites are an AMD `require([...], function(FileUploader) { ... })` callback guarding `FileUploader` with `typeof (FileUploader) != 'undefined'`. Since `FileUploader` is a declared callback **parameter** (not a possibly-undeclared global), `typeof` gives no extra safety over a direct `FileUploader !== undefined` check — behavior-preserving.

## Executed Tests

Neither file has JS unit-test coverage in this module (no test directory under `xwiki-platform-web-war` exercises `FileUploader`/import/attachments JS). Verified with `node --check` on both files (valid syntax) and manual review of the AMD callback semantics.

## Expected merging strategy
* Prefers squash: Yes
* Backport on branches: None — cleanup only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
