### PR TITLE
XWIKI-24752: Changing the resource type in the link dialog removes its input from the tab order

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/plugin.js
@@ -141,7 +141,7 @@
           // Fix the tab-key navigation.
           var resourceTypeDropDownToggle = this.getElement().findOne('.dropdown-toggle');
           var resourceTypeButton = this.getElement().findOne('button.resourceType');
-          var resourceReferenceInput = this.getElement().findOne('.ts-control > input');
+          var resourceReferenceInput = this.getResourceReferenceInput();
           var tabIndex = this.tabIndex;
           [resourceTypeDropDownToggle, resourceTypeButton, resourceReferenceInput].forEach(function(field) {
             var dialog = this;
@@ -156,13 +156,8 @@
               dialog._.currentFocusIndex = this._focusable.focusIndex;
             });
           }, this.getDialog());
-          // Fix the binding between the label and the input.
-          let id = resourceReferenceInput.getAttribute('id');
-          if (!id) {
-            id = CKEDITOR.tools.getNextId();
-            resourceReferenceInput.setAttribute('id', id);
-          }
-          this.getElement().findOne('label').setAttribute('for', id);
+          this.resourceReferenceFocusable = resourceReferenceInput._focusable;
+          this.updateResourceReferenceInput();
         },
         validate: function() {
           var resourceReference = this.getValue();
@@ -255,6 +250,39 @@
         getResourcePickerInput: function() {
           return this.getElement().findOne('input');
         },
+        /**
+         * @return the input the resource reference is typed in, which is the input created by the suggestion widget
+         *   when the selected resource type has a suggester, and the resource reference input otherwise
+         */
+        getResourceReferenceInput: function() {
+          return this.getElement().findOne('.ts-control > input') ||
+            this.getElement().findOne('input.resourceReference');
+        },
+        /**
+         * Makes the focusable and the label of the resource reference target the input that is currently displayed.
+         * The suggestion widget is destroyed and recreated whenever the resource type changes, so the input it had
+         * created is removed from the page.
+         */
+        updateResourceReferenceInput: function() {
+          const dialog = this.getDialog();
+          const focusable = this.resourceReferenceFocusable;
+          const input = this.getResourceReferenceInput();
+          focusable.element = input;
+          // isFocusable() is bound to the input that was passed when the focusable was created.
+          focusable.isFocusable = function() {
+            return !input.getAttribute('disabled') && input.isVisible();
+          };
+          input.on('focus', function() {
+            dialog._.currentFocusIndex = focusable.focusIndex;
+          });
+          // Fix the binding between the label and the input.
+          let id = input.getAttribute('id');
+          if (!id) {
+            id = CKEDITOR.tools.getNextId();
+            input.setAttribute('id', id);
+          }
+          this.getElement().findOne('label').setAttribute('for', id);
+        },
         getLabelElement: function() {
           return this.getElement().findOne('.cke_dialog_ui_labeled_label');
         },
@@ -262,6 +290,10 @@
           // Update the label.
           var resourceTypeConfig = $resource.types[data.newValue] || {label: data.newValue};
           this.getLabelElement().setText(resourceTypeConfig.label);
+          // This event is also fired while the resource picker is being created, before the focusable exists.
+          if (this.resourceReferenceFocusable) {
+            this.updateResourceReferenceInput();
+          }
         },
         onSelectResource: function(event, resource) {
           this.selectedResource = resource;

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/plugin.js
@@ -157,7 +157,7 @@
             });
           }, this.getDialog());
           this.resourceReferenceFocusable = resourceReferenceInput._focusable;
-          this.updateResourceReferenceInput();
+          this.initResourceReferenceInput();
         },
         validate: function() {
           var resourceReference = this.getValue();
@@ -259,11 +259,11 @@
             this.getElement().findOne('input.resourceReference');
         },
         /**
-         * Makes the focusable and the label of the resource reference target the input that is currently displayed.
-         * The suggestion widget is destroyed and recreated whenever the resource type changes, so the input it had
-         * created is removed from the page.
+         * Initializes the focusable and the label of the resource reference to target the input that is currently
+         * displayed. The suggestion widget is destroyed and recreated whenever the resource type changes, so the
+         * input it had created is removed from the page.
          */
-        updateResourceReferenceInput: function() {
+        initResourceReferenceInput: function() {
           const dialog = this.getDialog();
           const focusable = this.resourceReferenceFocusable;
           const input = this.getResourceReferenceInput();
@@ -292,7 +292,7 @@
           this.getLabelElement().setText(resourceTypeConfig.label);
           // This event is also fired while the resource picker is being created, before the focusable exists.
           if (this.resourceReferenceFocusable) {
-            this.updateResourceReferenceInput();
+            this.initResourceReferenceInput();
           }
         },
         onSelectResource: function(event, resource) {

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/LinkIT.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/LinkIT.java
@@ -35,6 +35,8 @@ import org.xwiki.test.docker.junit5.TestReference;
 import org.xwiki.test.docker.junit5.UITest;
 import org.xwiki.test.ui.TestUtils;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  * Test of the CKEditor Link Plugin.
  *
@@ -99,6 +101,12 @@ class LinkIT extends AbstractCKEditorIT
         editor.getRichTextArea().sendKeys(Keys.RIGHT, Keys.ENTER);
 
         linkDialog = editor.getToolBar().insertOrEditLink().setResourceType("attach");
+
+        // Changing the resource type destroys and recreates the suggestion widget, so make sure the input it creates
+        // is still reachable with the tab key and still bound to the field label.
+        assertTrue(linkDialog.isResourceReferenceInputNextInTabOrder());
+        assertTrue(linkDialog.isLabelBoundToResourceReferenceInput());
+
         linkDialog.getResourceSuggestInput().sendKeys("text").waitForSuggestions().selectByVisibleText(attachmentName);
         linkDialog.submit();
 

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/LinkDialog.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/LinkDialog.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.ckeditor.test.po;
 
+import java.util.List;
+
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
@@ -70,6 +72,51 @@ public class LinkDialog extends CKEditorDialog
     public SuggestInputElement getResourceSuggestInput()
     {
         return new SuggestInputElement(getResourceReferenceInput());
+    }
+
+    /**
+     * @return the input the resource reference is typed in, which is the input created by the suggestion widget when
+     *         the selected resource type has a suggester, and the resource reference input otherwise
+     */
+    private WebElement getDisplayedResourceReferenceInput()
+    {
+        List<WebElement> suggesterInputs = getResourcePicker().findElements(cssSelector(".ts-control > input"));
+        return suggesterInputs.isEmpty() ? getResourceReferenceInput() : suggesterInputs.get(0);
+    }
+
+    /**
+     * @return the first input displayed above the resource picker, which is the link display text
+     */
+    private WebElement getDisplayTextInput()
+    {
+        return getContainer().findElements(cssSelector(".cke_dialog_page_contents input.cke_dialog_ui_input_text"))
+            .stream().filter(WebElement::isDisplayed).findFirst().orElseThrow();
+    }
+
+    /**
+     * Moves the keyboard focus to the display text field, then presses the tab key once.
+     *
+     * @return {@code true} if the focus landed on the input the resource reference is typed in
+     * @since 18.8.0RC1
+     */
+    public boolean isResourceReferenceInputNextInTabOrder()
+    {
+        WebElement displayTextInput = getDisplayTextInput();
+        displayTextInput.click();
+        displayTextInput.sendKeys(Keys.TAB);
+        return getDriver().switchTo().activeElement().equals(getDisplayedResourceReferenceInput());
+    }
+
+    /**
+     * @return {@code true} if the field label is bound to the input the resource reference is typed in
+     * @since 18.8.0RC1
+     */
+    public boolean isLabelBoundToResourceReferenceInput()
+    {
+        String labelTarget =
+            getResourcePicker().findElement(xpath("preceding-sibling::label")).getDomAttribute("for");
+        return labelTarget != null
+            && labelTarget.equals(getDisplayedResourceReferenceInput().getDomAttribute("id"));
     }
 
     /**


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24752

# Changes

## Description

* Registered the resource picker's dialog focusable on the input that is currently displayed.
* Updated that focusable and the field `label[for]` when the resource type changes.
* Covered the tab order and the label binding in `LinkIT#insertLinks`.

## Clarifications

**Root cause.** The dialog's focusable for this field was registered once, on load, on the input that Tom Select creates. Changing the resource type destroys and recreates that suggester, so the focusable was left pointing at an element no longer in the page. CKEditor then skipped the field when tabbing. The label's `for` pointed at that same missing element.

Two details behind the fix:

* CKEditor's `Focusable` also captures the element in its own `isFocusable()`, so re-pointing `element` alone is not enough. Both are replaced.
* For resource types with no suggester, the input to use is `input.resourceReference`, not `getResourcePickerInput()`. The latter is the hidden input that holds the serialized reference.

Not a duplicate of XWIKI-24563: that fix covered the dialog as first opened, this one covers what happens after the resource type changes.

# Screenshots & Video

The change is keyboard-only, so there is nothing visual to show.

# Executed Tests

* `mvn clean install -Plegacy -pl xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins` — BUILD SUCCESS.
* `mvn clean install -Plegacy,integration-tests,docker -pl xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects` — BUILD SUCCESS, 0 Checkstyle violations.
* `mvn verify -Plegacy,integration-tests,docker -pl xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker -Dit.test=LinkIT -Dxwiki.test.ui.servletEngine=tomcat -Dxwiki.test.ui.database=postgresql` — `Tests run: 4, Failures: 0, Errors: 0`.
* Same `LinkIT` run with the `plugin.js` change reverted, to confirm the new assertion actually catches the regression — `Tests run: 4, Failures: 1`, `insertLinks` failing on the tab-order assertion with `expected: <true> but was: <false>`. The other three tests passed, which is why nothing in the suite caught this before.
* Manual check on an 18.4.5 snapshot instance driven by Playwright: the reference input is reached by Tab, and the label `for` resolves to the displayed input, for the Page, Mail Address, URL and Attachment resource types, and suggestions still load after switching types. The tab sequence from the Display Text field, after switching the resource type to Mail Address, goes from `Display Text -> [reference input skipped] -> resource type dropdown -> Options -> OK -> Cancel` to `Display Text -> reference input -> resource type dropdown -> Options -> OK -> Cancel`.

A multi-angle automated review was also run over the fix commit using the skill from the community dev-llm `xwiki-review`. One finding survived verification, it was that the new behaviour had no automated test, which the second commit addresses. Two findings were dropped because they were below the confidence bar.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * 18.4.X and 17.10.x similarly to XWIKI-24563.