### PR TITLE
[Misc] Remove the raw ResourceReferenceHandler types

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -151,6 +151,36 @@
             -->
             <revapi.differences>
               <justification>
+                ResourceReferenceHandler was declared as Comparable over the raw ResourceReferenceHandler type. It is
+                now Comparable over ResourceReferenceHandler&lt;?&gt;, which removes the raw type without changing the
+                erasure: the compiled compareTo() descriptor and the Comparable bridge method are identical, so
+                existing compiled Handlers keep working, and Handlers declaring the former raw parameter still
+                override it (with an unchecked warning).
+              </justification>
+              <criticality>allowed</criticality>
+              <differences>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.superTypeTypeParametersChanged</code>
+                  <old>interface org.xwiki.resource.ResourceReferenceHandler&lt;T&gt;</old>
+                  <new>interface org.xwiki.resource.ResourceReferenceHandler&lt;T&gt;</new>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.noLongerImplementsInterface</code>
+                  <old>interface org.xwiki.resource.ResourceReferenceHandler&lt;T&gt;</old>
+                  <new>interface org.xwiki.resource.ResourceReferenceHandler&lt;T&gt;</new>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <regex>true</regex>
+                  <code>java\.class\.noLongerImplementsInterface</code>
+                  <interface>java\.lang\.Comparable&lt;org\.xwiki\.resource\.ResourceReferenceHandler&gt;</interface>
+                </item>
+              </differences>
+            </revapi.differences>
+            <revapi.differences>
+              <justification>
                 These utility classes (only static members) had their implicit public constructor made private to
                 follow SonarQube rule java:S1118 (utility classes should not be instantiable). Instantiating them was
                 never useful, but this is technically a real breakage since existing code calling the constructor will

--- a/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-api/src/main/java/org/xwiki/resource/AbstractResourceReferenceHandler.java
+++ b/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-api/src/main/java/org/xwiki/resource/AbstractResourceReferenceHandler.java
@@ -49,7 +49,7 @@ public abstract class AbstractResourceReferenceHandler<T> implements ResourceRef
     }
 
     @Override
-    public int compareTo(ResourceReferenceHandler handler)
+    public int compareTo(ResourceReferenceHandler<?> handler)
     {
         return Integer.compare(getPriority(), handler.getPriority());
     }

--- a/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-api/src/main/java/org/xwiki/resource/ResourceReferenceHandler.java
+++ b/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-api/src/main/java/org/xwiki/resource/ResourceReferenceHandler.java
@@ -32,7 +32,7 @@ import org.xwiki.component.annotation.Role;
  * @since 6.1M2
  */
 @Role
-public interface ResourceReferenceHandler<T> extends Comparable<ResourceReferenceHandler>
+public interface ResourceReferenceHandler<T> extends Comparable<ResourceReferenceHandler<?>>
 {
     /**
      * The priority of execution relative to the other Handlers. The lowest values have the highest priorities and

--- a/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-api/src/test/java/org/xwiki/resource/ResourceReferenceHandlerTest.java
+++ b/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-api/src/test/java/org/xwiki/resource/ResourceReferenceHandlerTest.java
@@ -57,11 +57,11 @@ class ResourceReferenceHandlerTest
     @Test
     void priority()
     {
-        ResourceReferenceHandler handler1 = new TestableResourceReferenceHandler(500);
+        ResourceReferenceHandler<ResourceType> handler1 = new TestableResourceReferenceHandler(500);
         assertEquals(500, handler1.getPriority());
         assertTrue(handler1.getSupportedResourceReferences().contains(new ResourceType("test")));
 
-        ResourceReferenceHandler handler2 = new TestableResourceReferenceHandler(200);
+        ResourceReferenceHandler<ResourceType> handler2 = new TestableResourceReferenceHandler(200);
         assertTrue(handler1.compareTo(handler2) > 0);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/src/main/java/org/xwiki/resource/internal/AbstractResourceReferenceHandlerManager.java
+++ b/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/src/main/java/org/xwiki/resource/internal/AbstractResourceReferenceHandlerManager.java
@@ -62,7 +62,7 @@ public abstract class AbstractResourceReferenceHandlerManager<T> implements Reso
     @Inject
     private Logger logger;
 
-    protected abstract boolean matches(ResourceReferenceHandler handler, T resourceReferenceQualifier);
+    protected abstract boolean matches(ResourceReferenceHandler<?> handler, T resourceReferenceQualifier);
 
     protected abstract T extractResourceReferenceQualifier(ResourceReference reference);
 
@@ -70,7 +70,7 @@ public abstract class AbstractResourceReferenceHandlerManager<T> implements Reso
     public void handle(ResourceReference reference) throws ResourceReferenceHandlerException
     {
         // Look for a Handler supporting the Resource Type located in the passed Resource Reference object.
-        Set<ResourceReferenceHandler> orderedHandlers =
+        Set<ResourceReferenceHandler<?>> orderedHandlers =
             getMatchingHandlers(extractResourceReferenceQualifier(reference));
 
         if (!orderedHandlers.isEmpty()) {
@@ -100,13 +100,13 @@ public abstract class AbstractResourceReferenceHandlerManager<T> implements Reso
         return result;
     }
 
-    private Set<ResourceReferenceHandler> getMatchingHandlers(T resourceReferenceQualifier)
+    private Set<ResourceReferenceHandler<?>> getMatchingHandlers(T resourceReferenceQualifier)
         throws ResourceReferenceHandlerException
     {
         // Look for a Handler supporting the Resource Type located in the passed Resource Reference object.
         // TODO: Use caching to avoid having to sort all Handlers at every call.
-        Set<ResourceReferenceHandler> orderedHandlers = new TreeSet<>();
-        for (ResourceReferenceHandler handler : getHandlers(resourceReferenceQualifier.getClass())) {
+        Set<ResourceReferenceHandler<?>> orderedHandlers = new TreeSet<>();
+        for (ResourceReferenceHandler<?> handler : getHandlers(resourceReferenceQualifier.getClass())) {
             if (matches(handler, resourceReferenceQualifier)) {
                 orderedHandlers.add(handler);
             }
@@ -115,7 +115,8 @@ public abstract class AbstractResourceReferenceHandlerManager<T> implements Reso
         return orderedHandlers;
     }
 
-    private List<ResourceReferenceHandler> getHandlers(Class typeClass) throws ResourceReferenceHandlerException
+    private List<ResourceReferenceHandler<?>> getHandlers(Class<?> typeClass)
+        throws ResourceReferenceHandlerException
     {
         try {
             return this.contextComponentManager

--- a/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/src/main/java/org/xwiki/resource/internal/DefaultResourceReferenceHandlerChain.java
+++ b/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/src/main/java/org/xwiki/resource/internal/DefaultResourceReferenceHandlerChain.java
@@ -49,7 +49,7 @@ public class DefaultResourceReferenceHandlerChain implements ResourceReferenceHa
     /**
      * Contains all remaining Handlers to execute with Handlers on top executing first.
      */
-    private final Queue<ResourceReferenceHandler> handlerStack;
+    private final Queue<ResourceReferenceHandler<?>> handlerStack;
 
     private final ObservationManager observation;
 
@@ -57,7 +57,7 @@ public class DefaultResourceReferenceHandlerChain implements ResourceReferenceHa
      * @param orderedHandlers the sorted list of Handlers to execute
      * @param observation used to send event around executed handlers
      */
-    public DefaultResourceReferenceHandlerChain(Collection<ResourceReferenceHandler> orderedHandlers,
+    public DefaultResourceReferenceHandlerChain(Collection<ResourceReferenceHandler<?>> orderedHandlers,
         ObservationManager observation)
     {
         this.handlerStack = new LinkedList<>(orderedHandlers);

--- a/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/src/main/java/org/xwiki/resource/internal/MainResourceReferenceHandlerManager.java
+++ b/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/src/main/java/org/xwiki/resource/internal/MainResourceReferenceHandlerManager.java
@@ -38,7 +38,7 @@ import org.xwiki.resource.ResourceType;
 public class MainResourceReferenceHandlerManager extends AbstractResourceReferenceHandlerManager<ResourceType>
 {
     @Override
-    protected boolean matches(ResourceReferenceHandler handler, ResourceType resourceType)
+    protected boolean matches(ResourceReferenceHandler<?> handler, ResourceType resourceType)
     {
         return handler.getSupportedResourceReferences().contains(resourceType);
     }

--- a/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/src/main/java/org/xwiki/resource/internal/entity/EntityResourceReferenceHandlerManager.java
+++ b/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/src/main/java/org/xwiki/resource/internal/entity/EntityResourceReferenceHandlerManager.java
@@ -40,7 +40,7 @@ import org.xwiki.resource.internal.AbstractResourceReferenceHandlerManager;
 public class EntityResourceReferenceHandlerManager extends AbstractResourceReferenceHandlerManager<EntityResourceAction>
 {
     @Override
-    protected boolean matches(ResourceReferenceHandler handler, EntityResourceAction action)
+    protected boolean matches(ResourceReferenceHandler<?> handler, EntityResourceAction action)
     {
         return handler.getSupportedResourceReferences().contains(action);
     }

--- a/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/src/test/java/org/xwiki/resource/internal/DefaultResourceReferenceHandlerChainTest.java
+++ b/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/src/test/java/org/xwiki/resource/internal/DefaultResourceReferenceHandlerChainTest.java
@@ -22,6 +22,9 @@ package org.xwiki.resource.internal;
 import java.util.Queue;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.xwiki.component.util.ReflectionUtils;
 import org.xwiki.resource.ResourceReference;
 import org.xwiki.resource.ResourceReferenceHandler;
@@ -37,19 +40,22 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  * @since 6.1M2
  */
+@ExtendWith(MockitoExtension.class)
 class DefaultResourceReferenceHandlerChainTest
 {
+    @Mock
+    private Queue<ResourceReferenceHandler<?>> queue;
+
     @Test
     void executeNextWhenNoMoreAction() throws Exception
     {
         DefaultResourceReferenceHandlerChain chain = DefaultResourceReferenceHandlerChain.EMPTY;
-        Queue<ResourceReferenceHandler> queue = mock(Queue.class);
-        when(queue.isEmpty()).thenReturn(true);
-        ReflectionUtils.setFieldValue(chain, "handlerStack", queue);
+        when(this.queue.isEmpty()).thenReturn(true);
+        ReflectionUtils.setFieldValue(chain, "handlerStack", this.queue);
 
         chain.handleNext(mock(ResourceReference.class));
 
         // Verify that we don't get a ResourceReferenceHandler since the queue is empty.
-        verify(queue, never()).poll();
+        verify(this.queue, never()).poll();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/src/test/java/org/xwiki/resource/internal/MainResourceReferenceHandlerManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/src/test/java/org/xwiki/resource/internal/MainResourceReferenceHandlerManagerTest.java
@@ -22,6 +22,7 @@ package org.xwiki.resource.internal;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.component.util.DefaultParameterizedType;
 import org.xwiki.resource.ResourceReference;
@@ -51,23 +52,27 @@ class MainResourceReferenceHandlerManagerTest
     @InjectMockComponents
     private MainResourceReferenceHandlerManager handlerManager;
 
+    @Mock(name = "handler1")
+    private ResourceReferenceHandler<ResourceType> handler1;
+
+    @Mock(name = "handler2")
+    private ResourceReferenceHandler<ResourceType> handler2;
+
     @Test
     void handleWithOrder(ComponentManager componentManager) throws Exception
     {
         // First Handler component will lower priority
-        ResourceReferenceHandler testHandler = mock(ResourceReferenceHandler.class, "handler1");
-        when(testHandler.getSupportedResourceReferences()).thenReturn(Arrays.asList(new ResourceType("test")));
+        when(this.handler1.getSupportedResourceReferences()).thenReturn(Arrays.asList(new ResourceType("test")));
 
         // Second Handler component will higher priority so that it's executed first
-        ResourceReferenceHandler beforeTestHandler = mock(ResourceReferenceHandler.class, "handler2");
-        when(beforeTestHandler.getSupportedResourceReferences()).thenReturn(Arrays.asList(new ResourceType("test")));
-        // We return 1 to mean that the second Handler has a higher priority than the first Handler
-        when(beforeTestHandler.compareTo(testHandler)).thenReturn(-1);
+        when(this.handler2.getSupportedResourceReferences()).thenReturn(Arrays.asList(new ResourceType("test")));
+        // We return -1 to mean that the second Handler has a higher priority than the first Handler
+        when(this.handler2.compareTo(this.handler1)).thenReturn(-1);
 
         ComponentManager contextComponentManager = componentManager.getInstance(ComponentManager.class, "context");
-        when(contextComponentManager.<ResourceReferenceHandler>getInstanceList(
+        when(contextComponentManager.<ResourceReferenceHandler<?>>getInstanceList(
             new DefaultParameterizedType(null, ResourceReferenceHandler.class, ResourceType.class)))
-                .thenReturn(Arrays.asList(testHandler, beforeTestHandler));
+                .thenReturn(Arrays.<ResourceReferenceHandler<?>>asList(this.handler1, this.handler2));
 
         ResourceReference reference = mock(ResourceReference.class);
         when(reference.getType()).thenReturn(new ResourceType("test"));
@@ -75,24 +80,23 @@ class MainResourceReferenceHandlerManagerTest
         handlerManager.handle(reference);
 
         // Verify that the second Action is called (since it has a higher priority).
-        verify(beforeTestHandler).handle(same(reference), any(ResourceReferenceHandlerChain.class));
+        verify(this.handler2).handle(same(reference), any(ResourceReferenceHandlerChain.class));
     }
 
     @Test
     void matches()
     {
-        ResourceReferenceHandler resourceReferenceHandler1 = mock(ResourceReferenceHandler.class);
-        ResourceReferenceHandler resourceReferenceHandler2 = mock(ResourceReferenceHandler.class);
         ResourceType resourceType1 = new ResourceType("test1");
         ResourceType resourceType2 = new ResourceType("test2");
 
-        when(resourceReferenceHandler1.getSupportedResourceReferences()).thenReturn(Arrays.asList(resourceType1));
-        when(resourceReferenceHandler2.getSupportedResourceReferences()).thenReturn(Arrays.asList(resourceType1, resourceType2));
+        when(this.handler1.getSupportedResourceReferences()).thenReturn(Arrays.asList(resourceType1));
+        when(this.handler2.getSupportedResourceReferences())
+            .thenReturn(Arrays.asList(resourceType1, resourceType2));
 
-        assertTrue(handlerManager.matches(resourceReferenceHandler1, resourceType1));
-        assertFalse(handlerManager.matches(resourceReferenceHandler1, resourceType2));
+        assertTrue(this.handlerManager.matches(this.handler1, resourceType1));
+        assertFalse(this.handlerManager.matches(this.handler1, resourceType2));
 
-        assertTrue(handlerManager.matches(resourceReferenceHandler2, resourceType1));
-        assertTrue(handlerManager.matches(resourceReferenceHandler2, resourceType2));
+        assertTrue(this.handlerManager.matches(this.handler2, resourceType1));
+        assertTrue(this.handlerManager.matches(this.handler2, resourceType2));
     }
 }


### PR DESCRIPTION
# Jira URL

None — this is a `[Misc]` cleanup, follow-up to the review of
https://github.com/xwiki/xwiki-platform/pull/6258.

# Changes

## Description

`ResourceReferenceHandler` was declared as `Comparable` over its **own raw type**, which is where
every remaining `ResourceReferenceHandler` raw type in the code base came from:

```java
-public interface ResourceReferenceHandler<T> extends Comparable<ResourceReferenceHandler>
+public interface ResourceReferenceHandler<T> extends Comparable<ResourceReferenceHandler<?>>
```

Together with the matching parameter on `AbstractResourceReferenceHandler#compareTo`, this lets the
wildcard be propagated to the internal Handler manager and chain (`Set`/`Queue`/`Collection` of
Handlers, `matches()`, `getHandlers()`) and to their tests. After the change, `javac -Xlint` reports
**zero** `raw type: org.xwiki.resource.ResourceReferenceHandler` warnings across the platform.

## Clarifications

**Why the wildcard and not `Comparable<ResourceReferenceHandler<T>>`.** The `<T>` variant is
genuinely source-breaking, verified by compiling it: `a.compareTo(b)` across two different `T`s stops
compiling, a `ResourceReferenceHandler<?>` can no longer call `compareTo` at all (capture), and
`Collections.sort(List<ResourceReferenceHandler<?>>)` fails to infer. The `<?>` variant keeps all
three compiling.

**Backward compatibility.**

* *Binary:* the erasure is unchanged. `javap` on the recompiled class shows the `Comparable` bridge
  still calling descriptor `(Lorg/xwiki/resource/ResourceReferenceHandler;)I` — byte-for-byte the old
  signature. Existing compiled Handlers keep working.
* *Source:* an existing Handler declaring the old raw `public int compareTo(ResourceReferenceHandler
  handler)` still overrides the new method (override-by-erasure, JLS 8.4.2) and compiles, with only a
  `rawtypes` warning. Verified by compiling both shapes — a direct implementor and one extending
  `AbstractResourceReferenceHandler` — against the new jar.

**Revapi.** Revapi compares *parameterized* super types, so it reports three differences even though
the bytecode is identical: `superTypeTypeParametersChanged` on the interface, and
`noLongerImplementsInterface: Comparable<ResourceReferenceHandler>` on the interface plus on every
public class of the hierarchy (`AbstractResourceReferenceHandler`,
`AbstractServletResourceReferenceHandler`, …). They are ignored in `xwiki-platform-core/pom.xml`, the
last one via a regex on the `interface` attachment so that it covers the whole hierarchy without
silencing unrelated interface removals. That it is *not* a blanket ignore was checked by replacing
the interface pattern with a bogus value, which makes the difference fail the build again.

**The internal changes** (`org.xwiki.resource.internal`) are not public API. They are binary
compatible anyway (generic signatures only), and Revapi is green on them.

# Screenshots & Video

N/A — no functional change.

# Executed Tests

Every module of the platform that contains a class of the Handler hierarchy, built with tests,
Checkstyle and Revapi:

```
mvn install -pl xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-api,\
…-resource-default,…-resource-servlet,…-resource-temporary,…/xwiki-platform-webjars-api,\
…/xwiki-platform-job-handler,…/xwiki-platform-vfs-api,\
…/xwiki-platform-security-authentication-default,…/xwiki-platform-rendering-async-default,\
…/xwiki-platform-captcha-jcaptcha-api
```

`BUILD SUCCESS`, 10/10 modules, all tests green, and no `raw type` warning left for
`ResourceReferenceHandler`. A grep over the whole repository confirms no Handler implementation
exists outside `xwiki-platform-core`, so the single Revapi ignore covers the entire tree.

# Expected merging strategy

Prefers squash: Yes. No backport needed.

---
_Generated with [Claude Code](https://claude.com/claude-code)_
