### PR TITLE
XWIKI-24689: Wrong javadoc on LikeRight: it does not imply Login and View rights

### DIFF
--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/main/java/org/xwiki/like/internal/LikeRight.java
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/main/java/org/xwiki/like/internal/LikeRight.java
@@ -29,7 +29,7 @@ import org.xwiki.security.authorization.RuleState;
 /**
  * A programmatic right for Like feature.
  *
- * This right is allowed by default and implies Login and View rights.
+ * This right is allowed by default, targets wikis, spaces and documents, and implies no other right.
  *
  * @version $Id$
  * @since 12.7RC1


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24689

# Changes

## Description

The class javadoc of `LikeRight` stated that the right "implies Login and View rights", 
but `getImpliedRights()` returns `null`, so the Like right implies no other right.

This was accurate when the class was added (XWIKI-17508), but the javadoc was never 
updated when the implementation changed, so it has described the opposite of the code 
ever since.

## Clarifications

Documentation-only fix, no functional/behavioral change.

# Screenshots & Video

N/A

# Executed Tests

Not applicable. Javadoc-only change.

# Expected merging strategy

* Prefers squash: Yes 