### PR TITLE
XWIKI-23590: Inconsistent rounding of the "Save" button in page Preview mode

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/previewactions.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/previewactions.vm
@@ -60,7 +60,10 @@
     #editActionButton("$!{escapetool.xml($backToEditAction)}", 'backtoedit', 'btn-default')
     <div class="btn-group">
       #editActionButton('save', 'saveandview', 'btn-primary')
-      #editActionButton('saveandcontinue', 'save', 'btn-default')
+      ## The btn-group-last class is needed on the last visible button of the group because the hidden field added by
+      ## editActionButton is ignored by the css selectors, preventing the button from having rounded corners on its
+      ## right side.
+      #editActionButton('saveandcontinue', 'save', 'btn-default btn-group-last')
     </div>
     #editActionButton('cancel', 'cancel', 'btn-default')
   </div>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/previewactions.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/previewactions.vm
@@ -60,9 +60,6 @@
     #editActionButton("$!{escapetool.xml($backToEditAction)}", 'backtoedit', 'btn-default')
     <div class="btn-group">
       #editActionButton('save', 'saveandview', 'btn-primary')
-      ## The btn-group-last class is needed on the last visible button of the group because the hidden field added by
-      ## editActionButton is ignored by the css selectors, preventing the button from having rounded corners on its
-      ## right side.
       #editActionButton('saveandcontinue', 'save', 'btn-default btn-group-last')
     </div>
     #editActionButton('cancel', 'cancel', 'btn-default')


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-23590

# Changes

## Description

* Added the `btn-group-last` class to the last visible button of the save button group in `previewactions.vm`, so its right corners are rounded like the neighbouring "Cancel" button.

# Screenshots & Video

<img width="2120" height="897" alt="comparison-trimmed" src="https://github.com/user-attachments/assets/0510f865-2dfa-4a26-9364-cb9af926e0c6" />

# Executed Tests

* No Maven build: the change only touches a skin Velocity template, with no Java, LESS or test code involved.
* No automated test added: a border radius is not meaningfully assertable in a functional test, and the equivalent fix in XWIKI-18579 shipped without one. A Docker test could only assert the presence of the CSS class, which tests the implementation rather than the symptom.
* Local instance test, see screenshot above.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None
