### PR TITLE
[Misc] Set the XWiki.XWikiPreferences properties over REST in the test framework

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
@@ -2320,6 +2320,9 @@ public class TestUtils
 
     /**
      * Add and set a property into XWiki.XWikiPreferences. Create XWiki.XWikiPreferences if it does not exist.
+     * <p>
+     * The property is set over REST, and thus with the REST credentials rather than as the user currently logged in
+     * the browser, and the page displayed in the browser is left untouched.
      *
      * @param propertyName name of the property to set
      * @param propertyType the type of the property to add
@@ -2328,13 +2331,14 @@ public class TestUtils
      */
     public void setPropertyInXWikiPreferences(String propertyName, String propertyType, Object value)
     {
+        // The property may not be defined in the XWiki.XWikiPreferences class (e.g. "core.hierarchyMode"), in which
+        // case it must be added to the class before it can be set on the object.
         addClassProperty("XWiki", "XWikiPreferences", propertyName, propertyType);
-        gotoPage("XWiki", "XWikiPreferences", "edit", "editor", "object");
-        ObjectEditPage objectEditPage = new ObjectEditPage();
-        if (objectEditPage.hasObject("XWiki.XWikiPreferences")) {
-            updateObject("XWiki", "XWikiPreferences", "XWiki.XWikiPreferences", 0, propertyName, value);
-        } else {
-            addObject("XWiki", "XWikiPreferences", "XWiki.XWikiPreferences", propertyName, value);
+        try {
+            setWikiPreference(propertyName, Objects.toString(value, null));
+        } catch (Exception e) {
+            throw new RuntimeException(
+                String.format("Failed to set property [%s] in [XWiki.XWikiPreferences]", propertyName), e);
         }
     }
 


### PR DESCRIPTION
# Jira URL

N/A — `[Misc]` commit (functional test framework only, no user-visible change).

# Changes

## Description

* `TestUtils.setPropertyInXWikiPreferences()` now delegates to the existing REST-based
  `TestUtils.setWikiPreference()` instead of driving the browser.

## Clarifications

* The previous implementation did three things, two of them through the browser:
  1. `addClassProperty(...)` — a `propadd` navigation (kept: the property may not be defined in the
     `XWiki.XWikiPreferences` class at all, which is the case for `core.hierarchyMode`).
  2. `gotoPage("XWiki", "XWikiPreferences", "edit", "editor", "object")` — a full browser load of the object
     editor of `XWiki.XWikiPreferences`, a page carrying every xobject and every property of the wiki
     configuration, used only so that `ObjectEditPage.hasObject(...)` could answer whether the object exists.
  3. `updateObject(...)` / `addObject(...)` — a second navigation, to the `save` action.
* `setWikiPreference()` (added in 9.7RC1) already answers both questions over REST: it GETs the
  `XWiki.XWikiPreferences[0]` object, PUTs the single property when the object exists and POSTs the object when it
  does not. Steps 2 and 3 are therefore replaced by one REST round trip.
* Two consequences worth knowing, both documented in the Javadoc:
  * The property is set with the **REST credentials** rather than as the user currently logged in the browser. The
    `addClassProperty()` call is still made through the browser, so the browser user still needs edit rights on the
    class the first time a given property is used.
  * The page displayed in the browser is **left untouched**, where the previous implementation navigated away. Every
    caller in the repo was checked: none relies on the page it is left on (each one immediately navigates, deletes
    over REST, or is the last statement of a fixture method).
* `setWikiPreference()` declares `throws Exception` while `setPropertyInXWikiPreferences()` does not. Since this is
  public API of a published artifact the signature is left alone and the checked exception is wrapped, which is the
  pattern already used elsewhere in `TestUtils`.
* Split out of #6265, where the cost was noticed: that PR adds an `@AfterEach` restoring the hierarchy mode, and the
  reset was the dominant part of its cost.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

Changed module, all checks enabled:

```
mvn -B -ntp clean install -Dxwiki.spoon.skip=true    # in xwiki-platform-test-ui
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
You have 0 Checkstyle violations.
revapi:0.15.1:check — no API break
BUILD SUCCESS
```

Functional tests, run with `-Dxwiki.test.ui.servletEngine=tomcat -Dxwiki.test.ui.offline=true` (the modified
`xwiki-platform-test-ui` was `clean install`ed and its presence in the jar consumed by the ITs verified before each
run, since `install` alone can serve a cached jar):

| IT | callers exercised | result |
|---|---|---|
| `BreadcrumbsIT` (flamingo-skin) | `setHierarchyMode` | `Tests run: 2, Failures: 0, Errors: 0` |
| `ClassSheetIT` (xclass) | `setHierarchyMode` in `@BeforeAll` / `@AfterEach` | `Tests run: 1, Failures: 0, Errors: 0` |
| `CommentsIT` (flamingo-skin) | `setPropertyInXWikiPreferences("timezone"/"dateformat", …)` | see below |

`CommentsIT#commentsAreOrderedByDate` fails on this machine, **identically on `master` and on this branch**
(`expected: <1970/01/01 00:00> but was: <1970/01/01 01:00>` and the same for the French format), so it is not a
regression from this change. It looks like a pre-existing failure that only shows up when the host timezone is not
UTC — the test sets the wiki `timezone` preference to `UTC` and expects dates rendered at `00:00`, but gets a
one-hour offset on a `Europe/Paris` host. On the CI agents everything is UTC, so the offset is zero and the test
passes there whether or not the preference is honoured. Worth its own issue; not addressed here.

## Measurement

Timing logged inside `TestUtils.setHierarchyMode()` (temporary instrumentation, not committed) during the same
`BreadcrumbsIT` run, before and after the change:

| `setHierarchyMode` call | before | after |
|---|---|---|
| 1st call (the class property has to be created) | 3946 ms | 2389 ms |
| 2nd call (the class property already exists) | 2086 ms | **224 ms** |

~9x on the repeated call. Note that end-to-end test wall-clock is too noisy to show this (a control test containing
no `setHierarchyMode` call at all moved by 0.78 s between two runs), which is why the calls were timed directly.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * (none proposed — this only affects the test framework; happy to add `backport stable-*` labels if it helps the
    stable branches' test runtime)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
