### PR TITLE
XWIKI-23742: NotificationWatchUIX stylesheet selector too wide

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
@@ -341,19 +341,19 @@
       <code>#watchModal {
   text-align: left;
 }
-.panel-heading a {
+#watchModal .panel-heading a {
   color: black;
 }
-.panel-radio {
+#watchModal .panel-radio {
   padding: 8px 15px;
 }
-.help-icon {
+#watchModal .help-icon {
   float: right;
 }
-.panel-group .panel.wiki-option {
+#watchModal .panel-group .panel.wiki-option {
   margin-top: 2em;
 }
-.panel-title &gt; label {
+#watchModal .panel-title &gt; label {
   font-weight: unset;
   display: inline;
 }</code>


### PR DESCRIPTION
# TLDR

The `NotificationsWatchUIX` on-demand stylesheet declared 5 rules with **unscoped, generic
Bootstrap/skin class selectors** (`.panel-heading a`, `.panel-radio`, `.help-icon`,
`.panel-group .panel.wiki-option`, `.panel-title > label`). They therefore styled *every* panel on
any page loading that stylesheet — which is what broke the Change Request "save" modal.

**Fix:** prefix all 5 selectors with `#watchModal`. One file changed, CSS selectors only, no
behaviour and no id/markup change.

**Impact:**
* Inside the watch modal: nothing changes (`#watchModal .panel-radio` still wins over the skin).
* Outside: panels get their skin/Bootstrap styles back. This also un-breaks the skin's
  merge-conflict dialog (`previewdiff.vm`), whose `.panel-radio` padding was silently overridden.

**Verified** on a locally built `18.8.0-SNAPSHOT` jetty-hsqldb distribution: module + distribution
build green, served stylesheet confirmed scoped, modal computed styles unchanged, leak reproduced
before / gone after. No automated test added (pure CSS-selector scoping, nothing behavioural to
assert).

**Not a regression** — the unscoped selectors came with the file itself in 5f90563c041
(XWIKI-19751), first released in 16.5.0.

Details below.

---

# Jira URL

https://jira.xwiki.org/browse/XWIKI-23742

# Changes

## Description

* Scope the `XWiki.Notifications.Code.NotificationsWatchUIX` stylesheet selectors to `#watchModal`.

The UIX ships an on-demand (SSX) stylesheet whose rules were written without any scoping:

```css
.panel-heading a { color: black; }
.panel-radio { padding: 8px 15px; }
.help-icon { float: right; }
.panel-group .panel.wiki-option { margin-top: 2em; }
.panel-title > label { font-weight: unset; display: inline; }
```

Since `.panel-heading`, `.panel-title` and `.panel-radio` are generic Bootstrap/skin classes, these
rules applied to *every* panel on any page that loaded the stylesheet, not just to the watch modal.
That is what broke the Change Request "save" modal styling reported in the issue.

## Clarifications

* The issue only mentions `.panel-heading a`, but the four sibling rules leak in exactly the same
  way and every element they target lives inside `#watchModal`, so all five are scoped.
* `.panel-radio` is the most visible case: it is also used by the skin's merge-conflict dialog
  (`flamingo/previewdiff.vm`) and the skin defines its own `.panel-radio { float: left; padding: 15px }`
  in `flamingo/less/panels.less`. The UIX rule was silently overriding the skin's padding there.
  Inside the modal nothing changes: `#watchModal .panel-radio` (specificity 1,0,1,0) still wins over
  the skin rule.
* `.help-icon` and `.wiki-option` are only used by this UIX, so scoping them is a no-op today; it is
  done so the stylesheet stops declaring generic-looking global classes.
* The `#watchModal` id itself is unchanged, so the `NotificationsWatchModal` page object
  (`By.id("watchModal")`) is unaffected.

# Screenshots & Video

Verified on a locally built `18.8.0-SNAPSHOT` jetty-hsqldb distribution with this fix included.

**Inside the modal — nothing changes.** Computed styles on the live watch modal still match the
original rules, because `#watchModal .panel-radio` (specificity 1,0,1,0) still beats the skin's
`.panel-radio`:

| Element | Computed value |
|---|---|
| `#watchModal .panel-heading a` | `color: rgb(0, 0, 0)` |
| `#watchModal .panel-radio` | `padding: 8px 15px` |
| `#watchModal .help-icon` | `float: right` |
| `#watchModal .panel-title > label` | `font-weight: 400; display: inline` |

**Outside the modal — the leak is gone.** A plain Bootstrap panel injected into the page content of
the same (watch-stylesheet-loading) page:

| Property | Before (unscoped) | After (scoped) |
|---|---|---|
| `.panel-heading a` color | `rgb(0, 0, 0)` — forced black | `rgb(51, 51, 51)` — theme default |
| `.panel-radio` padding | `8px 15px` — UIX override | `15px` — skin's `panels.less` |
| `.panel-title > label` font-weight | `400` | `700` — Bootstrap default |
| `.panel-title > label` display | `inline` | `inline-block` |

Visually, "before" renders the panel label unbolded and the heading link forced to black; "after"
restores the skin's own bold label and link colour. That is the same class of breakage reported on
the Change Request save modal.

# Executed Tests

**1. Module build** — `xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui`:

```
mvn verify -B -ntp
```

BUILD SUCCESS: `xar:verify` (page format/authors/version), Checkstyle (0 violations), license check
(2/2 OK), Revapi, Spoon.

**2. Full rebuild and packaging** — to test the real artifact rather than the source file:

```
mvn clean install -B -ntp -DskipTests -f xwiki-platform-core/.../xwiki-platform-notifications-ui/pom.xml
mvn clean install -B -ntp -DskipTests -f xwiki-platform-distribution/pom.xml -Plegacy,snapshot
```

Both BUILD SUCCESS. Unzipped the resulting
`xwiki-platform-distribution-flavor-jetty-hsqldb-18.8.0-SNAPSHOT.zip` and ran `start_xwiki.sh`;
confirmed the bundled database ships the scoped CSS.

**3. Served stylesheet is correctly scoped** — on the running instance, enumerated
`document.styleSheets` and confirmed that all five rules coming from
`/xwiki/bin/ssx/XWiki/Notifications/Code/NotificationsWatchUIX` are now `#watchModal`-prefixed, and
that the skin's own `.panel-radio { float: left; padding: 15px }` still arrives independently from
`style.min.css`.

**4. The watch modal is visually and computationally unchanged** — opened the modal from the page
content menu on `Main.WebHome` and read back the computed styles (table above). All four rules still
resolve to their original values, confirming the added `#watchModal` prefix wins over the skin.
The modal renders identically: three watch options, right-aligned help icons, black headings, and
the `margin-top: 2em` gap before "Follow entire wiki".

**5. The reported leak no longer happens** — injected a plain Bootstrap panel into the page content
of that same page (so the watch stylesheet is loaded) and measured it with the fix in place, then
re-injected the old unscoped rules and measured again. Before/after values are in the table above:
with the old CSS the outside panel's heading link is forced black, its label loses Bootstrap's bold
and its radio padding is overridden; with the fix all three come from the skin as they should.

**6. Regression sweep over the source tree** — grepped all sources (excluding `target/`) for other
users of the affected class names:

* `.help-icon`, `.wiki-option` — used only by this UIX, so scoping them is a no-op today.
* `.panel-radio` — also used by `flamingo/previewdiff.vm` (merge-conflict dialog). That usage is
  *fixed* by the scoping, not regressed: it now keeps the skin's `15px` instead of silently
  inheriting this UIX's `8px 15px`.
* `#watchModal` — the id is unchanged, so the `NotificationsWatchModal` page object
  (`By.id("watchModal")`) is unaffected.

**Not run:** the `xwiki-platform-notifications-test-docker` functional tests (`NotificationsIT`,
`NotificationsSettingsIT`). They exercise the modal's behaviour, which this change does not touch,
and they assert no styling. No automated test is added — this is a pure CSS-selector scoping change
with no behavioural surface to assert on.

# Expected merging strategy

This is **not a regression**: the unscoped selectors were introduced together with the file itself in
commit 5f90563c041 (XWIKI-19751, "Move the "watch" button for a page to the page content menu"),
first released in XWiki 16.5.0. The file it replaced contained no panel rules at all.

* Prefers squash: Yes
* Backport on branches:
  *

🤖 Generated with [Claude Code](https://claude.com/claude-code)
