### PR TITLE
XWIKI-23771: AWM: Numeric field accepts invalid characters, causing server error on edit

### DIFF
--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/NumberClassFieldIT.java
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/NumberClassFieldIT.java
@@ -66,7 +66,7 @@ class NumberClassFieldIT
     /**
      * A decimal value like "3.5" is a valid HTML5 number but mismatches the {@code step="1"} constraint of the
      * default {@code long} type, so the browser must mark the field invalid. Both signs are checked because the
-     * step check is evaluated relative to the {@code min} attribute, which makes it sensitive to the sign.
+     * field has no {@code min} attribute, so the step check is evaluated relative to a base of 0.
      */
     @Test
     void browserRejectsDecimalInput(TestReference testReference)

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/NumberClassFieldIT.java
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/NumberClassFieldIT.java
@@ -19,11 +19,13 @@
  */
 package org.xwiki.appwithinminutes.test.ui;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.xwiki.appwithinminutes.test.po.ApplicationClassEditPage;
 import org.xwiki.appwithinminutes.test.po.EntryEditPage;
 import org.xwiki.test.docker.junit5.TestReference;
 import org.xwiki.test.docker.junit5.UITest;
+import org.xwiki.test.ui.TestUtils;
 import org.xwiki.xclass.test.po.ClassSheetPage;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -47,6 +49,13 @@ class NumberClassFieldIT
     private static final String FIELD_NAME = "number1";
 
     private static final String INVALID_FORMAT_MESSAGE = "is not a valid number of type \"long\"";
+
+    @BeforeEach
+    void setUp(TestUtils setup, TestReference testReference)
+    {
+        setup.loginAsSuperAdmin();
+        setup.deleteSpace(testReference.getLastSpaceReference());
+    }
 
     /**
      * Checks the successive validation layers of a Number field of the default {@code long} type, on a single
@@ -89,7 +98,7 @@ class NumberClassFieldIT
 
     private EntryEditPage addNumberFieldAndGoToEntry(TestReference testReference)
     {
-        ApplicationClassEditPage editor = goToEditor(testReference);
+        ApplicationClassEditPage editor = goToEditor(testReference.getLastSpaceReference());
         editor.addField("Number");
         editor.clickSaveAndView();
         new ClassSheetPage().clickTemplateLink().edit();

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/NumberClassFieldIT.java
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/NumberClassFieldIT.java
@@ -63,16 +63,22 @@ class NumberClassFieldIT
 
     /**
      * A value like "99999999999999999999" is a valid HTML5 number but overflows the default {@code long} type, so
-     * the {@code max} constraint set on the input must reject it before the entry can be saved.
+     * the {@code max} constraint set on the input must reject it before the entry can be saved. A decimal value
+     * like "3.5" is also a valid HTML5 number but mismatches the {@code step="1"} constraint of the default
+     * {@code long} type, so it must be rejected too, regardless of the sign of the {@code min} attribute.
      */
     @Test
-    void browserRejectsOutOfRangeInput(TestReference testReference)
+    void browserRejectsOutOfRangeAndDecimalInput(TestReference testReference)
     {
         EntryEditPage entryEditPage = addNumberFieldAndGoToEntry(testReference);
 
         entryEditPage.setValue(FIELD_NAME, "99999999999999999999");
 
         assertFalse(entryEditPage.isFieldValid(FIELD_NAME), "The out-of-range value was accepted as valid");
+
+        entryEditPage.setValue(FIELD_NAME, "3.5");
+
+        assertFalse(entryEditPage.isFieldValid(FIELD_NAME), "The decimal value was accepted as valid");
     }
 
     private EntryEditPage addNumberFieldAndGoToEntry(TestReference testReference)

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/NumberClassFieldIT.java
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/NumberClassFieldIT.java
@@ -65,11 +65,15 @@ class NumberClassFieldIT
 
     /**
      * A decimal value like "3.5" is a valid HTML5 number but mismatches the {@code step="1"} constraint of the
-     * default {@code long} type, so the browser must mark the field invalid. Both signs are checked because the
-     * field has no {@code min} attribute, so the step check is evaluated relative to a base of 0.
+     * default {@code long} type, so the browser must mark the field invalid. Both signs are checked since the
+     * field has no {@code min} attribute, so the step check is evaluated relative to a base of 0. A value like
+     * "99999999999999999999" is a valid HTML5 number that overflows the default {@code long} type. The browser
+     * can't be asked to catch it, since no {@code min}/{@code max} can express the {@code long} range without
+     * disabling the step check, so it reaches the server and must be reported with a friendly message rather
+     * than a generic error.
      */
     @Test
-    void browserRejectsDecimalInput(TestReference testReference)
+    void browserRejectsDecimalAndServerRejectsOutOfRangeValue(TestReference testReference)
     {
         EntryEditPage entryEditPage = addNumberFieldAndGoToEntry(testReference);
 
@@ -80,18 +84,6 @@ class NumberClassFieldIT
         entryEditPage.setValue(FIELD_NAME, "-3.5");
 
         assertFalse(entryEditPage.isFieldValid(FIELD_NAME), "The negative decimal value was accepted as valid");
-    }
-
-    /**
-     * A value like "99999999999999999999" is a valid HTML5 number that overflows the default {@code long} type.
-     * The browser can't be asked to catch it, since no {@code min}/{@code max} can express the {@code long} range
-     * without disabling the step check, so it reaches the server and must be reported with a friendly message
-     * rather than a generic error.
-     */
-    @Test
-    void saveShowsFriendlyErrorForOutOfRangeValue(TestReference testReference)
-    {
-        EntryEditPage entryEditPage = addNumberFieldAndGoToEntry(testReference);
 
         entryEditPage.setValue(FIELD_NAME, "42");
         entryEditPage.clickSaveAndContinue();

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/NumberClassFieldIT.java
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/NumberClassFieldIT.java
@@ -46,6 +46,8 @@ class NumberClassFieldIT
 {
     private static final String FIELD_NAME = "number1";
 
+    private static final String INVALID_FORMAT_MESSAGE = "is not a valid number of type \"long\"";
+
     /**
      * The Number field is rendered as an HTML5 number input, so the browser rejects non-numeric input, either by
      * refusing to insert it or by marking the field invalid, before the entry can be saved.
@@ -62,23 +64,42 @@ class NumberClassFieldIT
     }
 
     /**
-     * A value like "99999999999999999999" is a valid HTML5 number but overflows the default {@code long} type, so
-     * the {@code max} constraint set on the input must reject it before the entry can be saved. A decimal value
-     * like "3.5" is also a valid HTML5 number but mismatches the {@code step="1"} constraint of the default
-     * {@code long} type, so it must be rejected too, regardless of the sign of the {@code min} attribute.
+     * A decimal value like "3.5" is a valid HTML5 number but mismatches the {@code step="1"} constraint of the
+     * default {@code long} type, so the browser must mark the field invalid. Both signs are checked because the
+     * step check is evaluated relative to the {@code min} attribute, which makes it sensitive to the sign.
      */
     @Test
-    void browserRejectsOutOfRangeAndDecimalInput(TestReference testReference)
+    void browserRejectsDecimalInput(TestReference testReference)
     {
         EntryEditPage entryEditPage = addNumberFieldAndGoToEntry(testReference);
 
-        entryEditPage.setValue(FIELD_NAME, "99999999999999999999");
-
-        assertFalse(entryEditPage.isFieldValid(FIELD_NAME), "The out-of-range value was accepted as valid");
-
         entryEditPage.setValue(FIELD_NAME, "3.5");
 
-        assertFalse(entryEditPage.isFieldValid(FIELD_NAME), "The decimal value was accepted as valid");
+        assertFalse(entryEditPage.isFieldValid(FIELD_NAME), "The positive decimal value was accepted as valid");
+
+        entryEditPage.setValue(FIELD_NAME, "-3.5");
+
+        assertFalse(entryEditPage.isFieldValid(FIELD_NAME), "The negative decimal value was accepted as valid");
+    }
+
+    /**
+     * A value like "99999999999999999999" is a valid HTML5 number that overflows the default {@code long} type.
+     * The browser can't be asked to catch it, since no {@code min}/{@code max} can express the {@code long} range
+     * without disabling the step check, so it reaches the server and must be reported with a friendly message
+     * rather than a generic error.
+     */
+    @Test
+    void saveShowsFriendlyErrorForOutOfRangeValue(TestReference testReference)
+    {
+        EntryEditPage entryEditPage = addNumberFieldAndGoToEntry(testReference);
+
+        entryEditPage.setValue(FIELD_NAME, "42");
+        entryEditPage.clickSaveAndContinue();
+
+        entryEditPage.setValue(FIELD_NAME, "99999999999999999999");
+        entryEditPage.clickSaveAndContinue(false);
+
+        entryEditPage.waitForNotificationErrorMessage(INVALID_FORMAT_MESSAGE);
     }
 
     private EntryEditPage addNumberFieldAndGoToEntry(TestReference testReference)

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/NumberClassFieldIT.java
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/NumberClassFieldIT.java
@@ -86,7 +86,8 @@ class NumberClassFieldIT
 
         assertFalse(entryEditPage.isFieldValid(FIELD_NAME), "The negative decimal value was accepted as valid");
 
-        // A value inside the long range still saves, now that the range is no longer expressed as min and max.
+        // Save a valid value first so that the overflowing value below is submitted while editing an existing
+        // entry, which is the case this issue is about.
         entryEditPage.setValue(FIELD_NAME, "42");
         entryEditPage.clickSaveAndContinue();
 

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/NumberClassFieldIT.java
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/NumberClassFieldIT.java
@@ -49,33 +49,25 @@ class NumberClassFieldIT
     private static final String INVALID_FORMAT_MESSAGE = "is not a valid number of type \"long\"";
 
     /**
-     * The Number field is rendered as an HTML5 number input, so the browser rejects non-numeric input, either by
-     * refusing to insert it or by marking the field invalid, before the entry can be saved.
+     * Checks the successive validation layers of a Number field of the default {@code long} type, on a single
+     * fixture. Non-numeric input is rejected by the browser, which renders the field as an HTML5 number input and
+     * either refuses to insert the value or marks the field invalid. A decimal value like "3.5" is a valid HTML5
+     * number but mismatches the {@code step="1"} constraint, so the browser must mark the field invalid; both
+     * signs are checked since the field has no {@code min} attribute, so the step check is evaluated relative to a
+     * base of 0. A value like "99999999999999999999" is a valid HTML5 number that overflows the {@code long} type.
+     * The browser can't be asked to catch it, since no {@code min}/{@code max} can express the {@code long} range
+     * without disabling the step check, so it reaches the server and must be reported with a friendly message
+     * rather than a generic error.
      */
     @Test
-    void browserRejectsInvalidInput(TestReference testReference)
+    void numberFieldValidation(TestReference testReference)
     {
         EntryEditPage entryEditPage = addNumberFieldAndGoToEntry(testReference);
 
         entryEditPage.setValue(FIELD_NAME, "aaa");
 
         assertFalse("aaa".equals(entryEditPage.getValue(FIELD_NAME)) && entryEditPage.isFieldValid(FIELD_NAME),
-            "The invalid value was kept and accepted as valid");
-    }
-
-    /**
-     * A decimal value like "3.5" is a valid HTML5 number but mismatches the {@code step="1"} constraint of the
-     * default {@code long} type, so the browser must mark the field invalid. Both signs are checked since the
-     * field has no {@code min} attribute, so the step check is evaluated relative to a base of 0. A value like
-     * "99999999999999999999" is a valid HTML5 number that overflows the default {@code long} type. The browser
-     * can't be asked to catch it, since no {@code min}/{@code max} can express the {@code long} range without
-     * disabling the step check, so it reaches the server and must be reported with a friendly message rather
-     * than a generic error.
-     */
-    @Test
-    void browserRejectsDecimalAndServerRejectsOutOfRangeValue(TestReference testReference)
-    {
-        EntryEditPage entryEditPage = addNumberFieldAndGoToEntry(testReference);
+            "The non-numeric value was kept and accepted as valid");
 
         entryEditPage.setValue(FIELD_NAME, "3.5");
 
@@ -85,6 +77,7 @@ class NumberClassFieldIT
 
         assertFalse(entryEditPage.isFieldValid(FIELD_NAME), "The negative decimal value was accepted as valid");
 
+        // A value inside the long range still saves, now that the range is no longer expressed as min and max.
         entryEditPage.setValue(FIELD_NAME, "42");
         entryEditPage.clickSaveAndContinue();
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/NumberClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/NumberClass.java
@@ -91,9 +91,8 @@ public class NumberClass extends PropertyClass
     private static final String MIN = "min";
     private static final String MAX = "max";
 
-    // The largest magnitude a double can still represent every integer of, used as a safe stand-in for the long
-    // type's real range in the min/max attributes.
-    private static final long SAFE_INTEGER_LIMIT = 1L << 53;
+    // A safe stand-in for the long type's real range, kept below 2^53 so Blink's step-mismatch check still runs.
+    private static final long SAFE_INTEGER_LIMIT = 1L << 52;
     private static final String DATA_VALIDATION_BAD_INPUT = "data-validation-bad-input";
     private static final String DATA_VALIDATION_STEP_MISMATCH = "data-validation-step-mismatch";
     private static final String DATA_VALIDATION_RANGE_OVERFLOW = "data-validation-range-overflow";
@@ -227,8 +226,6 @@ public class NumberClass extends PropertyClass
         input.setType(INPUT_TYPE_NUMBER);
         input.setName(prefix + name);
         input.setID(prefix + name);
-        // The "size" attribute is ignored on type="number" inputs, kept here only for API compatibility.
-        input.setSize(getSize());
         input.setDisabled(isDisabled());
 
         String ntype = getNumberType();

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/NumberClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/NumberClass.java
@@ -226,14 +226,17 @@ public class NumberClass extends PropertyClass
         input.setDisabled(isDisabled());
 
         String ntype = getNumberType();
-        String invalidFormatMessage = localizePlainOrKey("core.validation.number.message.invalidformat");
-        input.addAttribute(DATA_VALIDATION_BAD_INPUT, invalidFormatMessage);
-        input.addAttribute(DATA_VALIDATION_STEP_MISMATCH, invalidFormatMessage);
+        input.addAttribute(DATA_VALIDATION_BAD_INPUT,
+            localizePlainOrKey("core.validation.number.message.invalidformat"));
         if (TYPE_FLOAT.equals(ntype) || TYPE_DOUBLE.equals(ntype)) {
             // Without an explicit step, the HTML5 default (step=1) makes any decimal value a stepMismatch.
             input.addAttribute(STEP, STEP_ANY);
         } else {
             input.addAttribute(STEP, STEP_INTEGER);
+            // A step mismatch can only be a decimal value here, which is a valid number, so the message asks for a
+            // whole number rather than reporting an invalid one.
+            input.addAttribute(DATA_VALIDATION_STEP_MISMATCH,
+                localizePlainOrKey("core.validation.number.message.wholenumberrequired"));
             // Only the integer type gets a range. Browsers evaluate min and max in double arithmetic, so a min set at
             // the magnitude of the long range makes them skip the step check altogether, letting decimals through on
             // the default number type. Values outside the long range are reported by fromString instead.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/NumberClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/NumberClass.java
@@ -90,9 +90,6 @@ public class NumberClass extends PropertyClass
     private static final String STEP_INTEGER = "1";
     private static final String MIN = "min";
     private static final String MAX = "max";
-
-    // A safe stand-in for the long type's real range, kept below 2^53 so Blink's step-mismatch check still runs.
-    private static final long SAFE_INTEGER_LIMIT = 1L << 52;
     private static final String DATA_VALIDATION_BAD_INPUT = "data-validation-bad-input";
     private static final String DATA_VALIDATION_STEP_MISMATCH = "data-validation-step-mismatch";
     private static final String DATA_VALIDATION_RANGE_OVERFLOW = "data-validation-range-overflow";
@@ -237,20 +234,18 @@ public class NumberClass extends PropertyClass
             input.addAttribute(STEP, STEP_ANY);
         } else {
             input.addAttribute(STEP, STEP_INTEGER);
-            String min;
-            String max;
+            // Only the integer type gets a range. Browsers evaluate min and max in double arithmetic, so a min set at
+            // the magnitude of the long range makes them skip the step check altogether, letting decimals through on
+            // the default number type. Values outside the long range are reported by fromString instead.
             if (TYPE_INTEGER.equals(ntype)) {
-                min = String.valueOf(Integer.MIN_VALUE);
-                max = String.valueOf(Integer.MAX_VALUE);
-            } else {
-                min = String.valueOf(-SAFE_INTEGER_LIMIT);
-                max = String.valueOf(SAFE_INTEGER_LIMIT);
+                String min = String.valueOf(Integer.MIN_VALUE);
+                String max = String.valueOf(Integer.MAX_VALUE);
+                input.addAttribute(MIN, min);
+                input.addAttribute(MAX, max);
+                String outOfRangeMessage = localizePlainOrKey("core.validation.number.message.outofrange", min, max);
+                input.addAttribute(DATA_VALIDATION_RANGE_OVERFLOW, outOfRangeMessage);
+                input.addAttribute(DATA_VALIDATION_RANGE_UNDERFLOW, outOfRangeMessage);
             }
-            input.addAttribute(MIN, min);
-            input.addAttribute(MAX, max);
-            String outOfRangeMessage = localizePlainOrKey("core.validation.number.message.outofrange", min, max);
-            input.addAttribute(DATA_VALIDATION_RANGE_OVERFLOW, outOfRangeMessage);
-            input.addAttribute(DATA_VALIDATION_RANGE_UNDERFLOW, outOfRangeMessage);
         }
 
         buffer.append(input.toString());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -1739,6 +1739,7 @@ core.users.email_unchecked.saveComment=Email of the user marked as not verified
 ###Validation
 core.validation.number.message.invalidformat=Please enter a valid number.
 core.validation.number.message.outofrange=Please enter a number between {0} and {1}.
+core.validation.number.message.wholenumberrequired=Please enter a whole number.
 core.validation.required=(Required)
 core.validation.required.message=This field is required.
 core.validation.required.message.terminal=This field is required for terminal pages.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/NumberClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/NumberClassTest.java
@@ -117,7 +117,7 @@ class NumberClassTest
      */
     private static Stream<Arguments> numberTypes()
     {
-        long safeIntegerLimit = 1L << 53;
+        long safeIntegerLimit = 1L << 52;
         return Stream.of(
             Arguments.of(NumberClass.TYPE_INTEGER, "1", String.valueOf(Integer.MIN_VALUE),
                 String.valueOf(Integer.MAX_VALUE)),

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/NumberClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/NumberClassTest.java
@@ -139,6 +139,9 @@ class NumberClassTest
 
         when(this.contextualLocalizationManager.getTranslationPlain("core.validation.number.message.invalidformat"))
             .thenReturn("Please enter a valid number.");
+        when(this.contextualLocalizationManager
+            .getTranslationPlain("core.validation.number.message.wholenumberrequired"))
+            .thenReturn("Please enter a whole number.");
         if (expectedMin != null) {
             when(this.contextualLocalizationManager.getTranslationPlain("core.validation.number.message.outofrange",
                 expectedMin, expectedMax)).thenReturn("Out of range.");
@@ -151,7 +154,11 @@ class NumberClassTest
         assertTrue(html.contains("type='number'"), html);
         assertTrue(html.contains("step='" + expectedStep + "'"), html);
         assertTrue(html.contains("data-validation-bad-input='Please enter a valid number.'"), html);
-        assertTrue(html.contains("data-validation-step-mismatch='Please enter a valid number.'"), html);
+        if ("1".equals(expectedStep)) {
+            assertTrue(html.contains("data-validation-step-mismatch='Please enter a whole number.'"), html);
+        } else {
+            assertFalse(html.contains("data-validation-step-mismatch"), html);
+        }
         if (expectedMin != null) {
             assertTrue(html.contains("min='" + expectedMin + "'"), html);
             assertTrue(html.contains("max='" + expectedMax + "'"), html);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/NumberClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/NumberClassTest.java
@@ -117,12 +117,10 @@ class NumberClassTest
      */
     private static Stream<Arguments> numberTypes()
     {
-        long safeIntegerLimit = 1L << 52;
         return Stream.of(
             Arguments.of(NumberClass.TYPE_INTEGER, "1", String.valueOf(Integer.MIN_VALUE),
                 String.valueOf(Integer.MAX_VALUE)),
-            Arguments.of(NumberClass.TYPE_LONG, "1", String.valueOf(-safeIntegerLimit),
-                String.valueOf(safeIntegerLimit)),
+            Arguments.of(NumberClass.TYPE_LONG, "1", null, null),
             Arguments.of(NumberClass.TYPE_FLOAT, "any", null, null),
             Arguments.of(NumberClass.TYPE_DOUBLE, "any", null, null));
     }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-23771

# Changes

## Description

Follow-up to #5830, which shipped with a client-side validation hole on the default `long` number type.

* **Removed the `min`/`max` attributes for the `long` type**, along with the `SAFE_INTEGER_LIMIT` constant. Browsers evaluate `min`/`max` in IEEE-754 doubles, and Chromium's `StepRange::StepMismatch` skips the step check entirely once a typed value's distance from `min` exceeds `2^53`. Any clamp near that magnitude therefore disables the very check it was meant to coexist with, letting a value like `3.5` pass client-side validation and reach the server on the default number type. With `min` absent the step base falls back to `0` and `step="1"` is enforced correctly for every value and both signs, with no magnitude-sensitive edge. The `integer` type keeps its range: `Integer.MIN_VALUE`/`MAX_VALUE` are its real bounds and double precision holds at that magnitude.
* **Values outside the `long` range are now reported server-side.** `fromString()` already produces the localized `core.model.xclass.classProperty.error.invalidNumberFormat` message introduced by #5830, so an overflowing value gets a friendly error on save instead of a generic server error. A `min`/`max` pair cannot express the `long` range faithfully in double arithmetic anyway, so the server is the only place that can check it correctly.
* **Removed the `input.setSize(getSize())` call** in `displayEdit()`. `size` is non-conforming on `type="number"` inputs and was only ever emitted as dead markup. `getSize()`/`setSize()` are untouched, so the XClass property API is unchanged.
* **Reworked `NumberClassFieldIT`** so each layer is covered where it actually applies: `browserRejectsDecimalAndServerRejectsOutOfRangeValue` asserts that `3.5` and `-3.5` are marked invalid client-side on the default `long` type, then that `99999999999999999999` is rejected on save with the localized message. This replaces the old client-side out-of-range assertion, which no longer applies.
* **Updated `NumberClassTest`** so the `long` row of the `displayEdit()` parameterized test expects no `min`/`max`/`data-validation-range-*` attributes.

## Clarifications

* Direct follow-up to the review comment https://github.com/xwiki/xwiki-platform/pull/5830#issuecomment-5415008797
* Net behaviour change for `long` fields compared to #5830: the browser no longer rejects out-of-range values before submit, it now rejects decimals reliably instead. Out-of-range values are caught on save with a friendly message. This trades an unreliable client-side range check for a reliable client-side step check plus a correct server-side range check.
* The `INPUT_TYPE_NUMBER = XCLASSNAME` constant flagged in the same review comment is left as is. Checkstyle's `MultipleStringLiterals` is enabled with `allowedDuplicates = 1`, so a plain `"number"` literal in `setType()` would need a new module-level `checkstyle-suppressions.xml` for `xwiki-platform-oldcore`, which is a heavier addition than the constant it would remove.

# Screenshots & Video

No UI change. This only adjusts the client-side HTML5 validation attributes and the error messages already introduced in #5830.

# Executed Tests

* `mvn -o verify -pl xwiki-platform-core/xwiki-platform-oldcore -Dtest=NumberClassTest` -- passes, 5 tests, 0 failures, 0 errors.
* `mvn -o verify -DskipTests` in `xwiki-platform-appwithinminutes-test-docker` -- passes, 0 Checkstyle violations, test sources compile.
* Went through the `/xwiki-review` multi-angle automated review process on this change; the two findings it surfaced (a stale javadoc explanation left over from an earlier approach, and a test-fixture consolidation suggestion) were both addressed in follow-up commits.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None

