### PR TITLE
XWIKI-24712: Document pickers don't keep the full width anymore after selecting a document in some macros

### DIFF
--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-webjar/src/main/webjar/macro/macroWizard.css
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-webjar/src/main/webjar/macro/macroWizard.css
@@ -174,3 +174,8 @@ ul.macro-list .macro-extension {
 .macro-tabs {
   margin-bottom: 0.5em;
 }
+
+/* Ensure that a Tom Select field is not resized after setting a value. */
+.macro-parameter-field .ts-wrapper.full {
+  float: none;
+}


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

  * https://jira.xwiki.org/browse/XWIKI-24712

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

  * Ensure to invalidate the float: left rule that breaks the width rule in macro configuration modal

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

The root problem is that the field is automatically resized in the macro configuration dialog after being filled, originally because of the `width: unset` rule located in [xwiki.selectize.css](https://github.com/xwiki/xwiki-platform/blob/master/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.css#L2-L4).

Now apparently this rule don't led to the same problem in other parts of XS because a `float: left` rule provided by bootstrap in the input-group elements [defined here](https://github.com/xwiki/xwiki-platform/blob/master/xwiki-platform-core/xwiki-platform-bootstrap/src/main/node/less/input-groups.less#L27-L30) is not enabled: for some reason that rule is enabled in the modal.

So there is at least 3 possible ways for solving this: 
  1. to remove the `width: unset` rule, but AFAIU it's provided because of possible conflicts with the rules provided in grid.less that might change the width globally for .full, so I guess we want to keep it
  2. to remove the `float: left` rule provided by bootstrap knowing that according to the comment it's only there to fix a problem with IE9 that we don't support. That being said, this rule is there for a long time and I'm a bit afraid of the side effects since we use those classes a lot
  3. to invalidate the `float: left` rule in the specific case of macro configuration dialog: it's the solution I chose here. It's probably far from being perfect as I can imagine we'll find the same problem in other parts of XWiki, but it's the less dangerous solution IMO. 

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 18.4.x
  * 18.7.x