### PR TITLE
XWIKI-24743: Unparseable date exception when trying to access old version of a doc

### DIFF
--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/AbstractWikiObjectPropertyReader.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/AbstractWikiObjectPropertyReader.java
@@ -98,12 +98,12 @@ public abstract class AbstractWikiObjectPropertyReader extends AbstractReader
             type = properties.getObjectPropertyType();
         }
         boolean useTypeAttribute = false;
-        if (type == null && !StringUtils.isEmpty(typeAttribute)) {
+        if (type == null && StringUtils.isNotEmpty(typeAttribute)) {
             type = typeAttribute;
             useTypeAttribute = true;
         }
         // last fallback: try to load the type from current xclass
-        if (type == null && !StringUtils.isEmpty(classReference)) {
+        if (type == null && StringUtils.isNotEmpty(classReference)) {
             type = this.currentXClassLoaderProvider.get().getXClassPropertyType(classReference, property.name);
         }
 
@@ -123,6 +123,4 @@ public abstract class AbstractWikiObjectPropertyReader extends AbstractReader
 
         return property;
     }
-
-
 }

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/AbstractWikiObjectPropertyReader.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/AbstractWikiObjectPropertyReader.java
@@ -23,6 +23,8 @@ import javax.inject.Inject;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
+import jakarta.inject.Provider;
+
 import org.apache.commons.lang3.StringUtils;
 import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.filter.FilterEventParameters;
@@ -42,6 +44,9 @@ public abstract class AbstractWikiObjectPropertyReader extends AbstractReader
 {
     @Inject
     private XarObjectPropertySerializerManager propertySerializerManager;
+
+    @Inject
+    private Provider<CurrentXClassLoader> currentXClassLoaderProvider;
 
     /**
      * Class holding information about wiki object property.
@@ -76,7 +81,7 @@ public abstract class AbstractWikiObjectPropertyReader extends AbstractReader
     }
 
     protected WikiObjectProperty readObjectProperty(XMLStreamReader xmlReader, XARInputProperties properties,
-        WikiClass wikiClass) throws XMLStreamException, FilterException
+        WikiClass wikiClass, String classReference) throws XMLStreamException, FilterException
     {
         String typeAttribute = xmlReader.getAttributeValue(null, XarObjectPropertyModel.ATTRIBUTE_TYPE);
         xmlReader.nextTag();
@@ -97,6 +102,10 @@ public abstract class AbstractWikiObjectPropertyReader extends AbstractReader
             type = typeAttribute;
             useTypeAttribute = true;
         }
+        // last fallback: try to load the type from current xclass
+        if (type == null && !StringUtils.isEmpty(classReference)) {
+            type = this.currentXClassLoaderProvider.get().getXClassPropertyType(classReference, property.name);
+        }
 
         try {
             property.value = this.propertySerializerManager.getPropertySerializer(type).read(xmlReader);
@@ -114,4 +123,6 @@ public abstract class AbstractWikiObjectPropertyReader extends AbstractReader
 
         return property;
     }
+
+
 }

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/CurrentXClassLoader.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/CurrentXClassLoader.java
@@ -19,27 +19,26 @@
  */
 package org.xwiki.filter.xar.internal.input;
 
-import javax.inject.Singleton;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamReader;
-
-import org.xwiki.component.annotation.Component;
-import org.xwiki.filter.FilterException;
-import org.xwiki.filter.xar.input.XARInputProperties;
+import org.xwiki.component.annotation.Role;
 
 /**
+ * Internal component for reading current xclass information as fallback for reading object properties.
+ *
  * @version $Id$
- * @since 9.0RC1
+ * @since 18.8.0RC1
+ * @since 18.4.5
+ * @since 17.10.13
  */
-@Component
-@Singleton
-public class WikiObjectPropertyReader extends AbstractWikiObjectPropertyReader
-    implements XARXMLReader<AbstractWikiObjectPropertyReader.WikiObjectProperty>
+@Role
+public interface CurrentXClassLoader
 {
-    @Override
-    public WikiObjectProperty read(XMLStreamReader xmlReader, XARInputProperties properties)
-        throws XMLStreamException, FilterException
-    {
-        return readObjectProperty(xmlReader, properties, null, null);
-    }
+    /**
+     * Read the class identified by the given reference and search for the type of the parameter identified by the
+     * given name.
+     *
+     * @param xclassReference the reference of the class to read.
+     * @param propertyName the name of the property for which to read the type.
+     * @return the property type or {@code null}.
+     */
+    String getXClassPropertyType(String xclassReference, String propertyName);
 }

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/WikiObjectReader.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/WikiObjectReader.java
@@ -129,7 +129,11 @@ public class WikiObjectReader extends AbstractWikiObjectPropertyReader
             if (elementName.equals(XarClassModel.ELEMENT_CLASS)) {
                 wikiObject.wikiClass = this.classReader.read(xmlReader, properties);
             } else if (elementName.equals(XarObjectPropertyModel.ELEMENT_PROPERTY)) {
-                wikiObject.properties.add(readObjectProperty(xmlReader, properties, wikiObject.wikiClass));
+                Object classReferenceParameter = wikiObject.parameters.get(WikiObjectFilter.PARAMETER_CLASS_REFERENCE);
+                String classReference =
+                    classReferenceParameter instanceof String ? (String) classReferenceParameter : null;
+                wikiObject.properties.add(readObjectProperty(xmlReader, properties, wikiObject.wikiClass,
+                    classReference));
             } else {
                 EventParameter parameter = OBJECT_PARAMETERS.get(elementName);
 

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/WikiObjectReader.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/WikiObjectReader.java
@@ -129,9 +129,8 @@ public class WikiObjectReader extends AbstractWikiObjectPropertyReader
             if (elementName.equals(XarClassModel.ELEMENT_CLASS)) {
                 wikiObject.wikiClass = this.classReader.read(xmlReader, properties);
             } else if (elementName.equals(XarObjectPropertyModel.ELEMENT_PROPERTY)) {
-                Object classReferenceParameter = wikiObject.parameters.get(WikiObjectFilter.PARAMETER_CLASS_REFERENCE);
                 String classReference =
-                    classReferenceParameter instanceof String ? (String) classReferenceParameter : null;
+                    (String) wikiObject.parameters.get(WikiObjectFilter.PARAMETER_CLASS_REFERENCE);
                 wikiObject.properties.add(readObjectProperty(xmlReader, properties, wikiObject.wikiClass,
                     classReference));
             } else {

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/test/java/org/xwiki/filter/xar/DocumentIntegrationTests.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/test/java/org/xwiki/filter/xar/DocumentIntegrationTests.java
@@ -21,6 +21,7 @@ package org.xwiki.filter.xar;
 
 import org.xwiki.filter.test.integration.junit5.FilterTest;
 import org.xwiki.filter.test.integration.junit5.FilterTest.Scope;
+import org.xwiki.filter.xar.internal.input.CurrentXClassLoader;
 import org.xwiki.test.annotation.AllComponents;
 
 /**
@@ -33,4 +34,9 @@ import org.xwiki.test.annotation.AllComponents;
 @Scope(value = "document"/*, pattern = "new1.test"*/)
 class DocumentIntegrationTests extends FilterTest
 {
+    @Override
+    protected void beforeTests() throws Exception
+    {
+        getComponentManager().registerMockComponent(CurrentXClassLoader.class);
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/test/java/org/xwiki/filter/xar/DocumentIntegrationTests.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/test/java/org/xwiki/filter/xar/DocumentIntegrationTests.java
@@ -24,6 +24,8 @@ import org.xwiki.filter.test.integration.junit5.FilterTest.Scope;
 import org.xwiki.filter.xar.internal.input.CurrentXClassLoader;
 import org.xwiki.test.annotation.AllComponents;
 
+import static org.mockito.Mockito.when;
+
 /**
  * Run all tests found in the classpath. These {@code *.test} files must follow the conventions described in
  * {@link org.xwiki.filter.test.integration.TestDataParser}.
@@ -37,6 +39,10 @@ class DocumentIntegrationTests extends FilterTest
     @Override
     protected void beforeTests() throws Exception
     {
-        getComponentManager().registerMockComponent(CurrentXClassLoader.class);
+        CurrentXClassLoader loader = getComponentManager().registerMockComponent(CurrentXClassLoader.class);
+        when(loader.getXClassPropertyType("space.classOldStyleTest", "property2")).thenReturn("StaticList");
+        when(loader.getXClassPropertyType("space.classOldStyleTest", "property1")).thenReturn("String");
+        when(loader.getXClassPropertyType("space.classOldStyleTest", "mypass")).thenReturn("Password");
+        when(loader.getXClassPropertyType("space.classOldStyleTest", "mydate")).thenReturn("Date");
     }
 }

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/test/resources/document/object/objectwithoutclassoldstyle.test
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/test/resources/document/object/objectwithoutclassoldstyle.test
@@ -1,0 +1,155 @@
+.#------------------------------------------------------------------------------
+.input|xwiki+xar/1.1
+.#------------------------------------------------------------------------------
+<?xml version='1.1' encoding='UTF-8'?>
+<xwikidoc version="1.7" reference="space.page" locale="">
+  <web>space</web>
+  <name>page</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <version>1.1</version>
+  <syntaxId>xwiki/1.0</syntaxId>
+  <hidden>false</hidden>
+  <enforceRequiredRights>true</enforceRequiredRights>
+  <object>
+    <name>space.page</name>
+    <number>0</number>
+    <className>space.classOldStyleTest</className>
+    <property>
+      <property1>value</property1>
+    </property>
+    <property>
+      <property2>
+        <value>value1</value>
+        <value>value2</value>
+        <value>value3</value>
+      </property2>
+    </property>
+    <property>
+      <mypass>somevalue</mypass>
+    </property>
+    <property>
+      <mydate>2026-03-03 09:37:29.0</mydate>
+    </property>
+    <property>
+      <myboolean>1</myboolean>
+    </property>
+  </object>
+</xwikidoc>
+.#------------------------------------------------------------------------------
+.expect|filter+xml
+.#------------------------------------------------------------------------------
+<wikiSpace name="space">
+  <wikiDocument name="page">
+    <p>
+      <parameters>
+        <entry>
+          <string>locale</string>
+          <locale></locale>
+        </entry>
+      </parameters>
+    </p>
+    <wikiDocumentLocale>
+      <wikiDocumentRevision revision="1.1">
+        <p>
+          <parameters>
+            <entry>
+              <string>syntax</string>
+              <org.xwiki.rendering.syntax.Syntax>
+                <type>
+                  <name>XWiki</name>
+                  <id>xwiki</id>
+                  <variants class="empty-list"/>
+                </type>
+                <version>1.0</version>
+              </org.xwiki.rendering.syntax.Syntax>
+            </entry>
+            <entry>
+              <string>hidden</string>
+              <boolean>false</boolean>
+            </entry>
+            <entry>
+              <string>enforce_required_rights</string>
+              <boolean>true</boolean>
+            </entry>
+          </parameters>
+        </p>
+        <wikiObject name="space.classOldStyleTest[0]">
+          <p>
+            <parameters>
+              <entry>
+                <string>name</string>
+                <string>space.page</string>
+              </entry>
+              <entry>
+                <string>number</string>
+                <int>0</int>
+              </entry>
+              <entry>
+                <string>class_reference</string>
+                <string>space.classOldStyleTest</string>
+              </entry>
+            </parameters>
+          </p>
+          <wikiObjectProperty name="property1" value="value">
+            <p>
+              <parameters>
+                <entry>
+                  <string>type</string>
+                  <string>String</string>
+                </entry>
+              </parameters>
+            </p>
+          </wikiObjectProperty>
+          <wikiObjectProperty name="property2">
+            <p>
+              <value t="java.util.ArrayList">
+                <string>value1</string>
+                <string>value2</string>
+                <string>value3</string>
+              </value>
+              <parameters>
+                <entry>
+                  <string>type</string>
+                  <string>StaticList</string>
+                </entry>
+              </parameters>
+            </p>
+          </wikiObjectProperty>
+          <wikiObjectProperty name="mypass" value="somevalue">
+            <p>
+              <parameters>
+                <entry>
+                  <string>type</string>
+                  <string>Password</string>
+                </entry>
+              </parameters>
+            </p>
+          </wikiObjectProperty>
+          <wikiObjectProperty name="mydate">
+            <p>
+              <value t="java.util.Date">2026-03-03 09:37:29.0 UTC</value>
+              <parameters>
+                <entry>
+                  <string>type</string>
+                  <string>Date</string>
+                </entry>
+              </parameters>
+            </p>
+          </wikiObjectProperty>
+          <wikiObjectProperty name="myboolean" value="1">
+            <p>
+              <parameters>
+                <entry>
+                  <string>type</string>
+                  <null/>
+                </entry>
+              </parameters>
+            </p>
+          </wikiObjectProperty>
+        </wikiObject>
+      </wikiDocumentRevision>
+    </wikiDocumentLocale>
+  </wikiDocument>
+</wikiSpace>

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/internal/filter/DefaultCurrentXClassLoader.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/internal/filter/DefaultCurrentXClassLoader.java
@@ -20,6 +20,7 @@
 package org.xwiki.internal.filter;
 
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 
@@ -54,6 +55,7 @@ public class DefaultCurrentXClassLoader implements CurrentXClassLoader
     private Provider<XWikiContext> contextProvider;
 
     @Inject
+    @Named("current")
     private DocumentReferenceResolver<String> stringDocumentReferenceResolver;
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/internal/filter/DefaultCurrentXClassLoader.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/internal/filter/DefaultCurrentXClassLoader.java
@@ -1,0 +1,82 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.internal.filter;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.filter.xar.internal.input.CurrentXClassLoader;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.PropertyInterface;
+import com.xpn.xwiki.objects.classes.BaseClass;
+
+/**
+ * Default implementation of {@link CurrentXClassLoader}.
+ *
+ * @version $Id$
+ * @since 18.8.0RC1
+ * @since 18.4.5
+ * @since 17.10.13
+ */
+@Component
+@Singleton
+public class DefaultCurrentXClassLoader implements CurrentXClassLoader
+{
+    @Inject
+    private Logger logger;
+
+    @Inject
+    private Provider<XWikiContext> contextProvider;
+
+    @Inject
+    private DocumentReferenceResolver<String> stringDocumentReferenceResolver;
+
+    @Override
+    public String getXClassPropertyType(String xclassName, String propertyName)
+    {
+        String result = null;
+        XWikiContext context = contextProvider.get();
+        DocumentReference xclassReference = this.stringDocumentReferenceResolver.resolve(xclassName);
+        try {
+            XWikiDocument document = context.getWiki().getDocument(xclassReference, context);
+            if (!document.isNew()) {
+                BaseClass baseClass = document.getXClass();
+                if (baseClass != null) {
+                    PropertyInterface propertyInterface = baseClass.safeget(propertyName);
+                    if (propertyInterface != null) {
+                        result = propertyInterface.getPropertyType();
+                    }
+                }
+            }
+        } catch (XWikiException e) {
+            this.logger.error("Error while trying to load current xclass [{}] to read type of property [{}]",
+                xclassName, propertyName, e);
+        }
+        return result;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
@@ -289,6 +289,7 @@ org.xwiki.internal.attachment.XWikiAttachmentSecurityManager
 org.xwiki.internal.authentication.DefaultUserAuthenticatedEventNotifier
 org.xwiki.internal.authentication.LoginLinkUIExtension
 org.xwiki.internal.authentication.RegisterLinkUIExtension
+org.xwiki.internal.filter.DefaultCurrentXClassLoader
 org.xwiki.internal.filter.Importer
 org.xwiki.internal.document.DocumentOverrideListener
 org.xwiki.internal.document.DocumentRequiredRightsReader

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/filter/DefaultCurrentXClassLoaderTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/filter/DefaultCurrentXClassLoaderTest.java
@@ -1,0 +1,83 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.internal.filter;
+
+import jakarta.inject.Named;
+import jakarta.inject.Provider;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.PropertyInterface;
+import com.xpn.xwiki.objects.classes.BaseClass;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link DefaultCurrentXClassLoader}.
+ */
+@ComponentTest
+class DefaultCurrentXClassLoaderTest
+{
+    @InjectMockComponents
+    private DefaultCurrentXClassLoader defaultCurrentXClassLoader;
+
+    @MockComponent
+    private Provider<XWikiContext> contextProvider;
+
+    @MockComponent
+    @Named("current")
+    private DocumentReferenceResolver<String> stringDocumentReferenceResolver;
+
+    @Test
+    void getXClassPropertyType() throws XWikiException
+    {
+        DocumentReference classReference = new DocumentReference("xwiki", "Space", "MyClass");
+        when(this.stringDocumentReferenceResolver.resolve("myclass")).thenReturn(classReference);
+
+        XWikiContext context = mock(XWikiContext.class);
+        when(contextProvider.get()).thenReturn(context);
+
+        XWiki xWiki = mock(XWiki.class);
+        when(context.getWiki()).thenReturn(xWiki);
+        XWikiDocument document = mock(XWikiDocument.class);
+        when(xWiki.getDocument(classReference, context)).thenReturn(document);
+        when(document.isNew()).thenReturn(true);
+        assertNull(this.defaultCurrentXClassLoader.getXClassPropertyType("myclass", "myprop"));
+
+        when(document.isNew()).thenReturn(false);
+        BaseClass baseClass = mock(BaseClass.class);
+        when(document.getXClass()).thenReturn(baseClass);
+        PropertyInterface property = mock(PropertyInterface.class);
+        when(baseClass.safeget("myprop")).thenReturn(property);
+        when(property.getPropertyType()).thenReturn("Date");
+        assertEquals("Date", this.defaultCurrentXClassLoader.getXClassPropertyType("myclass", "myprop"));
+    }
+}


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

  * https://jira.xwiki.org/browse/XWIKI-24743

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

 * Try a final fallback to get the data type based on the current xclass when reading the wiki oject properties


## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Build of the maven modules and manual test only.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-18.7.x
  * stable-18.4.x
  * stable-17.10.x