### PR TITLE
XWIKI-24724: Fix row position in livedata edit mode

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -294,6 +294,21 @@
                 </item>
               </differences>
             </revapi.differences>
+            <revapi.differences>
+              <justification>
+                Fetching a live data entry might require an optional list of properties to fetch, which was missing.
+                The REST API shouldn't be called directly from Java but through HTTP requests. Adding a new query string
+                parameter to an existing REST resource doesn't break existing code that calls this resource through HTTP.
+              </justification>
+              <criticality>allowed</criticality>
+              <differences>
+                <item>
+                  <code>java.method.numberOfParametersChanged</code>
+                  <old>method org.xwiki.livedata.rest.model.jaxb.Entry org.xwiki.livedata.rest.LiveDataEntryResource::getEntry(java.lang.String, java.lang.String, java.lang.String) throws java.lang.Exception</old>
+                  <new>method org.xwiki.livedata.rest.model.jaxb.Entry org.xwiki.livedata.rest.LiveDataEntryResource::getEntry(java.lang.String, java.lang.String, java.lang.String, java.util.List&lt;java.lang.String&gt;) throws java.lang.Exception</new>
+                </item>
+              </differences>
+            </revapi.differences>
           </analysisConfiguration>
         </configuration>
       </plugin>

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataEntryStore.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataEntryStore.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.livedata;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -39,6 +40,20 @@ public interface LiveDataEntryStore
      * @throws LiveDataException if retrieving the specified entry fails
      */
     Optional<Map<String, Object>> get(Object entryId) throws LiveDataException;
+
+    /**
+     * Returns an entry that includes the specified properties.
+     *
+     * @param entryId identifies the entry to return
+     * @param properties the properties the returned entry must include
+     * @return the specified entry
+     * @throws LiveDataException if retrieving the specified entry fails
+     * @since 18.8.0RC1
+     */
+    default Optional<Map<String, Object>> get(Object entryId, List<String> properties) throws LiveDataException
+    {
+        return get(entryId);
+    }
 
     /**
      * @param entryId identifies the entry whose property value to return

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataEntryStore.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataEntryStore.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -108,10 +109,17 @@ public class LiveTableLiveDataEntryStore extends WithParameters implements LiveD
     @Override
     public Optional<Map<String, Object>> get(Object entryId) throws LiveDataException
     {
+        return get(entryId, List.of());
+    }
+
+    @Override
+    public Optional<Map<String, Object>> get(Object entryId, List<String> properties) throws LiveDataException
+    {
         LiveDataQuery query = new LiveDataQuery();
         query.setSource(new Source(ROLE_HINT));
         String idProperty = this.liveDataConfigurationProvider.get().getMeta().getEntryDescriptor().getIdProperty();
-        query.setProperties(List.of(idProperty));
+        query.setProperties(Stream.concat(Stream.of(idProperty), properties.stream())
+            .filter(StringUtils::isNotEmpty).distinct().toList());
         query.setFilters(List.of(new LiveDataQuery.Filter(idProperty, entryId)));
         query.setLimit(1);
         return this.get(query).getEntries().stream().findFirst();

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataEntryStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataEntryStoreTest.java
@@ -21,6 +21,7 @@ package org.xwiki.livedata.internal.livetable;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -146,6 +147,50 @@ class LiveTableLiveDataEntryStoreTest
         assertEquals(1, query.getFilters().size());
         assertEquals("doc.fullName", query.getFilters().get(0).getProperty());
         assertEquals("testEntry", query.getFilters().get(0).getConstraints().get(0).getValue());
+    }
+
+    @Test
+    void getWithProperties() throws Exception
+    {
+        Map<String, Object> row = new HashMap<>();
+        row.put("doc_fullName", "MySpace.MyEntry");
+        row.put("status", "done");
+
+        Map<String, Object> liveTableResults = new HashMap<>();
+        liveTableResults.put("totalrows", 1);
+        liveTableResults.put("rows", Collections.singletonList(row));
+
+        when(this.resultsRenderer.getLiveTableResultsFromPage(eq("XWiki.LiveTableResults"), any()))
+            .thenReturn(this.objectMapper.writeValueAsString(liveTableResults));
+
+        Map<String, Object> expectedEntry = new HashMap<>();
+        expectedEntry.put("doc.fullName", "MySpace.MyEntry");
+        expectedEntry.put("status", "done");
+        assertEquals(Optional.of(expectedEntry), this.entryStore.get("testEntry", List.of("status", "doc.title")));
+
+        // The requested properties are queried in addition to the id property.
+        ArgumentCaptor<LiveDataQuery> queryCaptor = ArgumentCaptor.forClass(LiveDataQuery.class);
+        verify(this.resultsRenderer).getLiveTableResultsFromPage(eq("XWiki.LiveTableResults"), queryCaptor.capture());
+        LiveDataQuery query = queryCaptor.getValue();
+        assertEquals(asList("doc.fullName", "status", "doc.title"), query.getProperties());
+        assertEquals(1, query.getLimit());
+        assertEquals(1, query.getFilters().size());
+        assertEquals("doc.fullName", query.getFilters().get(0).getProperty());
+        assertEquals("testEntry", query.getFilters().get(0).getConstraints().get(0).getValue());
+    }
+
+    @Test
+    void getWithEmptyAndDuplicatedProperties() throws Exception
+    {
+        when(this.resultsRenderer.getLiveTableResultsFromPage(eq("XWiki.LiveTableResults"), any()))
+            .thenReturn("{\"totalrows\":0,\"rows\":[]}");
+
+        assertEquals(Optional.empty(),
+            this.entryStore.get("testEntry", asList("status", "", "doc.fullName", "status", null)));
+
+        ArgumentCaptor<LiveDataQuery> queryCaptor = ArgumentCaptor.forClass(LiveDataQuery.class);
+        verify(this.resultsRenderer).getLiveTableResultsFromPage(eq("XWiki.LiveTableResults"), queryCaptor.capture());
+        assertEquals(asList("doc.fullName", "status"), queryCaptor.getValue().getProperties());
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/main/resources/ApplicationResources.properties
@@ -172,6 +172,7 @@ livedata.filter.text.label=Filter on a text property.
 
 livedata.footnotes.computedTitle=Some pages have a computed title. Filtering and sorting by title will not work as expected for these pages.
 livedata.footnotes.propertyNotViewable=Displayed when some entries require special rights to be viewed and thus fields cannot be extracted from them.
+livedata.footnotes.frozenEntries=These entries are currently frozen, they will keep their positions while edit mode is active unless you manually change the sorting, the filters, or the page.
 
 livedata.bottombar.noEntries=(No entries)
 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataEntryResource.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataEntryResource.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.livedata.internal.rest;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -50,7 +51,7 @@ public class DefaultLiveDataEntryResource extends AbstractLiveDataResource imple
     private LiveDataResourceContextInitializer contextInitializer;
 
     @Override
-    public Entry getEntry(String sourceId, String namespace, String entryId) throws Exception
+    public Entry getEntry(String sourceId, String namespace, String entryId, List<String> properties) throws Exception
     {
         this.contextInitializer.initialize(namespace);
 
@@ -58,7 +59,7 @@ public class DefaultLiveDataEntryResource extends AbstractLiveDataResource imple
         Optional<LiveDataSource> source = this.liveDataSourceManager.get(querySource, namespace);
         if (source.isPresent()) {
             LiveDataEntryStore entryStore = source.get().getEntries();
-            Optional<Map<String, Object>> values = entryStore.get(entryId);
+            Optional<Map<String, Object>> values = entryStore.get(entryId, properties);
             if (values.isPresent()) {
                 return createEntry(values.get(), entryId, querySource, namespace);
             }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/rest/LiveDataEntryResource.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/rest/LiveDataEntryResource.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.livedata.rest;
 
+import java.util.List;
+
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -42,11 +44,12 @@ public interface LiveDataEntryResource
 {
     /**
      * Fetches an entry from the specified live data source.
-     * 
+     *
      * @param sourceId indicates the {@link LiveDataSource} component implementation
      * @param namespace the component manager name-space where to look for {@link LiveDataSource} implementations; if
      *            not specified then the context / current name-space is used
      * @param entryId identifies the entry to retrieve
+     * @param properties (since 18.8.0RC1) the list of properties to include in the returned live data entry
      * @return the specified entry
      * @throws Exception if retrieving the entry fails
      */
@@ -54,7 +57,8 @@ public interface LiveDataEntryResource
     Entry getEntry(
         @PathParam("sourceId") String sourceId,
         @QueryParam("namespace") @DefaultValue("") String namespace,
-        @PathParam("entryId") String entryId
+        @PathParam("entryId") String entryId,
+        @QueryParam("properties") List<String> properties
     ) throws Exception;
 
     /**

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-api/etc/platform-livedata-api.api.md
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-api/etc/platform-livedata-api.api.md
@@ -50,8 +50,9 @@ export interface LayoutDescriptor {
 
 // @beta
 export interface LiveDataSource {
-    addEntry(source: Source, values: unknown): Promise<void>;
+    addEntry(source: Source, values: unknown): Promise<Values | undefined>;
     getEntries(query: Query): Promise<Data>;
+    getEntry(source: Source, entryId: string, properties: string[]): Promise<Values | undefined>;
     updateEntry(source: Source, entryId: string, values: unknown): Promise<void>;
     updateEntryProperty(source: Source, entryId: string, propertyId: string, value: unknown): Promise<void>;
 }

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-api/src/liveDataSource.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-api/src/liveDataSource.ts
@@ -78,7 +78,7 @@ interface LiveDataSource {
    * Create a new entry from the given values.
    * @param source - the source description
    * @param values - the values of the new entry
-   * @returns a promise with the values of the newly created entry, or undefined if the source trturns none
+   * @returns a promise with the values of the newly created entry, or undefined if the source returns none
    * @since 18.8.0RC1
    */
   addEntry(source: Source, values: unknown): Promise<Values | undefined>;

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-api/src/liveDataSource.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-api/src/liveDataSource.ts
@@ -20,6 +20,7 @@
 import type { Data } from "./data";
 import type { Query } from "./query";
 import type { Source } from "./source";
+import type { Values } from "./values";
 
 /**
  * The component that provides the live data entries and their metadata.
@@ -34,6 +35,20 @@ interface LiveDataSource {
    * @returns a promise with the fetched data
    */
   getEntries(query: Query): Promise<Data>;
+
+  /**
+   * Fetch a single entry from its id.
+   * @param source - the source description
+   * @param entryId - the id of the entry to fetch
+   * @param properties - the properties to include in the fetched entry
+   * @returns a promise with the values of the entry, or undefined if the source returns none
+   * @since 18.8.0RC1
+   */
+  getEntry(
+    source: Source,
+    entryId: string,
+    properties: string[],
+  ): Promise<Values | undefined>;
 
   /**
    * Update a single property of an entry
@@ -63,10 +78,10 @@ interface LiveDataSource {
    * Create a new entry from the given values.
    * @param source - the source description
    * @param values - the values of the new entry
-   * @returns a promise that completes when the entry is created
-   * @since 18.7.0RC1
+   * @returns a promise with the values of the newly created entry, or undefined if the source trturns none
+   * @since 18.8.0RC1
    */
-  addEntry(source: Source, values: unknown): Promise<void>;
+  addEntry(source: Source, values: unknown): Promise<Values | undefined>;
 }
 
 export type { LiveDataSource };

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/displayers/BaseDisplayer.test.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/displayers/BaseDisplayer.test.js
@@ -259,55 +259,6 @@ describe("BaseDisplayer.vue", () => {
 
       expect(wrapper.emitted()["update:isView"]).toBeUndefined();
     });
-
-    it("Requests an edit instead of editing when a save is pending", async () => {
-      const requestEdit = fake();
-      const start = fake();
-      const wrapper = initEditModeWrapper({
-        editBus: { hasPendingSave: () => true, requestEdit, start },
-      });
-
-      await cell(wrapper).trigger("focusin");
-
-      // The pending save is going to refresh the table and re-render this cell, so the edit is
-      // only requested and must be resumed by the re-rendered cell.
-      expect(requestEdit.calledOnceWith("entry-1", "color")).toBe(true);
-      expect(start.called).toBe(false);
-      expect(wrapper.emitted()["update:isView"]).toBeUndefined();
-    });
-
-    it("Resumes a requested edit when the cell is re-created", () => {
-      const enablePendingEdit = fake.returns(true);
-      const wrapper = initEditModeWrapper({ editBus: { enablePendingEdit } });
-
-      expect(enablePendingEdit.calledOnceWith("entry-1", "color")).toBe(true);
-      expect(wrapper.emitted()["update:isView"]).toEqual([[false]]);
-    });
-
-    it("Resumes a requested edit when the entry is refreshed", async () => {
-      let pendingEdit = false;
-      const wrapper = initEditModeWrapper({
-        editBus: { enablePendingEdit: () => pendingEdit },
-      });
-
-      expect(wrapper.emitted()["update:isView"]).toBeUndefined();
-
-      // The refresh following a save re-uses the cell as-is and only updates its entry.
-      pendingEdit = true;
-      await wrapper.setProps({ entry: { color: "blue", age: "13" } });
-
-      expect(wrapper.emitted()["update:isView"]).toEqual([[false]]);
-    });
-
-    it("Does not resume an edit outside of edit mode", () => {
-      const enablePendingEdit = fake.returns(true);
-      initWrapper(BaseDisplayer, {
-        logic: { isEditMode: () => false },
-        editBus: { enablePendingEdit },
-      });
-
-      expect(enablePendingEdit.called).toBe(false);
-    });
   });
 
   describe("Ending an edit", () => {

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/displayers/BaseDisplayer.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/displayers/BaseDisplayer.vue
@@ -268,29 +268,6 @@ export default {
     onDisplayerFocus() {
       // In edit mode, focusing an editable cell should make it editable.
       if (this.logic.isEditMode()) {
-        const editBus = this.logic.getEditBus();
-
-        // If another cell is currently being saved, that save will then
-        // refresh the table and re-render this cell. Opening the editor now
-        // would just lock the edit bus before the editor gets destroyed.
-        if (editBus.hasPendingSave()) {
-          editBus.requestEdit(
-            this.logic.getEntryId(this.entry),
-            this.propertyId,
-          );
-        } else {
-          this.setEdit();
-        }
-      }
-    },
-    // Resume an edit that was requested on this cell.
-    resumeRequestedEdit() {
-      if (
-        this.logic.isEditMode() &&
-        this.logic
-          .getEditBus()
-          .enablePendingEdit(this.logic.getEntryId(this.entry), this.propertyId)
-      ) {
         this.setEdit();
       }
     },
@@ -355,9 +332,6 @@ export default {
     this.logic.getEditBus().onAnyEvent(() => {
       this.duringEditing = !this.logic.getEditBus().isEditable();
     });
-    // This cell might have been re-created by a refresh following a save,
-    // so we try to resume any edit that could have been requested on it.
-    this.resumeRequestedEdit();
   },
   watch: {
     // The disable prop behaves weirdly, so we handle that manually instead.
@@ -367,11 +341,6 @@ export default {
       } else {
         this.$refs.tippy.tippy.enable();
       }
-    },
-    // This cell might have been re-used as-is by a refresh following a save,
-    // so we try to resume any edit that could have been requested on it.
-    entry() {
-      this.resumeRequestedEdit();
     },
   },
 };

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/displayers/displayerTestsHelper.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/displayers/displayerTestsHelper.js
@@ -168,9 +168,6 @@ export function initWrapper(displayer, { props, logic, editBus, mocks }) {
               isEditable() {
                 return true;
               },
-              hasPendingSave: () => false,
-              requestEdit: () => {},
-              enablePendingEdit: () => false,
               onAnyEvent: () => {},
               ...editBus,
             };

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/cards/LayoutCardsCard.test.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/cards/LayoutCardsCard.test.js
@@ -41,6 +41,7 @@ function initWrapper(options = {}) {
             logic: {
               getEntryId: (e) => e.id,
               isEditMode: () => false,
+              isViewFrozen: () => false,
               isSelectionEnabled: () => false,
               getLayoutDescriptor: () => {
                 return { titleProperty: "title" };

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/cards/LayoutCardsCard.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/cards/LayoutCardsCard.vue
@@ -42,6 +42,8 @@
       <h2 v-if="!!titlePropertyId && logic.isPropertyVisible(titlePropertyId)">
         <LivedataDisplayer :property-id="titlePropertyId" :entry="entry" />
       </h2>
+      <!-- Footnote for frozen entries. -->
+      <sup v-if="isEntryFrozen">2</sup>
     </div>
 
     <!--
@@ -162,6 +164,15 @@ export default {
 
     isEntrySelectable() {
       return this.logic.isSelectionEnabled({ entry: this.entry });
+    },
+
+    // The entries are frozen when the live data is in edit mode.
+    isEntryFrozen() {
+      const frozen = this.logic.isViewFrozen() && !this.entry._new;
+      if (frozen) {
+        this.logic.footnotes.put("2", "livedata.footnotes.frozenEntries");
+      }
+      return frozen;
     },
   },
 

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/table/LayoutTableRow.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/table/LayoutTableRow.vue
@@ -45,6 +45,8 @@
     </td>
 
     <td v-if="logic.isEditMode()" class="actions-column">
+      <!-- Footnote for frozen entries. -->
+      <sup v-if="isEntryFrozen">2</sup>
       <template v-if="entry._new">
         <button
           type="button"
@@ -107,6 +109,14 @@ export default {
     },
     isEntrySelectable() {
       return this.logic.isSelectionEnabled({ entry: this.entry });
+    },
+    // The entries are frozen when the live data is in edit mode.
+    isEntryFrozen() {
+      const frozen = this.logic.isViewFrozen() && !this.entry._new;
+      if (frozen) {
+        this.logic.footnotes.put("2", "livedata.footnotes.frozenEntries");
+      }
+      return frozen;
     },
   },
 

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/services/LiveDataLogic.test.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/services/LiveDataLogic.test.js
@@ -1,0 +1,221 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+import { LiveDataLogic } from "./LiveDataLogic";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key) => key }),
+}));
+
+vi.mock("@xwiki/platform-livedata-componentstore", () => ({
+  componentStore: { load: vi.fn().mockResolvedValue({}) },
+}));
+
+const SOURCE = { id: "liveTable" };
+
+/**
+ * @param entries - the entries initially displayed
+ * @returns the serialized live data configuration
+ */
+function initData(entries) {
+  return JSON.stringify({
+    query: {
+      properties: ["name", "status"],
+      source: SOURCE,
+      sort: [],
+      filters: [],
+      offset: 0,
+      limit: 10,
+    },
+    data: { count: entries.length, entries },
+    meta: {
+      defaultLayout: "table",
+      layouts: [{ id: "table" }],
+      propertyDescriptors: [
+        { id: "name", visible: true },
+        { id: "status", visible: true },
+      ],
+      propertyTypes: [],
+      displayers: [{ id: "text" }],
+      defaultDisplayer: "text",
+      filters: [],
+      defaultFilter: "text",
+      entryDescriptor: { idProperty: "id" },
+    },
+  });
+}
+
+/**
+ * @param entries - the entries initially displayed
+ * @returns the live data logic and the mocked live data source
+ */
+function initLogic(entries) {
+  const liveDataSource = {
+    getEntries: vi.fn(),
+    getEntry: vi.fn(),
+    addEntry: vi.fn(),
+    updateEntry: vi.fn(),
+    updateEntryProperty: vi.fn(),
+  };
+  const logic = new LiveDataLogic(liveDataSource, initData(entries), true, () =>
+    Promise.resolve({}),
+  );
+  return { logic, liveDataSource };
+}
+
+/**
+ * @param logic - the live data logic
+ * @returns the ids of the currently displayed entries
+ */
+function displayedIds(logic) {
+  return logic.data.data.entries.map((entry) => entry.id);
+}
+
+describe("LiveDataLogic", () => {
+  let logic;
+  let liveDataSource;
+
+  beforeEach(() => {
+    ({ logic, liveDataSource } = initLogic([
+      { id: "1", name: "one" },
+      { id: "2", name: "two" },
+      { id: "3", name: "three" },
+    ]));
+  });
+
+  it("does not freeze the view outside of edit mode", async () => {
+    liveDataSource.getEntries.mockResolvedValue({
+      count: 3,
+      entries: [{ id: "3" }, { id: "1" }, { id: "2" }],
+    });
+
+    await logic.updateEntries();
+
+    expect(logic.isViewFrozen()).toBe(false);
+    expect(displayedIds(logic)).toStrictEqual(["3", "1", "2"]);
+  });
+
+  it("freezes the view when the edit mode is enabled, and unfreezes it when it is disabled", () => {
+    expect(logic.isViewFrozen()).toBe(false);
+
+    logic.enableEditMode();
+    expect(logic.isViewFrozen()).toBe(true);
+
+    logic.disableEditMode();
+    expect(logic.isViewFrozen()).toBe(false);
+  });
+
+  it("keeps the entries in their frozen position when they are reordered", async () => {
+    logic.enableEditMode();
+    liveDataSource.getEntries.mockResolvedValue({
+      count: 3,
+      entries: [
+        { id: "3", name: "three" },
+        { id: "1", name: "one" },
+        { id: "2", name: "two" },
+      ],
+    });
+
+    await logic.updateEntries();
+
+    expect(displayedIds(logic)).toStrictEqual(["1", "2", "3"]);
+  });
+
+  it("fetches the frozen entries that are not returned by the query anymore", async () => {
+    logic.enableEditMode();
+    // The second entry does not match the query anymore, it is not part of the returned entries.
+    liveDataSource.getEntries.mockResolvedValue({
+      count: 2,
+      entries: [
+        { id: "1", name: "one" },
+        { id: "3", name: "three" },
+      ],
+    });
+    liveDataSource.getEntry.mockResolvedValue({ name: "two (updated)" });
+
+    await logic.updateEntries();
+
+    expect(liveDataSource.getEntry).toHaveBeenCalledWith(SOURCE, "2", [
+      "name",
+      "status",
+    ]);
+    expect(displayedIds(logic)).toStrictEqual(["1", "2", "3"]);
+    expect(logic.data.data.entries[1]).toStrictEqual({
+      id: "2",
+      name: "two (updated)",
+    });
+  });
+
+  it("drops the frozen entries that cannot be fetched anymore", async () => {
+    logic.enableEditMode();
+    liveDataSource.getEntries.mockResolvedValue({
+      count: 2,
+      entries: [
+        { id: "1", name: "one" },
+        { id: "3", name: "three" },
+      ],
+    });
+    // The entry has been deleted in the meantime.
+    liveDataSource.getEntry.mockRejectedValue(new Error("Entry not found"));
+
+    await logic.updateEntries();
+
+    expect(displayedIds(logic)).toStrictEqual(["1", "3"]);
+  });
+
+  it("unfreezes the view when the query changes", async () => {
+    logic.enableEditMode();
+    // Sorting on a property is an explicit user action, the entries are expected to move.
+    logic.data.query.sort = [{ property: "name", descending: false }];
+    liveDataSource.getEntries.mockResolvedValue({
+      count: 3,
+      entries: [
+        { id: "3", name: "three" },
+        { id: "1", name: "one" },
+        { id: "2", name: "two" },
+      ],
+    });
+
+    await logic.updateEntries();
+
+    expect(displayedIds(logic)).toStrictEqual(["3", "1", "2"]);
+    expect(liveDataSource.getEntry).not.toHaveBeenCalled();
+    // The new order is frozen in turn.
+    expect(logic.isViewFrozen()).toBe(true);
+  });
+
+  it("keeps the drafts of the new entries when the view is frozen", async () => {
+    logic.enableEditMode();
+    logic.data.data.entries.push({ _new: true });
+    liveDataSource.getEntries.mockResolvedValue({
+      count: 3,
+      entries: [
+        { id: "1", name: "one" },
+        { id: "2", name: "two" },
+        { id: "3", name: "three" },
+      ],
+    });
+
+    await logic.updateEntries();
+
+    expect(displayedIds(logic)).toStrictEqual(["1", "2", "3", undefined]);
+    expect(logic.data.data.entries[3]._new).toBe(true);
+  });
+});

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/services/LiveDataLogic.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/services/LiveDataLogic.ts
@@ -67,6 +67,9 @@ export class LiveDataLogic implements Logic {
 
   private editMode: Ref<boolean> = ref(false);
 
+  // The view should be frozen in edit mode, this stores the current query and the order of the entries.
+  private frozenView?: { query: string; entryIds: string[] };
+
   constructor(
     private readonly liveDataSource: LiveDataSource,
     data: string,
@@ -424,58 +427,157 @@ export class LiveDataLogic implements Logic {
     }
   }
 
-  updateEntries() {
-    return (
-      this.fetchEntries()
-        // eslint-disable-next-line promise/always-return
-        .then((data) => {
-          // We need to keep drafts to insert them back in the entries.
-          const drafts = this.data.data.entries.filter((entry) => entry._new);
-          data.entries.push(...drafts);
+  async updateEntries() {
+    return this.fetchEntries()
+      .then(async (data) => {
+        // We need to keep drafts to insert them back in the entries.
+        const drafts = this.data.data.entries.filter((entry) => entry._new);
+        data.entries = await this.restoreFrozenView(data.entries);
+        // Refreeze the values (the restore operation might have unfrozen them).
+        this.freezeView(data.entries);
+        data.entries.push(...drafts);
 
-          this.data.data = data;
-          // Before triggering 'entriesUpdated', we wait for the next tick to be sure to have the DOM updated
-          // first.
-          // It turns out this is not enough when components are resolved asynchronously.
-          // Therefore, we preemptively resolve the components that are going to be displayed here. Since they are
-          // cached, the rendering of the displayers will not be delayed later on, and listeners of entriesUpdated
-          // have access to a fully rendered DOM. Note that this approach is not optimal, and we should aim for a
-          // mechanism that does not rely on direct DOM access. Instead, we should provide way to alter the data
-          // externally before starting the rendering. (see https://jira.xwiki.org/browse/XWIKI-23423)
-          const preloadDisplayer = this.getPropertyDescriptors()
-            .filter((it) => it != undefined && this.isPropertyVisible(it.id))
-            .map((it) =>
-              componentStore.load(
-                "displayer",
-                (this.getDisplayerDescriptor(it!.id) as { id: string }).id,
-              ),
-            );
-          // eslint-disable-next-line promise/catch-or-return,promise/always-return,promise/no-nesting
-          Promise.all(preloadDisplayer).then(() => {
-            nextTick(() => this.triggerEvent("entriesUpdated", {}));
-          });
-          // Remove the outdated footnotes, they will be recomputed by the new entries.
-          this.footnotes.reset();
-        })
-        .catch((err) => {
-          // Prevent undesired notifications of the end user for non business related errors (for
-          // instance, the user left the page before the request was completed). See
-          // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/readyState
-          if (err.readyState === 4) {
-            // eslint-disable-next-line promise/catch-or-return,promise/no-nesting
-            this.translate("livedata.error.updateEntriesFailed").then(
-              // @ts-expect-error XWiki.widget is excepted to be globally accessible
-              (value) => new XWiki.widgets.Notification(value, "error"),
-            );
-          }
+        this.data.data = data;
+        // Before triggering 'entriesUpdated', we wait for the next tick to be sure to have the DOM updated
+        // first.
+        // It turns out this is not enough when components are resolved asynchronously.
+        // Therefore, we preemptively resolve the components that are going to be displayed here. Since they are
+        // cached, the rendering of the displayers will not be delayed later on, and listeners of entriesUpdated
+        // have access to a fully rendered DOM. Note that this approach is not optimal, and we should aim for a
+        // mechanism that does not rely on direct DOM access. Instead, we should provide way to alter the data
+        // externally before starting the rendering. (see https://jira.xwiki.org/browse/XWIKI-23423)
+        const preloadDisplayer = this.getPropertyDescriptors()
+          .filter((it) => it != undefined && this.isPropertyVisible(it.id))
+          .map((it) =>
+            componentStore.load(
+              "displayer",
+              (this.getDisplayerDescriptor(it!.id) as { id: string }).id,
+            ),
+          );
+        // eslint-disable-next-line promise/catch-or-return,promise/always-return,promise/no-nesting
+        Promise.all(preloadDisplayer).then(() => {
+          nextTick(() => this.triggerEvent("entriesUpdated", {}));
+        });
+        // Remove the outdated footnotes, they will be recomputed by the new entries.
+        this.footnotes.reset();
+        return;
+      })
+      .catch((err) => {
+        // Prevent undesired notifications of the end user for non business related errors (for
+        // instance, the user left the page before the request was completed). See
+        // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/readyState
+        if (err.readyState === 4) {
+          // eslint-disable-next-line promise/catch-or-return,promise/no-nesting
+          this.translate("livedata.error.updateEntriesFailed").then(
+            // @ts-expect-error XWiki.widget is excepted to be globally accessible
+            (value) => new XWiki.widgets.Notification(value, "error"),
+          );
+        }
 
-          // Do not log if the request has been aborted (e.g., because a second request was started
-          // for the same LD with new criteria).
-          if (err.statusText !== "abort") {
-            console.error("Failed to fetch the entries", err);
-          }
-        })
+        // Do not log if the request has been aborted (e.g., because a second request was started
+        // for the same LD with new criteria).
+        if (err.statusText !== "abort") {
+          console.error("Failed to fetch the entries", err);
+        }
+      });
+  }
+
+  /**
+   * Freeze the view.
+   * @param entries - the displayed entries to freeze
+   */
+  private freezeView(entries: Values[]) {
+    if (!this.editMode.value) {
+      this.frozenView = undefined;
+      return;
+    }
+    this.frozenView = {
+      query: this.getQuerySerialized(),
+      entryIds: entries
+        .map((entry) => this.getEntryId(entry))
+        .filter((entryId): entryId is string => entryId !== undefined),
+    };
+  }
+
+  /**
+   * Restore the frozen view.
+   * Newly fetched values are passed as parameter and will be used as-is if they are part of the frozen set.
+   * Missing values will be fetched manually.
+   * @param entries - the newly fetched entries
+   * @returns the entries to display
+   */
+  private async restoreFrozenView(entries: Values[]): Promise<Values[]> {
+    if (this.frozenView?.query !== this.getQuerySerialized()) {
+      // If the query changed, the view needs to be unfrozen.
+      return entries;
+    }
+    const fetchedEntries = new Map(
+      entries.map((entry): [string | undefined, Values] => [
+        this.getEntryId(entry),
+        entry,
+      ]),
     );
+    // The missing entries changed page, we didn't fetch their new state and need to do it manually.
+    const movedEntries = await this.fetchEntriesById(
+      this.frozenView.entryIds.filter(
+        (entryId) => !fetchedEntries.has(entryId),
+      ),
+    );
+    return this.frozenView.entryIds
+      .map(
+        (entryId) => fetchedEntries.get(entryId) ?? movedEntries.get(entryId),
+      )
+      .filter((entry): entry is Values => entry !== undefined);
+  }
+
+  /**
+   * Indicate whether the view is frozen, meaning the entries should keep their position.
+   * @returns true if the view is frozen, false otherwise
+   * @since 18.8.0RC1
+   */
+  isViewFrozen(): boolean {
+    return this.editMode.value && this.frozenView !== undefined;
+  }
+
+  /**
+   * Fetch the entries having the given ids, one by one and independently of the current query, since
+   * they are precisely the entries that the query does not select anymore.
+   * @param entryIds - the ids of the entries to fetch
+   * @returns the fetched entries, by id, without the ones that could not be fetched
+   */
+  private async fetchEntriesById(entryIds: string[]) {
+    const source = this.data.query.source;
+    const idProperty = this.data.meta.entryDescriptor.idProperty || "id";
+    const fetchedEntries = await Promise.all(
+      entryIds.map(
+        async (entryId): Promise<[string, Values | undefined]> => [
+          entryId,
+          // An entry that can't be fetched anymore does not exist anymore.
+          await this.liveDataSource
+            .getEntry(source, entryId, this.data.query.properties)
+            .catch(() => undefined),
+        ],
+      ),
+    );
+    const entries = new Map<string, Values>();
+    fetchedEntries.forEach(([entryId, entry]) => {
+      if (entry) {
+        // The entry is identified by the id it was fetched with, which its values do not necessarily
+        // hold.
+        entries.set(entryId, { ...entry, [idProperty]: entryId });
+      }
+    });
+    return entries;
+  }
+
+  private getQuerySerialized() {
+    const query = this.data.query;
+    return JSON.stringify({
+      filters: query.filters,
+      sort: query.sort,
+      offset: query.offset,
+      limit: query.limit,
+    });
   }
 
   /**
@@ -1538,10 +1640,12 @@ export class LiveDataLogic implements Logic {
 
   enableEditMode() {
     this.editMode.value = true;
+    this.freezeView(this.data.data.entries);
   }
 
   disableEditMode() {
     this.editMode.value = false;
+    this.frozenView = undefined;
   }
 
   isEditMode(): boolean {
@@ -1559,7 +1663,7 @@ export class LiveDataLogic implements Logic {
       const entryActionKeys = this.getEntryActionKeys();
       try {
         // Submit only data properties, filtering out internal flags and action keys.
-        await this.liveDataSource.addEntry(
+        const newEntry = await this.liveDataSource.addEntry(
           this.data.query.source,
           Object.fromEntries(
             Object.entries(this.data.data.entries[newEntryIndex]).filter(
@@ -1569,6 +1673,11 @@ export class LiveDataLogic implements Logic {
         );
         // We remove the draft once it's successfully saved.
         this.data.data.entries.splice(newEntryIndex, 1);
+        // The created entry is added to the frozen view.
+        const newEntryId = newEntry && this.getEntryId(newEntry);
+        if (newEntryId) {
+          this.frozenView?.entryIds.push(newEntryId);
+        }
         await this.updateEntries();
       } catch (e) {
         console.error("Failed to create entry", e);

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/services/editBus.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/services/editBus.ts
@@ -37,8 +37,6 @@ export class EditBusService {
       [key: string]: { editing: boolean; tosave: boolean; content: unknown };
     };
   }>;
-  // This variable stores an edit request made while an edition is in progress.
-  private pendingEdit?: { entryId: string; propertyId: string };
 
   /**
    * Default constructor.
@@ -149,54 +147,6 @@ export class EditBusService {
       }
     }
     return true;
-  }
-
-  /**
-   * Indicates whether a cell has been edited and is in the middle of the save
-   * process. In that state, opening a new cell for edition should be deferred
-   * (see {@link requestEdit}), since a refresh will happen and re-render the
-   * cells.
-   *
-   * @returns true if a save is in progress, false otherwise
-   */
-  public hasPendingSave() {
-    for (const propertyStates of Object.values(this.editStates)) {
-      for (const propertyState of Object.values(propertyStates)) {
-        if (propertyState.tosave) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Stores a request for edition, to perform it later (once all save processes
-   * have completed). See {@link enablePendingEdit} to apply it.
-   *
-   * @param entryId - the entry id of the cell to edit
-   * @param propertyId - the property id of the cell to edit
-   */
-  public requestEdit(entryId: string, propertyId: string) {
-    this.pendingEdit = { entryId, propertyId };
-  }
-
-  /**
-   * Enables a pending edit request if it targets the given cell.
-   *
-   * @param entryId - the entry id of the cell
-   * @param propertyId - the property id of the cell
-   * @returns true if the given cell had a pending edit request, false otherwise
-   */
-  public enablePendingEdit(entryId: string, propertyId: string) {
-    if (
-      this.pendingEdit?.entryId === entryId &&
-      this.pendingEdit?.propertyId === propertyId
-    ) {
-      this.pendingEdit = undefined;
-      return true;
-    }
-    return false;
   }
 
   onAnyEvent(callback: () => unknown) {

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/services/i18nResolver.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/services/i18nResolver.ts
@@ -93,6 +93,7 @@ export async function i18nResolver(
       "filter.text.label",
       "footnotes.computedTitle",
       "footnotes.propertyNotViewable",
+      "footnotes.frozenEntries",
       "bottombar.noEntries",
       "error.updateEntriesFailed",
       "error.addEntryFailed",

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-xwiki/etc/platform-livedata-xwiki.api.md
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-xwiki/etc/platform-livedata-xwiki.api.md
@@ -20,12 +20,14 @@ export function initTranslationsBuilder(resolver: Resolver): (local: string, i18
 export class XWikiLiveDataSource implements LiveDataSource {
     constructor($: JQueryStatic);
     // (undocumented)
-    addEntry(source: Source, values: unknown): Promise<void>;
+    addEntry(source: Source, values: unknown): Promise<Values | undefined>;
     // (undocumented)
     getEntries(liveDataQuery: Query): Promise<{
         count: number;
         entries: Values[];
     }>;
+    // (undocumented)
+    getEntry(source: Source, entryId: string, properties: string[]): Promise<Values | undefined>;
     // (undocumented)
     updateEntry(source: Source, entryId: string, values: unknown): Promise<void>;
     // (undocumented)

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-xwiki/src/XWikiLiveDataSource.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-xwiki/src/XWikiLiveDataSource.ts
@@ -87,6 +87,21 @@ export class XWikiLiveDataSource implements LiveDataSource {
     }
   }
 
+  getEntry(
+    source: Source,
+    entryId: string,
+    properties: string[],
+  ): Promise<Values | undefined> {
+    // The entry URL already holds parameters (e.g. the namespace), so the properties are appended to it.
+    const entryURL = `${this.getEntryURL(source, entryId)}&${this.$.param(
+      { properties },
+      true,
+    )}`;
+    return Promise.resolve(this.$.getJSON(entryURL)).then(
+      (entry) => entry?.values,
+    );
+  }
+
   updateEntry(source: Source, entryId: string, values: unknown): Promise<void> {
     return Promise.resolve(
       this.$.ajax({
@@ -114,15 +129,16 @@ export class XWikiLiveDataSource implements LiveDataSource {
     );
   }
 
-  addEntry(source: Source, values: unknown): Promise<void> {
+  addEntry(source: Source, values: unknown): Promise<Values | undefined> {
     return Promise.resolve(
       this.$.ajax({
         type: "POST",
         url: this.getEntriesURL(source),
         contentType: "application/json",
+        dataType: "json",
         data: JSON.stringify({ values }),
       }),
-    );
+    ).then((newEntry) => newEntry?.values);
   }
 
   private getEntriesURL(source: Source) {

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-xwiki/src/XWikiLiveDataSource.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-xwiki/src/XWikiLiveDataSource.ts
@@ -87,7 +87,7 @@ export class XWikiLiveDataSource implements LiveDataSource {
     }
   }
 
-  getEntry(
+  async getEntry(
     source: Source,
     entryId: string,
     properties: string[],
@@ -97,9 +97,7 @@ export class XWikiLiveDataSource implements LiveDataSource {
       { properties },
       true,
     )}`;
-    return Promise.resolve(this.$.getJSON(entryURL)).then(
-      (entry) => entry?.values,
-    );
+    return (await this.$.getJSON(entryURL))?.values;
   }
 
   updateEntry(source: Source, entryId: string, values: unknown): Promise<void> {

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-xwiki/src/liveDataSource.test.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-xwiki/src/liveDataSource.test.ts
@@ -22,7 +22,7 @@ import { XWikiLiveDataSource } from "./XWikiLiveDataSource";
 // eslint-disable-next-line import-x/no-named-as-default
 import $ from "jquery";
 import { stub } from "sinon";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const getJSONStub = stub($, "getJSON");
 // @ts-expect-error leftover from initial javascript implementation
@@ -67,6 +67,54 @@ describe("liveDataSource.js", () => {
       });
 
       expect(res).toEqual({ count: 0, entries: [] });
+    });
+  });
+
+  describe("getEntry", () => {
+    afterEach(() => {
+      // Restore the default behavior of the stub, shared by the whole test suite.
+      getJSONStub.resetBehavior();
+      // @ts-expect-error leftover from initial javascript implementation
+      getJSONStub.returns(Promise.resolve({ count: 0, entries: [] }));
+    });
+
+    it("requests the given properties and returns the values of the entry", async () => {
+      global.XWiki = { contextPath: "http://localhost", currentWiki: "xwiki" };
+      getJSONStub.resetBehavior();
+      getJSONStub.returns(
+        // @ts-expect-error leftover from initial javascript implementation
+        Promise.resolve({ values: { name: "entryName", status: "done" } }),
+      );
+
+      const liveDataSource = new XWikiLiveDataSource($);
+
+      const values = await liveDataSource.getEntry(
+        { id: "test" },
+        "MySpace.MyEntry",
+        ["name", "status"],
+      );
+
+      expect(values).toEqual({ name: "entryName", status: "done" });
+      const entryURL = getJSONStub.lastCall.args[0] as string;
+      expect(entryURL).toContain(
+        "/rest/liveData/sources/test/entries/MySpace.MyEntry?",
+      );
+      // The properties are appended to the parameters the entry URL already holds.
+      expect(entryURL).toContain("namespace=wiki%3Axwiki");
+      expect(entryURL).toContain("properties=name&properties=status");
+    });
+
+    it("returns undefined when the source does not return any value", async () => {
+      global.XWiki = { contextPath: "http://localhost", currentWiki: "xwiki" };
+      getJSONStub.resetBehavior();
+      // @ts-expect-error leftover from initial javascript implementation
+      getJSONStub.returns(Promise.resolve(undefined));
+
+      const liveDataSource = new XWikiLiveDataSource($);
+
+      expect(
+        await liveDataSource.getEntry({ id: "test" }, "MySpace.MyEntry", []),
+      ).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24724
Forum discussion: https://forum.xwiki.org/t/ui-improvements-for-live-datas-edit-mode/18748

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

This PR adds support for freezing rows and cards when edit mode is enabled. It means that, during an editing session, the value will no longer move around unless the user manually decides to change the sort/filter/page.
A footnote on all the entries explains this behavior to the user.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This required to add support for optional an properties parameter to the REST API `GET /entries/{id}` endpoint. It was previously missing, causing a discrepancy with the behavior of the `GET /entries` endpoint.
* The feature checking for "pending edits", that was previously used to handle moving rows when switching cells, has been removed since it's no longer useful.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
<img width="1232" height="1127" alt="image" src="https://github.com/user-attachments/assets/d500837b-4be1-46e7-8adb-98b9cbccc684" />

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
I tested the feature extensively manually, and also ran the existing test suite locally.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: N/A