### PR TITLE
[Misc] Restore the default hierarchy mode after each BreadcrumbsIT test

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/BreadcrumbsIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/BreadcrumbsIT.java
@@ -21,6 +21,7 @@ package org.xwiki.flamingo.test.docker;
 
 import java.util.Arrays;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -52,6 +53,16 @@ class BreadcrumbsIT
     void setUp(TestUtils setup)
     {
         setup.loginAsSuperAdmin();
+    }
+
+    @AfterEach
+    void tearDown(TestUtils setup)
+    {
+        // Restore the default hierarchy mode, whatever happened during the test. The hierarchy mode is a wiki-wide
+        // configuration, so leaving it set to "parentchild" breaks the breadcrumb of all the tests executing after
+        // this one in the same XWiki instance. Note that we need to log back in since a test can have logged out.
+        setup.loginAsSuperAdmin();
+        setup.setHierarchyMode("reference");
     }
 
     @Test
@@ -93,10 +104,6 @@ class BreadcrumbsIT
         assertFalse(vp.hasBreadcrumbContent(PARENT_TITLE, false, true));
         assertTrue(vp.hasBreadcrumbContent(CHILD_TITLE, true, true));
         assertTrue(vp.hasBreadcrumbContent(parentPageName, false, false));
-
-        // Set back the default hierarchy mode (but first we need to log back).
-        setup.loginAsSuperAdmin();
-        setup.setHierarchyMode("reference");
     }
 
     @Test


### PR DESCRIPTION
# Jira URL

N/A — `[Misc]` commit (test-only cleanup, no user-visible change).

# Changes

## Description

* Move the reset of the `core.hierarchyMode` wiki configuration out of the body of
  `BreadcrumbsIT.verifyBreadcrumbInParentChildMode()` and into an `@AfterEach` method, so that the default
  (`reference`) mode is restored whatever happens during the test.

## Clarifications

* `verifyBreadcrumbInParentChildMode()` sets `core.hierarchyMode` to `parentchild` at the beginning of the test and
  reset it to `reference` as its very last statement. Since `core.hierarchyMode` is a wiki-wide configuration and since
  all the `AllIT` nested tests share a single XWiki instance, any failure occurring between those two statements leaves
  the whole instance in `parentchild` mode for the rest of the module run.
* This is exactly what happened in build
  [`ptsgtoharkxxw`](https://community.develocity.cloud/s/ptsgtoharkxxw) (job *XWiki Environment Tests /
  xwiki-platform / stable-18.7.x* #12): one Selenium `get` command timed out while creating the parent page
  (`BreadcrumbsIT:71`) and, as a direct consequence, three more tests failed:
  * `BreadcrumbsIT.verifyBreadcrumbInLongHierarchy` — `NoSuchElementException` on `#hierarchy`, because in
    `parentchild` mode `hierarchy.vm` calls `#hierarchy_parentChild()`, which renders nothing at all when the document
    has no parent (`hierarchy_macros.vm`), so the `#hierarchy` element does not exist.
  * `CreatePageNestedDocumentsIT.createNestedDocumentsFromURL` and `.createNestedDocumentsFromUI` — `expected: </A> but
    was: <Home Page/A>`, because in `parentchild` mode UI-created pages get the default parent.
* The `TimeoutException` that triggered it is an infrastructure flicker (a Develocity failure group of 14 occurrences
  over the last 2 months, hitting unrelated tests too) and is not addressed here. What this PR fixes is the blast
  radius: such a flicker should cost 1 failure, not 4, and should not make unrelated tests fail.
* Note that the `@AfterEach` needs to log back in as superadmin since `verifyBreadcrumbInParentChildMode()` forces the
  guest user, and `TestUtils.setHierarchyMode()` goes through the object editor UI.
* Why an `@AfterEach` rather than a `try`/`finally` inside the test, or an `@AfterEach` guarded by a flag:
  * It's the idiom already used for this very configuration in `ClassSheetIT`.
  * Unlike a `try`/`finally`, it doesn't destroy the original failure: in Java an exception thrown from `finally`
    discards the exception being propagated, whereas JUnit keeps the test's exception as primary and attaches a
    tear-down failure as suppressed. That matters here precisely because the trigger was a Selenium timeout, so the
    clean-up is itself likely to fail in the same conditions.
  * A flag-guarded `@AfterEach` (to skip the reset for tests that never changed the mode) was measured and rejected:
    `@UITest` is `@TestInstance(PER_CLASS)`, so the flag has to be reset by hand, which is the fragility JUnit warns
    about with that lifecycle, for a saving of 4.7s (see below).

# Screenshots & Video

N/A — no UI change.

# Executed Tests

```
mvn -B -ntp verify -Dit.test=BreadcrumbsIT -Dxwiki.test.ui.offline=true
```

in `xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker`:

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 132.0 s -- in org.xwiki.flamingo.test.docker.BreadcrumbsIT
You have 0 Checkstyle violations.
```

Since the two tests share one XWiki instance and `verifyBreadcrumbInLongHierarchy` is the test that fails when the mode
leaks, a green 2-test run does verify that the tear-down really restores the mode.

Cost of the tear-down, measured on `verifyBreadcrumbInLongHierarchy` (the test that does not change the mode), same
machine and same conditions:

| | duration |
|---|---|
| without the `@AfterEach` | 3.69 s |
| with the `@AfterEach` | 8.39 s |

So the unconditional reset costs ~4.7s once per module run (the class run is 132s), which seems a fair price for
keeping the clean-up unconditional and free of shared mutable test state.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * (none — happy to add `backport stable-*` labels if you think it is worth it, the leak exists on the stable branches
    too)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
