### PR TITLE
XWIKI-22154: "aria-labelledby" for navigation panel entries and corresponding ids contain illegal whitespaces

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/TemplateProviderMacros.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/TemplateProviderMacros.xml
@@ -214,7 +214,8 @@
     $('.location-picker.modal').prop('modalTrigger', $(this)).modal();
   });
 
-  var getLocalSpaceReference = function(nodeId) {
+  var getLocalSpaceReference = function(escapedNodeId) {
+    var nodeId = $.fn.xtree.unescapeNodeId(escapedNodeId);
     var separatorIndex = nodeId.indexOf(':');
     var nodeType = nodeId.substr(0, separatorIndex);
     var nodeStringReference = nodeId.substr(separatorIndex + 1);

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/AnnotationConfigSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/AnnotationConfigSheet.xml
@@ -289,21 +289,22 @@ $annotationsConfigDoc.display('annotationClass', 'edit')
             // Once the node is loaded, check it, if possible.
             // If the node did not load (lack of permissions, hidden document, etc.), nothing happens.
             tree.check_node(idToCheck);
-          }.bind(this, savedId));
+          }.bind(this, $.fn.xtree.escapeNodeId(savedId)));
         }
       });
 
       // Listen to tree nodes being checked/unchecked and save the changes in the DOM to be saved on submit.
       treeElement.on('changed.jstree', function(event, data) {
-        var node = data.node;
+        // The savedIds list holds the node ids as they are serialized in the form field, i.e. unescaped.
+        var nodeId = $.fn.xtree.unescapeNodeId(data.node.id);
         var initialNrOfNodes = savedIds.length;
 
         // Update the savedIds list.
-        var savedIdIndex = savedIds.indexOf(node.id);
+        var savedIdIndex = savedIds.indexOf(nodeId);
         if (data.action == 'select_node') {
           // If it's not in the list, add it.
           if (savedIdIndex == -1) {
-            savedIds.push(node.id);
+            savedIds.push(nodeId);
           }
         } else if (data.action == 'deselect_node') {
           // If it's in the list, remove it.

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/main/resources/js/attachment/move.js
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/main/resources/js/attachment/move.js
@@ -70,7 +70,7 @@ require(['jquery', config.treeWebjar], function ($) {
 
   selectButton.on('click', function() {
     modal.modal('hide');
-    var docReference = $.jstree.reference(tree).get_selected(false)[0]
+    var docReference = $.fn.xtree.unescapeNodeId($.jstree.reference(tree).get_selected(false)[0])
     const idx = docReference.indexOf(':')
     docReference = docReference.substring(idx + 1);
     if (docReference) {

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/LinkTreeElement.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/LinkTreeElement.java
@@ -87,7 +87,7 @@ public class LinkTreeElement extends DocumentTreeElement
      */
     public void createNode(DocumentReference origin, String name)
     {
-        String createDocumentNodeId = getCreateDocumentNodeId(origin);
+        String createDocumentNodeId = escapeNodeId(getCreateDocumentNodeId(origin));
         WebElement originNode = getDriver().findElement(By.id(createDocumentNodeId));
         originNode.findElement(By.tagName("a")).click();
         // We cannot reuse the element
@@ -97,7 +97,7 @@ public class LinkTreeElement extends DocumentTreeElement
         SpaceReference targetSpace = new SpaceReference(name, origin.getLastSpaceReference());
         DocumentReference target = new DocumentReference("WebHome", targetSpace);
         getDriver().waitUntilCondition(
-            ExpectedConditions.presenceOfElementLocated(By.id(getNodeId(target)))
+            ExpectedConditions.presenceOfElementLocated(By.id(escapeNodeId(getNodeId(target))))
         );
         openTo(getNodeId(target));
     }

--- a/xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-ui/src/main/resources/XWiki/InplaceEditing.xml
+++ b/xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-ui/src/main/resources/XWiki/InplaceEditing.xml
@@ -1260,7 +1260,7 @@ require(['jquery', 'xwiki-meta'], function($, meta) {
   var updateDocTrees = function(xwikiDocument) {
     var plainTitle = xwikiDocument.getPlainTitle();
     $('.jstree-xwiki').each(function() {
-      $(this).jstree?.(true)?.set_text?.('document:' + xwikiDocument.id, plainTitle);
+      $(this).jstree?.(true)?.set_text?.($.fn.xtree.escapeNodeId('document:' + xwikiDocument.id), plainTitle);
     });
   };
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/RenamePageIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/RenamePageIT.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.xwiki.flamingo.skin.test.po.AttachmentsPane;
 import org.xwiki.flamingo.skin.test.po.AttachmentsViewPage;
 import org.xwiki.flamingo.skin.test.po.JobQuestionPane;
+import org.xwiki.index.tree.test.po.DocumentPickerModal;
 import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
@@ -935,6 +936,44 @@ class RenamePageIT
         setup.gotoPage(sourcePage, "edit", "editor=object");
         List<ObjectEditPane> rightObjects = new ObjectEditPage().getObjectsOfClass(XWIKI_RIGHTS_CLASS, true);
         assertEquals(1, rightObjects.size(), "The refused move must have left the source page's right in place.");
+    }
+
+    /**
+     * Move a page to a parent whose name contains white space, using the tree picker. The tree escapes the identifier
+     * of its nodes so that they can be used as HTML identifiers, so this checks that it unescapes them back before
+     * sending them to the server. See XWIKI-22151 and XWIKI-22154.
+     */
+    @Order(14)
+    @Test
+    void renamePageToParentWithWhiteSpaceUsingTreePicker(TestUtils setup) throws Exception
+    {
+        String targetSpaceName = "Rename Space";
+        DocumentReference targetParent = new DocumentReference("xwiki", targetSpaceName, "WebHome");
+        DocumentReference source =
+            new DocumentReference("xwiki", Arrays.asList("RenamePageIT", "MoveToSpaceWithWhiteSpace"), "WebHome");
+        DocumentReference target =
+            new DocumentReference("xwiki", Arrays.asList(targetSpaceName, "MoveToSpaceWithWhiteSpace"), "WebHome");
+
+        setup.rest().delete(targetParent);
+        setup.rest().delete(source);
+        setup.rest().delete(target);
+
+        setup.createPage(targetParent, "", targetSpaceName);
+        setup.createPage(source, "", "MoveToSpaceWithWhiteSpace");
+
+        new SolrTestUtils(setup).waitEmptyQueue();
+
+        RenamePage renamePage = setup.gotoPage(source).rename();
+        renamePage.getDocumentPicker().browseDocuments();
+        new DocumentPickerModal().selectDocument(targetSpaceName, "WebHome");
+        renamePage.clickRenameButton().waitUntilFinished();
+
+        // The page landed in the space that was selected in the tree, not in a space named after its escaped
+        // identifier (e.g. "Rename%20Space").
+        assertTrue(setup.pageExists(Arrays.asList(targetSpaceName, "MoveToSpaceWithWhiteSpace"), "WebHome"),
+            "The page was not moved to the [" + targetSpaceName + "] space.");
+        assertFalse(setup.pageExists(Arrays.asList("RenamePageIT", "MoveToSpaceWithWhiteSpace"), "WebHome"),
+            "The page is still in its original location.");
     }
 
     private static List<String> newSpaces(List<String> parentSpaces, String lastSpace)

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-docker/src/test/it/org/xwiki/index/test/ui/docker/DocumentTreeMacroIT.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-docker/src/test/it/org/xwiki/index/test/ui/docker/DocumentTreeMacroIT.java
@@ -22,6 +22,7 @@ package org.xwiki.index.test.ui.docker;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -51,6 +52,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @UITest
 class DocumentTreeMacroIT
 {
+    /**
+     * The HTML attributes that hold a tree node identifier.
+     */
+    private static final List<String> ID_ATTRIBUTE_NAMES = List.of("id", "aria-activedescendant", "aria-labelledby");
+
+    private static final Pattern WHITE_SPACE = Pattern.compile("\\s");
+
     @Test
     @Order(1)
     void sortDocumentsBy(TestUtils setup, TestReference testReference) throws Exception
@@ -475,6 +483,55 @@ class DocumentTreeMacroIT
         assertFalse(tree.hasNode(getNodeId(childrenSubEve2)));
         assertFalse(tree.hasNode(getNodeId(alice)));
         assertFalse(tree.hasNode(getNodeId(subAlice)));
+    }
+
+    /**
+     * Verify that the node identifiers rendered by the tree don't contain characters that are forbidden in an HTML
+     * identifier, and that the tree still resolves them back to the right entity reference when it talks to the server.
+     */
+    @Test
+    @Order(7)
+    void escapeNodeIds(TestUtils setup, TestReference testReference)
+    {
+        SpaceReference testSpaceReference = testReference.getLastSpaceReference();
+        DocumentReference parent = new DocumentReference("WebHome", new SpaceReference("A B", testSpaceReference));
+        DocumentReference child =
+            new DocumentReference("WebHome", new SpaceReference("C D", parent.getLastSpaceReference()));
+
+        setup.loginAsSuperAdmin();
+        // Clean up.
+        setup.deletePage(testReference, true);
+        createPage(setup, parent, "", "");
+        createPage(setup, child, "", "");
+
+        TreeElement tree = getDocumentTree(setup, testReference, true, Map.of("openTo", getNodeId(child)));
+
+        // The tree opened to the specified node, which means it was able to send the escaped node identifiers back to
+        // the server, unescaped, both to compute the path and to load the child nodes.
+        assertTrue(tree.hasNode(getNodeId(child)));
+        assertNodeLabels(tree.getNode(getNodeId(parent)).getChildren(), "C D");
+        assertEquals(List.of(getNodeId(child)), tree.getSelectedNodeIDs());
+
+        // None of the identifiers rendered by the tree contains white space, which is forbidden in an HTML identifier.
+        List<String> renderedIds = getRenderedIds(setup, testSpaceReference.getName());
+        assertTrue(renderedIds.contains(TreeElement.escapeNodeId(getNodeId(child))),
+            "The node with white space in its reference was not rendered: " + renderedIds);
+        renderedIds.forEach(renderedId -> assertFalse(WHITE_SPACE.matcher(renderedId).find(),
+            "The rendered identifier [" + renderedId + "] contains white space."));
+    }
+
+    /**
+     * @return the values of the attributes that hold a node identifier, collected from the tree with the given HTML
+     *         identifier and from all its descendants
+     */
+    @SuppressWarnings("unchecked")
+    private List<String> getRenderedIds(TestUtils setup, String treeId)
+    {
+        return (List<String>) setup.getDriver().executeScript("const attributeNames = arguments[0];"
+            + "const tree = document.getElementById(arguments[1]);"
+            + "return [tree, ...tree.querySelectorAll('*')]"
+            + "  .flatMap(element => attributeNames.map(name => element.getAttribute(name)))"
+            + "  .filter(value => value !== null);", ID_ATTRIBUTE_NAMES, treeId);
     }
 
     private ViewPage createPage(TestUtils setup, DocumentReference documentReference, String title, String content)

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/PanelsCode/NavigationConfigurationSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/PanelsCode/NavigationConfigurationSheet.xml
@@ -316,6 +316,7 @@ require([
   'xwiki-l10n!xwiki-panels-navigation-config-messages',
   'xwiki-meta',
   'jquery-ui',
+  'xwiki-tree',
   'xwiki-events-bridge'
 ], function($, l10n, xwikiMeta) {
   var getLocalDocumentReference = function(absoluteDocumentReference) {
@@ -366,7 +367,7 @@ require([
   var getNodeData = function(exclusion) {
     var documentReference = exclusion.data('reference');
     return {
-      id: 'document:' + documentReference,
+      id: $.fn.xtree.escapeNodeId('document:' + documentReference),
       text: exclusion.text(),
       children: exclusion.data('children') !== false,
       data: {
@@ -410,7 +411,7 @@ require([
   };
 
   var showOrCreateNode = function(tree, page) {
-    var node = tree.get_node('document:' + page.data('reference'));
+    var node = tree.get_node($.fn.xtree.escapeNodeId('document:' + page.data('reference')));
     if (node) {
       tree.show_node(node.id);
     } else {
@@ -477,7 +478,7 @@ require([
 
   var excludePagesFromDynamicFilter = function(pages, tree) {
     tree &amp;&amp; pages.find('.page').not('.included').each(function() {
-      tree.hide_node('document:' + $(this).data('reference'));
+      tree.hide_node($.fn.xtree.escapeNodeId('document:' + $(this).data('reference')));
     });
   };
 

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-test-pageobjects/src/main/java/org/xwiki/tree/test/po/TreeElement.java
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-test-pageobjects/src/main/java/org/xwiki/tree/test/po/TreeElement.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.tree.test.po;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -37,6 +39,12 @@ import org.xwiki.test.ui.po.BaseElement;
  */
 public class TreeElement extends BaseElement
 {
+    /**
+     * The characters that {@code encodeURIComponent()} leaves unchanged.
+     */
+    private static final String UNRESERVED_CHARACTERS =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.!~*'()";
+
     /**
      * The element that represents the tree.
      */
@@ -58,7 +66,7 @@ public class TreeElement extends BaseElement
      */
     public TreeNodeElement getNode(String nodeId)
     {
-        return new TreeNodeElement(this.element, By.id(nodeId));
+        return new TreeNodeElement(this.element, By.id(escapeNodeId(nodeId)));
     }
 
     /**
@@ -67,12 +75,10 @@ public class TreeElement extends BaseElement
      */
     public boolean hasNode(String nodeId)
     {
-        // We cannot use By.id(nodeId) because findElements returns 0 elements if the id contains special characters
-        // such as backslash (which is used to escape special characters in an entity reference which the node id can
-        // be). Such an element id is technically invalid but the browsers are handling it fine.
-        // See https://code.google.com/p/selenium/issues/detail?id=8173
+        // We cannot use By.id() because findElements returns 0 elements if the id contains special characters that
+        // Selenium doesn't escape properly. See https://code.google.com/p/selenium/issues/detail?id=8173
         return !getDriver().findElementsWithoutWaiting(this.element,
-            By.xpath(".//*[@id = '" + nodeId + "']")).isEmpty();
+            By.xpath(".//*[@id = '" + escapeNodeId(nodeId) + "']")).isEmpty();
     }
 
     /**
@@ -133,7 +139,7 @@ public class TreeElement extends BaseElement
     public TreeElement waitForNodeSelected(String nodeId)
     {
         String selectedNodeXPath =
-            String.format(".//*[@id = '%s_anchor' and contains(@class, 'jstree-clicked')]", nodeId);
+            String.format(".//*[@id = '%s_anchor' and contains(@class, 'jstree-clicked')]", escapeNodeId(nodeId));
         getDriver().waitUntilElementIsVisible(this.element, By.xpath(selectedNodeXPath));
         return this;
     }
@@ -149,8 +155,9 @@ public class TreeElement extends BaseElement
     @SuppressWarnings("unchecked")
     public List<String> getSelectedNodeIDs()
     {
-        return (List<String>) getDriver()
+        List<String> selectedNodeIds = (List<String>) getDriver()
             .executeScript("return jQuery.jstree.reference(jQuery(arguments[0])).get_selected()", this.element);
+        return selectedNodeIds.stream().map(TreeElement::unescapeNodeId).toList();
     }
 
     /**
@@ -163,7 +170,48 @@ public class TreeElement extends BaseElement
                 + "{flat:true, no_data:true, no_state:true})" + ".map(function(element) {return element.id});",
             this.element);
 
-        return Arrays.asList(selectedNodeIDs);
+        return Arrays.stream(selectedNodeIDs).map(TreeElement::unescapeNodeId).toList();
+    }
+
+    /**
+     * Percent-encodes the given node identifier the same way the tree widget does, so that it matches the {@code id}
+     * attribute of the corresponding HTML element. Page objects that locate a tree node by its identifier need this
+     * because entity references can contain characters that are forbidden in an HTML identifier, such as white space.
+     *
+     * @param nodeId the node identifier, holding the entity reference as is
+     * @return the escaped node identifier
+     * @since 18.8.0RC1
+     */
+    public static String escapeNodeId(String nodeId)
+    {
+        if (nodeId == null) {
+            return null;
+        }
+        StringBuilder result = new StringBuilder();
+        for (byte nodeIdByte : nodeId.getBytes(StandardCharsets.UTF_8)) {
+            char character = (char) (nodeIdByte & 0xFF);
+            if (UNRESERVED_CHARACTERS.indexOf(character) >= 0) {
+                result.append(character);
+            } else {
+                result.append(String.format("%%%02X", nodeIdByte & 0xFF));
+            }
+        }
+        // The colon and the at sign separate the components of a node identifier and are both valid in an HTML
+        // identifier, so the tree widget leaves them as is, in order to keep the escaped node identifiers readable.
+        return result.toString().replace("%3A", ":").replace("%40", "@");
+    }
+
+    /**
+     * Reverts {@link #escapeNodeId(String)}, turning a node identifier read from the tree back into the entity
+     * reference it holds.
+     *
+     * @param nodeId the escaped node identifier
+     * @return the node identifier holding the entity reference as is
+     * @since 18.8.0RC1
+     */
+    public static String unescapeNodeId(String nodeId)
+    {
+        return nodeId == null ? null : URLDecoder.decode(nodeId, StandardCharsets.UTF_8);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
@@ -48,6 +48,32 @@ define([
     };
   }
 
+  // jsTree node identifiers are used, without any escaping, both as the HTML id attribute of the rendered nodes and
+  // as the value sent back to the server (e.g. to look up children, to move or copy a node to a new parent, etc.).
+  // Entity references can contain spaces, but HTML ids must not contain any whitespace, so we escape the ids of the
+  // nodes received from the server before handing them to jsTree, and we unescape them back before sending them to
+  // the server, in order to keep both usages happy. Other scripts that read a node id from the tree's public API
+  // (e.g. get_selected()) and need the original, unescaped, entity reference should use $.fn.xtree.unescapeNodeId().
+  var escapeId = function(id) {
+    return String(id).replaceAll('%', '%25').replaceAll(' ', '%20');
+  };
+
+  var unescapeId = function(id) {
+    return String(id).replaceAll('%20', ' ').replaceAll('%25', '%');
+  };
+
+  // Escapes the id of the given node, and of all its nested children (in case the node was received with its
+  // children already inlined), so that the id can be safely used as an HTML id attribute.
+  var escapeNodeId = function(node) {
+    if (node && typeof node.id === 'string') {
+      node.id = escapeId(node.id);
+    }
+    if (node && Array.isArray(node.children)) {
+      node.children.forEach(escapeNodeId);
+    }
+    return node;
+  };
+
   var formToken = $('meta[name=form_token]').attr('content');
 
   var getNodeTypes = function(nodes) {
@@ -116,11 +142,11 @@ define([
       childrenURL = this.element.attr('data-url');
       parameters = $.extend({
         data: 'children',
-        id: node.id
+        id: unescapeId(node.id)
       }, parameters);
     }
     if (childrenURL) {
-      post(childrenURL, parameters).then(callback, () => callback([]));
+      post(childrenURL, parameters).then(children => children.map(escapeNodeId)).then(callback, () => callback([]));
     } else {
       callback([]);
     }
@@ -363,7 +389,8 @@ define([
       // We need to retrieve the node path from the server.
       var url = this.element.attr('data-url');
       if (url) {
-        return Promise.resolve(post(url, {data: 'path', 'id': nodeId}));
+        return Promise.resolve(
+          post(url, {data: 'path', 'id': unescapeId(nodeId)}).then(nodes => nodes.map(escapeNodeId)));
       } else {
         return Promise.reject();
       }
@@ -519,7 +546,11 @@ define([
       if (!url) {
         url = this.element.attr('data-url');
         params.action = action;
-        params.id = node.id;
+        params.id = unescapeId(node.id);
+      }
+      if (params.parent) {
+        // The parent is specified, as a node id, when moving or copying a node to a new parent.
+        params.parent = unescapeId(params.parent);
       }
       params.form_token = formToken;
       var promise = this.jobRunner.run(url, params);
@@ -758,6 +789,16 @@ define([
       $.extend($.jstree.reference(this), customTreeAPI, {jobRunner: createJobRunner(this)});
     });
   };
+
+  // Turns a node id read from the tree's public API (e.g. get_selected()) back into the original, unescaped, entity
+  // reference. Node ids are escaped so they can be safely used as HTML id attributes (see #escapeNodeId), so scripts
+  // that need to resolve a node id into an entity reference, rather than pass it back to the tree itself, must
+  // unescape it first.
+  $.fn.xtree.unescapeNodeId = unescapeId;
+
+  // Escapes the id of a node built outside of this module (e.g. the response of a job triggered through #execute)
+  // before inserting it into the tree, so that the tree's ids stay consistently escaped.
+  $.fn.xtree.escapeNodeId = escapeNodeId;
 
   return $;
 });

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
@@ -48,28 +48,44 @@ define([
     };
   }
 
-  // jsTree node identifiers are used, without any escaping, both as the HTML id attribute of the rendered nodes and
-  // as the value sent back to the server (e.g. to look up children, to move or copy a node to a new parent, etc.).
-  // Entity references can contain spaces, but HTML ids must not contain any whitespace, so we escape the ids of the
-  // nodes received from the server before handing them to jsTree, and we unescape them back before sending them to
-  // the server, in order to keep both usages happy. Other scripts that read a node id from the tree's public API
-  // (e.g. get_selected()) and need the original, unescaped, entity reference should use $.fn.xtree.unescapeNodeId().
-  var escapeId = function(id) {
-    return String(id).replaceAll('%', '%25').replaceAll(' ', '%20');
+  // jsTree node identifiers are used, without any escaping, both as the HTML id attribute of the rendered nodes and as
+  // the value sent back to the server (e.g. to look up children, to move or copy a node to a new parent, etc.). Entity
+  // references can contain characters that are forbidden in an HTML id, such as white space, so the tree escapes every
+  // node id that enters its model and unescapes it back on the way out, i.e. when the id is sent to the server.
+  //
+  // The escaped form is the percent-encoding of the node id, except for the colon and the at sign, which separate the
+  // components of a node id (e.g. "document:xwiki:Some Space.Some Page") and are both valid in an HTML id, so they are
+  // left as is in order to keep the escaped id readable. Leaving them as is doesn't break the round trip because their
+  // encoded form is produced only for these two characters, so both forms mean the same thing to decodeURIComponent().
+  const escapeNodeId = function(nodeId) {
+    return convertNodeId(nodeId, id => encodeURIComponent(id).replaceAll('%3A', ':').replaceAll('%40', '@'));
   };
 
-  var unescapeId = function(id) {
-    return String(id).replaceAll('%20', ' ').replaceAll('%25', '%');
+  // Turns a node id read from the tree's model (e.g. through get_selected()) back into the original entity reference.
+  // Scripts that need to resolve a node id into an entity reference, rather than pass it back to the tree, must
+  // unescape it first.
+  const unescapeNodeId = function(nodeId) {
+    return convertNodeId(nodeId, decodeURIComponent);
   };
 
-  // Escapes the id of the given node, and of all its nested children (in case the node was received with its
-  // children already inlined), so that the id can be safely used as an HTML id attribute.
-  var escapeNodeId = function(node) {
-    if (node && typeof node.id === 'string') {
-      node.id = escapeId(node.id);
-    }
-    if (node && Array.isArray(node.children)) {
-      node.children.forEach(escapeNodeId);
+  const convertNodeId = function(nodeId, convert) {
+    // The root node id is a jsTree internal that is neither rendered nor sent to the server.
+    return typeof nodeId === 'string' && nodeId !== $.jstree.root ? convert(nodeId) : nodeId;
+  };
+
+  // Escapes the id and the parent id of the given node definition, and of all its nested children, in case the node
+  // was received with its children already inlined.
+  const escapeNode = function(node) {
+    if (node && typeof node === 'object') {
+      if (typeof node.id === 'string') {
+        node.id = escapeNodeId(node.id);
+      }
+      if (typeof node.parent === 'string') {
+        node.parent = escapeNodeId(node.parent);
+      }
+      if (Array.isArray(node.children)) {
+        node.children.forEach(escapeNode);
+      }
     }
     return node;
   };
@@ -142,11 +158,11 @@ define([
       childrenURL = this.element.attr('data-url');
       parameters = $.extend({
         data: 'children',
-        id: unescapeId(node.id)
+        id: unescapeNodeId(node.id)
       }, parameters);
     }
     if (childrenURL) {
-      post(childrenURL, parameters).then(children => children.map(escapeNodeId)).then(callback, () => callback([]));
+      post(childrenURL, parameters).then(children => children.map(escapeNode)).then(callback, () => callback([]));
     } else {
       callback([]);
     }
@@ -390,7 +406,7 @@ define([
       var url = this.element.attr('data-url');
       if (url) {
         return Promise.resolve(
-          post(url, {data: 'path', 'id': unescapeId(nodeId)}).then(nodes => nodes.map(escapeNodeId)));
+          post(url, {data: 'path', 'id': unescapeNodeId(nodeId)}).then(nodes => nodes.map(escapeNode)));
       } else {
         return Promise.reject();
       }
@@ -513,7 +529,9 @@ define([
     if (element.attr('data-url')) {
       defaultParams.core.data = getChildren;
     } else if (element.attr('data-json')) {
-      defaultParams.core.data = element.data('json');
+      // The tree data is specified inline, using the entity references as node ids, so it needs to be escaped.
+      const json = element.data('json');
+      defaultParams.core.data = Array.isArray(json) ? json.map(escapeNode) : escapeNode(json);
     }
     return $.extend(true, defaultParams, element.data('config'));
   };
@@ -524,6 +542,9 @@ define([
       if (!isArray) {
         nodeIds = [nodeIds];
       }
+      // The node ids are specified by the caller, using the entity reference, so they need to be escaped before they
+      // can be matched against the ids from the tree model.
+      nodeIds = nodeIds.map(escapeNodeId);
       // Select the nodes if no callback is provided.
       callback = callback || this.select_node.bind(this);
       // The tree is often expanded to show a specific node when the page loads (i.e. right after the tree is ready) and
@@ -546,11 +567,11 @@ define([
       if (!url) {
         url = this.element.attr('data-url');
         params.action = action;
-        params.id = unescapeId(node.id);
+        params.id = unescapeNodeId(node.id);
       }
       if (params.parent) {
         // The parent is specified, as a node id, when moving or copying a node to a new parent.
-        params.parent = unescapeId(params.parent);
+        params.parent = unescapeNodeId(params.parent);
       }
       params.form_token = formToken;
       var promise = this.jobRunner.run(url, params);
@@ -763,7 +784,7 @@ define([
     }).on('changed.jstree', function(event, data) {
       if (data.instance.settings.xwiki && typeof data.instance.settings.xwiki.fieldName !== 'undefined') {
         var fieldName = data.instance.settings.xwiki.fieldName;
-        var fieldValue = data.selected.join('|');
+        var fieldValue = data.selected.map(unescapeNodeId).join('|');
         $('input[type="hidden"]').filter(function() {
           return $(this).attr('name') === fieldName;
         }).val(fieldValue);
@@ -790,15 +811,10 @@ define([
     });
   };
 
-  // Turns a node id read from the tree's public API (e.g. get_selected()) back into the original, unescaped, entity
-  // reference. Node ids are escaped so they can be safely used as HTML id attributes (see #escapeNodeId), so scripts
-  // that need to resolve a node id into an entity reference, rather than pass it back to the tree itself, must
-  // unescape it first.
-  $.fn.xtree.unescapeNodeId = unescapeId;
-
-  // Escapes the id of a node built outside of this module (e.g. the response of a job triggered through #execute)
-  // before inserting it into the tree, so that the tree's ids stay consistently escaped.
+  // The bridge between the entity reference based node ids used by the tree data source and the escaped node ids used
+  // by the tree model and by the rendered HTML id attributes.
   $.fn.xtree.escapeNodeId = escapeNodeId;
+  $.fn.xtree.unescapeNodeId = unescapeNodeId;
 
   return $;
 });

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/exporter/exporter.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/exporter/exporter.js
@@ -567,7 +567,8 @@ require(['jquery'], function ($) {
     if (config.excludeNestedPagesByDefault) {
       return new Promise((resolve, reject) => {
         const tree = exportTreeModal.find('.export-tree').jstree(true);
-        const currentPageNodeId = 'document:' + XWiki.Model.serialize(XWiki.currentDocument.documentReference);
+        const currentPageNodeId = $.fn.xtree.escapeNodeId(
+          'document:' + XWiki.Model.serialize(XWiki.currentDocument.documentReference));
         tree.open_node(currentPageNodeId, () => {
           tree.select_node(currentPageNodeId);
           tree.deselectChildNodes(currentPageNodeId);

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/job/question/ExtensionBreakingQuestion.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/job/question/ExtensionBreakingQuestion.js
@@ -44,9 +44,9 @@ require(['jquery', 'xwiki-meta', 'xwiki-tree'], function($, xm) {
         for (var i = 0; i < selectedNodes.length; ++i) {
           var node = selectedNodes[i];
           if (node.data.type == 'extension') {
-            answerProperties.selectedExtensions.push(node.id);
+            answerProperties.selectedExtensions.push($.fn.xtree.unescapeNodeId(node.id));
           } else if (node.data.type == 'page') {
-            answerProperties.selectedDocuments.push(node.id);
+            answerProperties.selectedDocuments.push($.fn.xtree.unescapeNodeId(node.id));
           } else if (node.id == 'freePages') {
             // For free pages, we can rely on the state of the "freePage" node
             answerProperties.selectAllFreePages = true;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/job/question/XClassBreakingQuestion.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/job/question/XClassBreakingQuestion.js
@@ -46,7 +46,7 @@ require(['jquery', 'xwiki-meta', 'xwiki-tree'], function($, xm) {
             // For free pages, we can rely on the state of the "freePage" node
             answerProperties.selectAllFreePages = true;
           } else {
-            answerProperties.selectedDocuments.push(node.id);
+            answerProperties.selectedDocuments.push($.fn.xtree.unescapeNodeId(node.id));
           }
         }
 

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.js
@@ -87,7 +87,7 @@ require(['xwiki-tree'], function($) {
 });
 
 // Document Tree Picker
-require(['jquery', 'xwiki-meta'], function($, xm) {
+require(['jquery', 'xwiki-meta', 'xwiki-tree'], function($, xm) {
   $('.location-picker').each(function() {
     var picker = $(this);
     // The wiki field can be either a select (drop down) or an input (text or hidden).
@@ -109,7 +109,7 @@ require(['jquery', 'xwiki-meta'], function($, xm) {
     });
 
     picker.find('.modal').on('xwiki:locationTreePicker:select', function(event, data) {
-      var selectedNodeId = data.tree.get_selected()[0];
+      var selectedNodeId = $.fn.xtree.unescapeNodeId(data.tree.get_selected()[0]);
       var separatorIndex = selectedNodeId.indexOf(':');
       var nodeType = selectedNodeId.substr(0, separatorIndex);
       var nodeStringReference = selectedNodeId.substr(separatorIndex + 1);

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-ui/src/main/resources/XWiki/WYSIWYG/ImageSelectorServiceUIX/DocumentTree.xml
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-ui/src/main/resources/XWiki/WYSIWYG/ImageSelectorServiceUIX/DocumentTree.xml
@@ -127,7 +127,8 @@
     <property>
       <code>require(['jquery', 'xwiki-wysiwyg-image-selector'], function ($, imageSelector) {
   function getSelected(instance) {
-    return instance.get_selected(false)[0];
+    var selected = instance.get_selected(false)[0];
+    return selected &amp;&amp; $.fn.xtree.unescapeNodeId(selected);
   }
 
   function validateSelection(instance) {

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-webjar/src/main/webjar/resource/entityResourcePicker.js
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-webjar/src/main/webjar/resource/entityResourcePicker.js
@@ -98,12 +98,17 @@ define('xwiki-wysiwyg-entity-resource-picker', [
         }).on('xtree.runJob', function (event, promise, action, node, params) {
           if (action === 'create') {
             promise.then(function (promiseData) {
-              if (createdNodes[params.id] === undefined) {
-                createdNodes[params.id] = {};
+              // The parent node id is already escaped (it comes from the tree's own model), but params.id was
+              // unescaped by #execute() before being sent to the server, so we use the parent node id instead in
+              // order to match what #refresh_node.jstree reads later from data.node.id.
+              if (createdNodes[node.id] === undefined) {
+                createdNodes[node.id] = {};
               }
               if (promiseData instanceof Array) {
-                let newNode = promiseData[0];
-                createdNodes[params.id][newNode.id] = newNode;
+                // The job response carries the raw, unescaped, id of the newly created node, so we need to escape it
+                // before it can be inserted into the tree.
+                let newNode = $.fn.xtree.escapeNodeId(promiseData[0]);
+                createdNodes[node.id][newNode.id] = newNode;
               }
             });
           }
@@ -159,9 +164,10 @@ define('xwiki-wysiwyg-entity-resource-picker', [
   };
 
   var getEntityReference = function(node) {
-    var separatorIndex = node.id.indexOf(':');
-    var nodeType = node.id.substr(0, separatorIndex);
-    var nodeStringReference = node.id.substr(separatorIndex + 1);
+    var nodeId = $.fn.xtree.unescapeNodeId(node.id);
+    var separatorIndex = nodeId.indexOf(':');
+    var nodeType = nodeId.substr(0, separatorIndex);
+    var nodeStringReference = nodeId.substr(separatorIndex + 1);
     return XWiki.Model.resolve(nodeStringReference, XWiki.EntityType.byName(nodeType));
   };
 

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-webjar/src/main/webjar/resource/entityResourcePicker.js
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-webjar/src/main/webjar/resource/entityResourcePicker.js
@@ -98,16 +98,17 @@ define('xwiki-wysiwyg-entity-resource-picker', [
         }).on('xtree.runJob', function (event, promise, action, node, params) {
           if (action === 'create') {
             promise.then(function (promiseData) {
-              // The parent node id is already escaped (it comes from the tree's own model), but params.id was
-              // unescaped by #execute() before being sent to the server, so we use the parent node id instead in
-              // order to match what #refresh_node.jstree reads later from data.node.id.
+              // We index the created nodes by the id of their parent node, as it appears in the tree model, because
+              // that's what #refresh_node.jstree reads later from data.node.id. Note that params.id can't be used
+              // because #execute() unescaped it before sending it to the server.
               if (createdNodes[node.id] === undefined) {
                 createdNodes[node.id] = {};
               }
               if (promiseData instanceof Array) {
-                // The job response carries the raw, unescaped, id of the newly created node, so we need to escape it
-                // before it can be inserted into the tree.
-                let newNode = $.fn.xtree.escapeNodeId(promiseData[0]);
+                // The job response carries the unescaped id of the newly created node, so we need to escape it before
+                // the node can be inserted into the tree.
+                let newNode = promiseData[0];
+                newNode.id = $.fn.xtree.escapeNodeId(newNode.id);
                 createdNodes[node.id][newNode.id] = newNode;
               }
             });


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22154

# Changes

## Description

* Escape jsTree node ids (percent-encode spaces/`%`) before handing them to jsTree, and unescape them back before sending them to the server, so that the rendered `id`/anchor `id`/`aria-activedescendant` attributes never contain literal whitespace.
* Expose `$.fn.xtree.unescapeNodeId()` and `$.fn.xtree.escapeNodeId()` so other scripts can convert between the tree's escaped node id and the raw entity reference.
* Update every other script that reads a raw node id off the tree's public API (`get_selected()`, `data.node.id`) and resolves it into an entity reference, to unescape it first: the location picker (page rename/move), the attachment move dialog, the WYSIWYG entity resource picker, and the extension/class "breaking pages" delete-confirmation dialogs.

## Clarifications

* This is XWIKI-18356 reopened: that original fix (#3015) only escaped/unescaped the id in `getChildren`, which missed the "move to a new parent" case and broke XWIKI-22151 (moving a page into a space with a space in its name created a literal `A%20B` space). It was reverted.
* This time the escape/unescape is centralized in `tree.js` for every id the tree itself sends to or receives from the server (children, path, the acted-on node **and** the move/copy destination parent), and every other consumer that independently parses a tree node id back into an entity reference has been updated to unescape it first, so the same class of regression shouldn't resurface.
* I found the other consumers by searching for scripts calling `get_selected()`/reading `data.node.id` and checking whether they parse the id into an entity reference (risky) or just use it as an opaque token / literal comparison (safe, left untouched — e.g. `exporter.js` and the `data.id` field already carry the bare, unprefixed, unescaped reference and are unaffected).

**Compatibility note:** the jsTree node `id` (`type:reference`) is not a documented/`@Unstable`-tagged API and isn't covered by Revapi (it's JS-only), but it is de facto relied on: this PR itself had to update 6 in-repo scripts that parse it as an entity reference. Any xwiki-contrib extension or wiki-page script doing the same thing (reading `get_selected()`/`data.node.id` and parsing it) would need the same one-line fix, now available as `$.fn.xtree.unescapeNodeId()`. I couldn't find a way to avoid this: jsTree hard-codes the rendered `id` attribute to the node's model id and resolves clicks back to a model node by reading that same DOM attribute, so a valid (whitespace-free) HTML id and a raw, unescaped model id are mutually exclusive with jsTree's current internals — I verified this by prototyping the DOM-only alternative and it broke click-to-select. The original XWIKI-18356 PR (#3015) took the same position on this id not being a sanctioned front-end API; happy to raise it on the dev list instead if reviewers disagree.

# Screenshots & Video

No visible UI change; the fix only affects the `id`/`aria-activedescendant` attribute values (now percent-escaped instead of containing raw whitespace) and internal id plumbing.

# Executed Tests

* `mvn clean install -B -ntp -Plegacy -pl xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar,xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api,xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-webjar` — builds clean, jshint/Checkstyle/Revapi pass.
* `mvn clean install -B -ntp -Plegacy -pl xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war` — builds clean, jshint/Checkstyle/Revapi pass.
* Manually verified on a local 18.7.0-SNAPSHOT instance (hot-swapped jars/resources):
  * The navigation tree's rendered `id`, anchor `id` and `aria-activedescendant` for a page/space with a space in the name are all percent-escaped, no literal whitespace.
  * Moved a page into a space literally named `A B` via the rename/move tree picker: the destination breadcrumb correctly shows "A B" and the page actually lands in the `A B` space (verified via REST), not in a corrupted `A%20B` space — i.e. the XWIKI-22151 regression does not reproduce.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * No backport. This changes how jsTree node ids are represented across several UI flows (navigation tree, rename/move, attachment move, WYSIWYG link/image picker, extension/class delete confirmation), so it should soak on master first.

