### PR TITLE
[Misc] Suppress false-positive SonarCloud infinite recursion warnings

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/SolrCoreInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/SolrCoreInitializer.java
@@ -45,6 +45,10 @@ public interface SolrCoreInitializer
      * @deprecated use {@link #initialize(XWikiSolrCore)} instead
      */
     @Deprecated(since = "16.1.0RC1")
+    // This default implementation and the default implementation of #initialize(XWikiSolrCore) delegate to each
+    // other on purpose, as a bridge between the deprecated and the current method: an implementation is expected to
+    // override at least one of the two, so this never actually recurses infinitely at runtime.
+    @SuppressWarnings("javabugs:S2190")
     default void initialize(SolrClient client) throws SolrException
     {
         initialize(new DefaultXWikiSolrCore(getCoreName(), getCoreName(), client, -1));

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/SolrCoreInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/SolrCoreInitializer.java
@@ -45,9 +45,7 @@ public interface SolrCoreInitializer
      * @deprecated use {@link #initialize(XWikiSolrCore)} instead
      */
     @Deprecated(since = "16.1.0RC1")
-    // This default implementation and the default implementation of #initialize(XWikiSolrCore) delegate to each
-    // other on purpose, as a bridge between the deprecated and the current method: an implementation is expected to
-    // override at least one of the two, so this never actually recurses infinitely at runtime.
+    // Intentional bridge with #initialize(XWikiSolrCore): every implementation overrides at least one of the two.
     @SuppressWarnings("javabugs:S2190")
     default void initialize(SolrClient client) throws SolrException
     {

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-api/src/main/java/org/xwiki/security/authentication/AuthenticationFailureStrategy.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-api/src/main/java/org/xwiki/security/authentication/AuthenticationFailureStrategy.java
@@ -62,6 +62,11 @@ public interface AuthenticationFailureStrategy
      * @deprecated use {@link #validateForm(String, HttpServletRequest)} instead
      */
     @Deprecated(since = "17.0.0RC1")
+    // This default implementation and the default implementation of #validateForm(String, HttpServletRequest)
+    // delegate to each other on purpose, as a bridge between the deprecated javax method and the current jakarta
+    // one: an implementation is expected to override at least one of the two, so this never actually recurses
+    // infinitely at runtime.
+    @SuppressWarnings("javabugs:S2190")
     default boolean validateForm(String username, javax.servlet.http.HttpServletRequest request)
     {
         return validateForm(username, JakartaServletBridge.toJakarta(request));

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-api/src/main/java/org/xwiki/security/authentication/AuthenticationFailureStrategy.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-api/src/main/java/org/xwiki/security/authentication/AuthenticationFailureStrategy.java
@@ -62,10 +62,8 @@ public interface AuthenticationFailureStrategy
      * @deprecated use {@link #validateForm(String, HttpServletRequest)} instead
      */
     @Deprecated(since = "17.0.0RC1")
-    // This default implementation and the default implementation of #validateForm(String, HttpServletRequest)
-    // delegate to each other on purpose, as a bridge between the deprecated javax method and the current jakarta
-    // one: an implementation is expected to override at least one of the two, so this never actually recurses
-    // infinitely at runtime.
+    // Intentional bridge with #validateForm(String, HttpServletRequest): every implementation overrides at least
+    // one of the two.
     @SuppressWarnings("javabugs:S2190")
     default boolean validateForm(String username, javax.servlet.http.HttpServletRequest request)
     {


### PR DESCRIPTION
# Jira URL

N/A — `[Misc]` change (no JIRA issue needed).

# Changes

## Description

* Suppress 2 false-positive `javabugs:S2190` ("Recursion should not be infinite") BLOCKER SonarCloud findings.
* Both flagged sites are the standard XWiki deprecation-bridge idiom: two `default` methods on a `@Role` interface delegate to each other (old API → new API and back), so an implementation is expected to override at least one of them. This is verified safe in practice:
  * `AbstractSolrCoreInitializer` already overrides `initialize(XWikiSolrCore)`, breaking the cycle for `SolrCoreInitializer#initialize(SolrClient)`.
  * All three existing `AuthenticationFailureStrategy` implementations (`LegacyAuthenticationFailureStrategy`, `CaptchaAuthenticationFailureStrategy`, `DisableAccountFailureStrategy`) already override `validateForm(String, HttpServletRequest)` (jakarta), breaking the cycle for `validateForm(String, javax.servlet.http.HttpServletRequest)`.
* Added `@SuppressWarnings("javabugs:S2190")` on each flagged default method, with a short explanatory comment as required by the [XWiki SonarQube convention](https://dev.xwiki.org/xwiki/bin/view/Community/CodeStyle/JavaCodeStyle/#HSonarQube).

## Clarifications

* Why an actual structural fix isn't possible: the only way to make the mutual-recursion cycle structurally impossible — rather than just unreachable by every real implementation — is to make one of the two delegating methods abstract (drop its `default` body). That's not an option here: both flagged methods are the *deprecated* side of an API migration (`SolrClient` → `XWikiSolrCore`, javax → jakarta `HttpServletRequest`), meant to let implementations written before the newer method existed keep compiling and working unmodified. Making either method abstract would force every existing implementor of these `@Role` interfaces — including third-party extensions outside this repository — to implement a method they currently don't, which is a backward-compatibility break. Removing the deprecated method entirely isn't an option either at this stage, since it's still within its deprecation window. So the mutual delegation is inherent to how XWiki does backward-compatible API evolution, not a defect in this code, and the correct resolution is documenting the false positive rather than restructuring around it.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

```
mvn clean install -B -ntp -Plegacy,quality -pl xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api,xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-api
```
`BUILD SUCCESS`, both modules `SUCCESS` (Checkstyle 0 violations, JaCoCo coverage met, Revapi clean), 128/128 goals executed.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  *

---

SonarCloud issues (marked Accepted):
- https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issues=AZ-AMw0npN28pifR1L_z&open=AZ-AMw0npN28pifR1L_z
- https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issues=AaAPhen4yezmGMmr0i4L&open=AaAPhen4yezmGMmr0i4L

---
_Generated by [Claude Code](https://claude.ai/code)_