### PR TITLE
XWIKI-24743: Unparseable date exception when trying to access old version of a doc

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/BasePropertyOutputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/BasePropertyOutputFilterStream.java
@@ -19,6 +19,8 @@
  */
 package com.xpn.xwiki.internal.filter.output;
 
+import java.text.ParseException;
+
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 
@@ -31,10 +33,12 @@ import org.xwiki.filter.FilterEventParameters;
 import org.xwiki.filter.FilterException;
 import org.xwiki.filter.event.model.WikiObjectPropertyFilter;
 import org.xwiki.internal.objects.ObjectPropertyParser;
+import org.xwiki.xar.internal.property.DateXarObjectPropertySerializer;
 
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.objects.BaseProperty;
 import com.xpn.xwiki.objects.classes.BaseClass;
+import com.xpn.xwiki.objects.classes.DateClass;
 import com.xpn.xwiki.objects.classes.PropertyClassInterface;
 import com.xpn.xwiki.objects.classes.StringClass;
 
@@ -81,7 +85,7 @@ public class BasePropertyOutputFilterStream extends AbstractElementOutputFilterS
             if (propertyclass != null) {
                 // Bulletproofing using PropertyClassInterface#fromString when a String is passed (in case it's not
                 // really a String property)
-                property = value instanceof String valueString ? propertyclass.fromString(valueString)
+                property = value instanceof String valueString ? readStringPropertyValue(propertyclass, valueString)
                     : propertyclass.fromValue(value);
             } else {
                 property = computeMissingProperty(value, parameters);
@@ -95,6 +99,20 @@ public class BasePropertyOutputFilterStream extends AbstractElementOutputFilterS
                 this.entity = property;
             } else {
                 this.entity.apply(property, true);
+            }
+        }
+    }
+
+    private BaseProperty readStringPropertyValue(PropertyClassInterface propertyClass, String value)
+        throws XWikiException
+    {
+        try {
+            return propertyClass.fromString(value);
+        } catch (XWikiException e) {
+            if (propertyClass instanceof DateClass && e.getCause() instanceof ParseException) {
+                return propertyClass.fromValue(DateXarObjectPropertySerializer.parseDate(value));
+            } else {
+                throw e;
             }
         }
     }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24743

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

 * Fallback on trying to parse the date using the XAR format if the value is a String and a ParseException is thrown

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 