### PR TITLE
[Misc] Simplify two regular expressions that backtrack super-linearly (SonarQube)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-csrf/src/test/java/org/xwiki/csrf/DefaultCSRFTokenTest.java
+++ b/xwiki-platform-core/xwiki-platform-csrf/src/test/java/org/xwiki/csrf/DefaultCSRFTokenTest.java
@@ -75,7 +75,7 @@ class DefaultCSRFTokenTest
     /**
      * Characters that might break the layout and must thus not appear in a token.
      */
-    private static final Pattern BAD_CHARACTERS = Pattern.compile(".*[&?*_/#^,.({\\[\\]})~!=+-].*");
+    private static final Pattern BAD_CHARACTERS = Pattern.compile("[&?*_/#^,.({\\[\\]})~!=+-]");
 
     /**
      * URL of the current document.
@@ -349,7 +349,7 @@ class DefaultCSRFTokenTest
         for (int i = 0; i < 30; ++i) {
             this.csrf.clearToken();
             String token = this.csrf.getToken();
-            assertFalse(BAD_CHARACTERS.matcher(token).matches(),
+            assertFalse(BAD_CHARACTERS.matcher(token).find(),
                 "The token \"" + token + "\" contains a character that might break the layout");
         }
     }

--- a/xwiki-platform-tools/xwiki-platform-tool-standards-validator/src/main/java/org/xwiki/validator/HTML5DutchWebGuidelinesValidator.java
+++ b/xwiki-platform-tools/xwiki-platform-tool-standards-validator/src/main/java/org/xwiki/validator/HTML5DutchWebGuidelinesValidator.java
@@ -50,10 +50,12 @@ import org.xwiki.validator.framework.AbstractHTML5Validator;
 public class HTML5DutchWebGuidelinesValidator extends AbstractHTML5Validator
 {
     /**
-     * Pattern an email address must match.
+     * Pattern an email address must match. The domain labels are matched by an atomic group because they are
+     * fully determined by the dot that ends each of them, so allowing the group to be re-entered on backtracking
+     * would only grow the stack.
      */
     private static final Pattern EMAIL =
-        Pattern.compile("^[\\w\\-]([\\.\\w])+[\\w]+@([\\w\\-]+\\.)+[a-zA-Z]{2,4}$");
+        Pattern.compile("^[\\w-][.\\w]+\\w@(?>[\\w-]+\\.)+[a-zA-Z]{2,4}$");
 
     /**
      * String used to identify the charset in the content-type meta.


### PR DESCRIPTION
The SonarCloud quality gate on `master` is failing on `new_reliability_rating` (C, threshold A). The whole gap is three issues, all introduced on 2026-08-25 by #6222:

* [java:S8786](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issues=AaA4sJ0IaJjkWr1B0-MZ&open=AaA4sJ0IaJjkWr1B0-MZ) — `DefaultCSRFTokenTest`
* [java:S8786](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issues=AaA4sJ8haJjkWr1B0-Mb&open=AaA4sJ8haJjkWr1B0-Mb) and [java:S5998](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issues=AaA4sJ8haJjkWr1B0-Ma&open=AaA4sJ8haJjkWr1B0-Ma) — `HTML5DutchWebGuidelinesValidator`

Both regular expressions are older than #6222; that PR only moved them out of `String#matches()` into `Pattern.compile()` constants, which is what made Sonar's regex analyzers look at them at all. They are genuine defects, so this fixes them rather than accepting the issues.

### Equivalence of the e-mail pattern

`^[\w\-]([\.\w])+[\w]+@([\w\-]+\.)+[a-zA-Z]{2,4}$` → `^[\w-][.\w]+\w@(?>[\w-]+\.)+[a-zA-Z]{2,4}$`

Reasoning:

* `[\w\-]`≡`[\w-]`, `[\.\w]`≡`[.\w]`, `[\w]+`≡`\w+` — notation only.
* Local part: `([\.\w])+[\w]+` and `[.\w]+\w` both denote "at least two characters from `[.\w]`, the last one in `\w`" (split the old `A+B` at its last character, and conversely).
* Domain: `[\w-]+\.` is deterministic at any start position — greedy `[\w-]+` stops at the first character outside `[\w-]`, and every shorter match leaves a `[\w-]` character where `\.` is required, so no shorter match can ever succeed. Making the group atomic therefore discards only dead backtracking states. The enclosing `+` still gives iterations back, which is where the backtracking that `[a-zA-Z]{2,4}$` genuinely needs lives (`a.bb.cc` still matches).

Differential test, both patterns under `matches()` — **127,635,397 inputs of which 5,300,348 match, zero differences**:

| enumeration | inputs | matching | differences |
| --- | --- | --- | --- |
| whole string, alphabet `{a,B,9,_,.,-,@}`, length 8–9 (8 is the shortest possible match) | 46,118,408 | 26,000 | 0 |
| domain part after `a.b@`, alphabet `{a,B,9,-,.}`, length 1–11 | 61,035,155 | 1,671,152 | 0 |
| local part before `@c.de`, alphabet `{a,B,9,_,.,-}`, length 1–9 | 12,093,234 | 1,953,100 | 0 |
| domain part after `a.b@` × 6 TLD tails stressing `{2,4}`, alphabet `{a,9,-,.}`, length 1–10 | 8,388,600 | 1,650,096 | 0 |

Also zero differences over an exhaustive sweep of length ≤ 7 with `\n` and `\r` in the alphabet, and over a hand-written corpus of realistic and near-miss addresses, which covers the `^`/`$` anchors.

### One intentional behaviour difference

An input that used to throw `StackOverflowError` is now rejected. With `-Xss512k` and `a.b@` followed by *n* domain labels:

| *n* | old | new |
| --- | --- | --- |
| 1 000 | `StackOverflowError` | 0 ms |
| 5 000 | `StackOverflowError` | 2 ms |
| 100 000 | `StackOverflowError` | 7 ms |

That is a crash becoming a `false`, which is what `validateRpd8s17` means for such an address. No other input changes outcome.

### The CSRF token check

The check now uses `find()` on the bare character class instead of `matches()` on `".*...*"`. Those two differ only for a token containing a line terminator, which the old `.`-based pattern silently let through. That case is unreachable here: `DefaultCSRFToken#getToken` returns `Base64.encodeBase64URLSafeString(bytes).replaceAll("[_=+-]", "x")`, so a token is drawn from `[A-Za-z0-9x]`. The assertion outcome is therefore identical for every token the generator can produce, and the new form is the stricter one, which is what the assertion means.

### The findings are not cosmetic

The old local part backtracks quadratically — for an input of *n* `a`s that never reaches an `@`: 2 000 → 20 ms, 4 000 → 47 ms, 8 000 → 172 ms, 16 000 → 778 ms, 32 000 → 3 068 ms (4× per doubling). The new one is under a millisecond at every size.

### Verification

`mvn -Plegacy,quality install` on both modules: BUILD SUCCESS, 17 + 56 tests green (including the 47 `HTML5DutchWebGuidelinesValidatorTest` tests that cover the e-mail validation). Re-running the Sonar Java analyzer on both files reports no remaining issues.

Both changed constants are `private static final`, so there is no API surface involved, and `xwiki-platform-tool-standards-validator` is depended on only by `xwiki-platform-distribution-flavor-test-webstandards` and `-escaping`, i.e. it is functional-test tooling rather than runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
