### PR TITLE
[Misc] Check the SonarCloud pull request analysis on an aggregator pom and on a legacy module (DO NOT MERGE)

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -315,6 +315,8 @@
   </build>
   <modules>
     <!-- Sorted Alphabetically -->
+    <!-- TEMPORARY: this comment exists only to make the SonarCloud pull request analysis see a change
+         to this aggregator pom. To be reverted, this pull request is not meant to be merged. -->
     <module>xwiki-platform-activeinstalls2</module>
     <module>xwiki-platform-administration</module>
     <module>xwiki-platform-alerts</module>

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-annotation/src/main/java/org/xwiki/annotation/internal/AnnotationVelocityContextInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-annotation/src/main/java/org/xwiki/annotation/internal/AnnotationVelocityContextInitializer.java
@@ -81,18 +81,8 @@ public class AnnotationVelocityContextInitializer implements VelocityContextInit
                     + "annotations service will not be accessible in velocity context. Root cause is [{}].",
                 ExceptionUtils.getRootCauseMessage(e));
         }
-    }
-
-    /**
-     * TEMPORARY: comparing a value with itself is reported by SonarQube as a bug (java:S1764). It is here only to
-     * check that the pull request analysis reports on a legacy module and that its quality gate then fails. To be
-     * reverted, this pull request is not meant to be merged.
-     *
-     * @param value any value
-     * @return whether the value equals itself
-     */
-    private boolean isSelfEqual(int value)
-    {
-        return value == value;
+        // TEMPORARY: this comment keeps this legacy module among the ones the pull request changes, now that the
+        // bug checking that the quality gate fails on one has been taken out. To be reverted, this pull request is
+        // not meant to be merged.
     }
 }

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-annotation/src/main/java/org/xwiki/annotation/internal/AnnotationVelocityContextInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-annotation/src/main/java/org/xwiki/annotation/internal/AnnotationVelocityContextInitializer.java
@@ -82,4 +82,17 @@ public class AnnotationVelocityContextInitializer implements VelocityContextInit
                 ExceptionUtils.getRootCauseMessage(e));
         }
     }
+
+    /**
+     * TEMPORARY: comparing a value with itself is reported by SonarQube as a bug (java:S1764). It is here only to
+     * check that the pull request analysis reports on a legacy module and that its quality gate then fails. To be
+     * reverted, this pull request is not meant to be merged.
+     *
+     * @param value any value
+     * @return whether the value equals itself
+     */
+    private boolean isSelfEqual(int value)
+    {
+        return value == value;
+    }
 }


### PR DESCRIPTION
**Do not merge.** This pull request exists only to exercise the SonarCloud pull request analysis
after the rework of its module selection, and its two changes have to be reverted.

It touches the two paths that had no run behind them:

- `xwiki-platform-core/pom.xml`, an aggregator pom. Such a change used to widen the analysis to the
  whole reactor, 577 modules; it should now select that pom's own module and its ancestors only.
- a legacy module, which the analysis did not build at all until now, so an issue introduced in one
  passed the gate and turned the master quality gate red after the merge instead.

Expected outcome:

- the "Select the modules the pull request changes" step reports 4 of the reactor's 577 modules:
  `.`, `xwiki-platform-core`, `xwiki-platform-core/xwiki-platform-legacy`,
  `xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-annotation`
- the job **fails** on the quality gate, `new_reliability_rating` being tripped by the `java:S1764`
  bug deliberately added to the legacy module. A failure is the result being checked for here.

Once that is confirmed the bug is removed and the branch pushed again, which has to turn the job
green and checks the `synchronize` trigger on the way.
