### PR TITLE
[Misc] Fix a SonarQube issue: a possible NPE when resolving the edit mode

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/edit/EditModeResolver.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/edit/EditModeResolver.java
@@ -109,18 +109,23 @@ public class EditModeResolver
         // Otherwise, we fallback to the default editor. This part is taken from the getDefaultDocumentEditor macro
         // defined in macros.vm from xwiki-platform-web-templates.
 
-        // If a sheet matches the edit action for this document and no specific editor was specified,
-        // the Inline Form edit mode will be used.
+        // There is no document to edit when the edit mode is resolved outside of a request that targets a document,
+        // in which case we can neither look for sheets nor check the document syntax.
         XWikiContext context = this.xwikiContextProvider.get();
         XWikiDocument document = (XWikiDocument) context.get("tdoc");
-        if (!this.sheetManager.getSheets(document, context.getAction()).isEmpty()) {
-            return INLINE;
-        }
+        if (document != null) {
+            // If a sheet matches the edit action for this document and no specific editor was specified,
+            // the Inline Form edit mode will be used.
+            if (!this.sheetManager.getSheets(document, context.getAction()).isEmpty()) {
+                return INLINE;
+            }
 
-        // If the default editor is set to WYSIWYG, it will be used if possible.
-        String xwikiEditorPreference = context.getWiki().getEditorPreference(context);
-        if (WYSIWYG.equals(xwikiEditorPreference) && isSyntaxWYSIWYGEditable(document.getSyntax().toIdString())) {
-            return xwikiEditorPreference;
+            // If the default editor is set to WYSIWYG, it will be used if possible.
+            String xwikiEditorPreference = context.getWiki().getEditorPreference(context);
+            if (WYSIWYG.equals(xwikiEditorPreference)
+                && isSyntaxWYSIWYGEditable(document.getSyntax().toIdString())) {
+                return xwikiEditorPreference;
+            }
         }
 
         return WIKI;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/edit/EditModeResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/edit/EditModeResolverTest.java
@@ -53,6 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -188,6 +189,18 @@ class EditModeResolverTest
     void getEditModeDefaultOther()
     {
         assertEquals(EditModeResolver.WIKI, this.editModeResolver.getEditMode());
+    }
+
+    @Test
+    void getEditModeWithoutDocument()
+    {
+        wysiwygSyntaxSupported(true);
+        when(this.wiki.getEditorPreference(this.xwikiContext)).thenReturn(EditModeResolver.WYSIWYG);
+        when(this.xwikiContext.get("tdoc")).thenReturn(null);
+
+        assertEquals(EditModeResolver.WIKI, this.editModeResolver.getEditMode());
+
+        verifyNoInteractions(this.sheetManager);
     }
 
     @Test


### PR DESCRIPTION
Fixes the SonarCloud issue that turned the `master` quality gate red (New Reliability Rating C):
https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&open=AaBKgSjv2Sq2goC8pHGa
(`javabugs:S2259` — "Fix this access that will throw a NullPointerException when executed", on
`EditModeResolver.java:122`).

`EditModeResolver#getEditMode()` reads the translated document from the XWiki context (`tdoc`) and
then dereferences it twice — it passes it to `SheetManager#getSheets()` (which starts with
`document.getDocumentReference()`) and calls `document.getSyntax()`. The `tdoc` context entry is
absent when the edit mode is resolved outside of a request targeting a document, so both accesses
can throw.

* Return the default `wiki` edit mode when there is no document in the context, since neither the
  sheets nor the document syntax can be looked up without one.
* Add a unit test covering that case.

The issue was introduced by 3ca286673577c0a301d5b8fd92017952fcf8f310 (XWIKI-24371), which moved the
`getDefaultDocumentEditor` Velocity macro into this new component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)