### PR TITLE
XWIKI-15952: Update Scheduled Job With Job Re-Definition

### DIFF
--- a/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/SchedulerPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/SchedulerPlugin.java
@@ -22,7 +22,9 @@ package com.xpn.xwiki.plugin.scheduler;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.inject.Provider;
@@ -65,6 +67,8 @@ import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.api.Api;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.BaseObject;
+import com.xpn.xwiki.objects.BaseProperty;
+import com.xpn.xwiki.objects.PropertyInterface;
 import com.xpn.xwiki.plugin.XWikiDefaultPlugin;
 import com.xpn.xwiki.plugin.XWikiPluginInterface;
 import com.xpn.xwiki.plugin.scheduler.internal.SchedulerJobClassDocumentInitializer;
@@ -925,7 +929,48 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
                     LOGGER.warn("Failed to register job in document [{}]: [{}]", document.getDocumentReference(),
                         ExceptionUtils.getRootCauseMessage(e));
                 }
+            } else if (isJobDefinitionModified(originalJobObj, jobObj)) {
+                // Modified job. The scheduler holds the job xobject that was passed to it when the job was registered,
+                // so the new definition is only taken into account once the job has been registered again.
+                try {
+                    // Leave alone a job the scheduler doesn't know about: it gets registered with its new definition
+                    // when it's scheduled.
+                    JobState state = getCurrentJobState(jobObj);
+                    if (state != null && !JobState.STATE_NONE.equals(state.getValue())) {
+                        // We get the document from the store as we don't want to corrupt the document instance
+                        // associated with the event
+                        BaseObject jobObject = getModifiableObject(document.getDocumentReference(), xcontext);
+
+                        reloadJob(jobObject, xcontext);
+                    }
+                } catch (Exception e) {
+                    LOGGER.warn("Failed to reload job in document [{}]: [{}]", document.getDocumentReference(),
+                        ExceptionUtils.getRootCauseMessage(e));
+                }
             }
         }
+    }
+
+    /**
+     * @param previousJobObject the job xobject as it was before the modification
+     * @param jobObject the job xobject as it is after the modification
+     * @return {@code true} when the modification affects the definition of the job, i.e. anything but its status,
+     *         which the scheduler itself saves whenever it registers or unregisters a job
+     */
+    private boolean isJobDefinitionModified(BaseObject previousJobObject, BaseObject jobObject)
+    {
+        Set<String> properties = new HashSet<>(previousJobObject.getPropertyList());
+        properties.addAll(jobObject.getPropertyList());
+        properties.remove(STATUS);
+
+        return properties.stream().anyMatch(property -> !Objects.equals(getPropertyValue(previousJobObject, property),
+            getPropertyValue(jobObject, property)));
+    }
+
+    private Object getPropertyValue(BaseObject object, String property)
+    {
+        PropertyInterface value = object.safeget(property);
+
+        return value instanceof BaseProperty<?> baseProperty ? baseProperty.getValue() : null;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-test/xwiki-platform-scheduler-test-docker/src/test/it/org/xwiki/scheduler/test/ui/SchedulerIT.java
+++ b/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-test/xwiki-platform-scheduler-test-docker/src/test/it/org/xwiki/scheduler/test/ui/SchedulerIT.java
@@ -22,7 +22,9 @@ package org.xwiki.scheduler.test.ui;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
+import org.xwiki.model.reference.LocalDocumentReference;
 import org.xwiki.scheduler.test.po.SchedulerHomePage;
+import org.xwiki.scheduler.test.po.SchedulerJobOutputPage;
 import org.xwiki.scheduler.test.po.SchedulerPage;
 import org.xwiki.scheduler.test.po.editor.SchedulerEditPage;
 import org.xwiki.test.docker.junit5.UITest;
@@ -39,8 +41,10 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @UITest(
     properties = {
-        // The scheduler UI need programming right
-        "xwikiPropertiesAdditionalProperties=test.prchecker.excludePattern=xwiki:Scheduler\\.WebHome",
+        // The scheduler UI need programming right, and so does the job page holding the Groovy script executed by
+        // verifyJobScriptModificationIsUsed()
+        "xwikiPropertiesAdditionalProperties=test.prchecker.excludePattern="
+            + "xwiki:Scheduler\\.(WebHome|SchedulerScriptTestJob)",
 
         // Override in order to add the Scheduler Plugin
         "xwikiCfgPlugins=com.xpn.xwiki.plugin.skinx.JsSkinExtensionPlugin,"
@@ -61,6 +65,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 })
 class SchedulerIT
 {
+    private static final String OUTPUT_PAGE = "SchedulerScriptTestOutput";
+
+    private static final LocalDocumentReference OUTPUT_REFERENCE =
+        new LocalDocumentReference("Scheduler", OUTPUT_PAGE);
+
     @Test
     @Order(1)
     void verifyScheduler(TestUtils setup)
@@ -161,5 +170,61 @@ class SchedulerIT
         SchedulerPage schedulerPage = schedulerEdit.clickSaveAndView();
 
         assertEquals("{{/code}}", schedulerPage.getScript());
+    }
+
+    @Test
+    @Order(3)
+    void verifyJobScriptModificationIsUsed(TestUtils setup)
+    {
+        setup.loginAsSuperAdmin();
+
+        setup.deletePage("Scheduler", "SchedulerScriptTestJob");
+        // Create the output page up front, so that waiting for the content written by a job is waiting for that
+        // content to replace a known one, rather than for the page itself to come into existence.
+        setup.createPage(OUTPUT_REFERENCE, "no job executed yet");
+
+        // Create a job that writes a known content in the output page. Its cron expression is set far in the future
+        // so that the job only runs when it's explicitly triggered.
+        SchedulerHomePage schedulerHomePage = SchedulerHomePage.gotoPage();
+        schedulerHomePage.setJobName("SchedulerScriptTestJob");
+        SchedulerEditPage schedulerEdit = schedulerHomePage.clickAdd();
+        String jobName = "Script modification job";
+        schedulerEdit.setJobName(jobName);
+        schedulerEdit.setJobDescription(jobName);
+        schedulerEdit.setCron("0 0 0 1 1 ? 2100");
+        schedulerEdit.setScript(getOutputScript("first"));
+        schedulerHomePage = schedulerEdit.clickSaveAndView().backToHome();
+
+        schedulerHomePage.clickJobActionSchedule(jobName);
+        if (schedulerHomePage.hasError()) {
+            fail("Failed to schedule job. Error [" + schedulerHomePage.getErrorMessage() + "]");
+        }
+
+        schedulerHomePage.clickJobActionTrigger(jobName);
+        if (schedulerHomePage.hasError()) {
+            fail("Failed to trigger job. Error [" + schedulerHomePage.getErrorMessage() + "]");
+        }
+        SchedulerJobOutputPage.gotoPage(OUTPUT_REFERENCE).waitUntilContentIs("first");
+
+        // Modify the script of the scheduled job. The new script must be used without having to unschedule and
+        // schedule the job again.
+        schedulerHomePage = SchedulerHomePage.gotoPage();
+        schedulerEdit = schedulerHomePage.clickJobActionEdit(jobName);
+        schedulerEdit.setScript(getOutputScript("second"));
+        schedulerHomePage = schedulerEdit.clickSaveAndView().backToHome();
+
+        schedulerHomePage.clickJobActionTrigger(jobName);
+        if (schedulerHomePage.hasError()) {
+            fail("Failed to trigger job. Error [" + schedulerHomePage.getErrorMessage() + "]");
+        }
+        SchedulerJobOutputPage.gotoPage(OUTPUT_REFERENCE).waitUntilContentIs("second");
+
+        SchedulerHomePage.gotoPage().clickJobActionUnschedule(jobName);
+    }
+
+    private String getOutputScript(String content)
+    {
+        return String.format("def output = xwiki.getDocument('Scheduler.%s')\noutput.setContent('%s')\n"
+            + "output.save()", OUTPUT_PAGE, content);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-test/xwiki-platform-scheduler-test-pageobjects/src/main/java/org/xwiki/scheduler/test/po/SchedulerJobOutputPage.java
+++ b/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-test/xwiki-platform-scheduler-test-pageobjects/src/main/java/org/xwiki/scheduler/test/po/SchedulerJobOutputPage.java
@@ -1,0 +1,77 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.scheduler.test.po;
+
+import org.openqa.selenium.TimeoutException;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.test.ui.po.ViewPage;
+
+/**
+ * A page written to by the script of a scheduler job, used to observe that the job has been executed.
+ *
+ * @version $Id$
+ * @since 18.8.0RC1
+ */
+public class SchedulerJobOutputPage extends ViewPage
+{
+    /**
+     * How long to wait, in seconds, for a job to have written its content. Longer than the default timeout since each
+     * reload of this page takes a share of it.
+     */
+    private static final int TIMEOUT = 30;
+
+    /**
+     * @param reference the reference of the page the job writes to
+     * @return the page object for that page
+     */
+    public static SchedulerJobOutputPage gotoPage(EntityReference reference)
+    {
+        getUtil().gotoPage(reference, "view");
+
+        return new SchedulerJobOutputPage();
+    }
+
+    /**
+     * Wait until the job has written the passed content in this page. A job is executed asynchronously from the action
+     * that triggers it, so the content only appears after this page has been loaded, hence the reload. Contrary to
+     * {@link ViewPage#waitUntilContent(String)}, reloading is safe here since the content is written by the scheduler
+     * and not by an asynchronous process that loading this page would start over.
+     * <p>
+     * The page must already exist, so that the content of a page that exists is what is being waited for. Locating the
+     * content of a page that doesn't exist yet fails with a wait of its own, which would consume the whole timeout.
+     *
+     * @param expectedContent the content the job is expected to write
+     */
+    public void waitUntilContentIs(String expectedContent)
+    {
+        // Using an array to have an effectively final variable.
+        String[] lastContent = new String[1];
+        try {
+            getDriver().waitUntilCondition(driver -> {
+                driver.navigate().refresh();
+                lastContent[0] = getContent();
+
+                return expectedContent.equals(lastContent[0]);
+            }, TIMEOUT);
+        } catch (TimeoutException e) {
+            throw new TimeoutException(String.format("Got [%s]%nExpected [%s]", lastContent[0], expectedContent), e);
+        }
+    }
+}


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-15952 (XWIKI-21673 and XWIKI-24021 are closed as duplicates of it)

## Problem

`SchedulerPlugin.buildJobDetails()` puts the job xobject in the Quartz `JobDataMap`, and `GroovyJob` reads the script from *that* instance. `onDocumentEvent()` only registers a job when its xobject is new, so editing an already-scheduled job's script or cron expression has no effect until the job is unscheduled and scheduled again, or until XWiki is restarted.

The job doesn't fail — it keeps running its previous code, which makes the problem hard to notice. It just cost the install counts on extensions.xwiki.org: the counter job's script was extended on 2026-08-15 to also count the Active Installs 2 population, the weekly runs after that silently kept using the old script, and every extension kept displaying only its Active Installs 1 count (Change Request UI showed 0 install instead of 164, since it has no AI1 installs at all). Unscheduling and scheduling the job made a single run write the correct counts to 359 extension pages.

## Fix

Reload an already-registered job when its definition changes, through the existing `reloadJob()` (added for XWIKI-14494), so that saving the job document is enough.

Two guards:

- **Status-only changes are ignored.** The scheduler saves the `status` field itself whenever it registers, pauses or unregisters a job, so without this the job would be reloaded in the middle of the scheduler's own save.
- **A job the scheduler doesn't know about is left alone**, so that saving an unscheduled job doesn't add a dormant job to the scheduler. It's registered with its new definition when it gets scheduled.

## Test

`SchedulerIT.verifyJobScriptModificationIsUsed` schedules a job writing a known content, triggers it, then modifies its script and triggers it again.

The wait for the content a job writes is exposed by a new `SchedulerJobOutputPage` page object rather than done in the test, which has no business touching the web driver. No existing page object fits: a job runs asynchronously from the action that triggers it, so waiting for its content means reloading the page, and `ViewPage#waitUntilContent()` deliberately doesn't reload — reloading would start over an asynchronous process that the page itself had triggered, which isn't the case here.

The page the job writes to is created before the job is scheduled, so that the wait is for a content replacing a known one. Locating the content of a page that doesn't exist yet fails with a wait of its own, which consumes the whole timeout and reports no content at all instead of the content it found.

Verified both ways on `hsqldb-default-default-jetty_standalone-default-firefox`, with the WAR's scheduler jar checked with `javap` each time to make sure the run exercised the intended code (`mvn install` without `clean` happily installs a build-cache jar without the edit):

- with the fix: `Tests run: 3, Failures: 0, Errors: 0`
- main code reverted to master: `SchedulerIT.verifyJobScriptModificationIsUsed:220 » Timeout Got [first] Expected [second]`

It fails on the *second* content only — the first assertion, before the script modification, passes — so it targets exactly this behaviour.

The job page is added to `test.prchecker.excludePattern` because `GroovyJob` checks `Right.PROGRAM` against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
