### PR TITLE
XWIKI-24755: XClass properties can only be reordered with a mouse in the class editor

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/javascript.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/javascript.vm
@@ -104,6 +104,7 @@
     'xwiki-job-runner': "#removeJsSuffix($services.webjars.url('org.xwiki.platform:xwiki-platform-job-webjar', ""jobRunner${jsExtension}""))",
     'xwiki-locale-picker': $xwiki.getSkinFile('localePicker.js', true),
     'xwiki-meta': $xwiki.getSkinFile('js/xwiki/meta.js'),
+    'xwiki-reorder-controls': $xwiki.getSkinFile('uicomponents/widgets/reorderControls.js'),
     'xwiki-selectize': $xwiki.getSkinFile('uicomponents/suggest/xwiki.selectize.js'),
     'xwiki-suggestAttachments-bundle': $xwiki.getSkinFile('uicomponents/suggest/suggestAttachments.js'),
     'xwiki-tree-finder': "#removeJsSuffix($services.webjars.url('org.xwiki.platform:xwiki-platform-tree-webjar', ""finder${jsExtension}""))",

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/EditClassIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/EditClassIT.java
@@ -212,6 +212,72 @@ class EditClassIT
         assertEquals(List.of("testA", "testC", "testB"), classEditPage.getProperties());
     }
 
+    @Test
+    @Order(6)
+    void reorderPropertyWithoutDragging(TestUtils setup, TestReference reference) throws Exception
+    {
+        setup.rest().savePage(reference, "Some content", "");
+        ClassEditPage classEditPage = setup.editClass(reference);
+        classEditPage.addProperty("testA", "Number");
+        classEditPage.addProperty("testB", "Number");
+        classEditPage.addProperty("testC", "Number");
+
+        // A property added without reloading the editor gets its move buttons too, and they move it right away.
+        // The properties added before it keep exactly one pair of buttons, however many times the editor adds one.
+        assertEquals(List.of("testA", "testB", "testC"), classEditPage.getProperties());
+        assertEquals(2, classEditPage.getMovePropertyButtonCount("testA"));
+        assertEquals(2, classEditPage.getMovePropertyButtonCount("testC"));
+        classEditPage.movePropertyUp("testC");
+        assertEquals(List.of("testA", "testC", "testB"), classEditPage.getProperties());
+        classEditPage.movePropertyDown("testC");
+        assertEquals(List.of("testA", "testB", "testC"), classEditPage.getProperties());
+
+        classEditPage.clickSaveAndView();
+
+        classEditPage = setup.editClass(reference);
+        assertEquals(List.of("testA", "testB", "testC"), classEditPage.getProperties());
+
+        // Both move controls are buttons, and each one has an accessible name and a tooltip naming the property it
+        // moves.
+        assertEquals("button", classEditPage.getMovePropertyUpButton("testC").getTagName());
+        assertEquals("move up", classEditPage.getMovePropertyUpButtonName("testC"));
+        assertEquals("Move property testC up", classEditPage.getMovePropertyUpButtonTooltip("testC"));
+        assertEquals("move down", classEditPage.getMovePropertyDownButtonName("testA"));
+        assertEquals("Move property testA down", classEditPage.getMovePropertyDownButtonTooltip("testA"));
+
+        // A single click moves the property, and the button keeps the focus so that several moves can be performed in
+        // a row.
+        classEditPage.movePropertyUp("testC");
+        assertEquals(List.of("testA", "testC", "testB"), classEditPage.getProperties());
+        assertTrue(classEditPage.isMovePropertyUpButtonFocused("testC"));
+        classEditPage.waitForReorderAnnouncement("Property moved to position 2 out of 3");
+        classEditPage.movePropertyUp("testC");
+        assertEquals(List.of("testC", "testA", "testB"), classEditPage.getProperties());
+
+        // The first property cannot be moved further up, and says so rather than staying silent.
+        classEditPage.movePropertyUp("testC");
+        assertEquals(List.of("testC", "testA", "testB"), classEditPage.getProperties());
+        classEditPage.waitForReorderAnnouncement("Property already at the top of the list");
+
+        // The last property cannot be moved further down, and says so too.
+        classEditPage.movePropertyDown("testB");
+        assertEquals(List.of("testC", "testA", "testB"), classEditPage.getProperties());
+        classEditPage.waitForReorderAnnouncement("Property already at the bottom of the list");
+
+        // The arrow keys move the property too, and both buttons answer both keys.
+        classEditPage.movePropertyDownWithKeyboard("testC");
+        assertEquals(List.of("testA", "testC", "testB"), classEditPage.getProperties());
+        classEditPage.movePropertyUpWithKeyboard("testC");
+        assertEquals(List.of("testC", "testA", "testB"), classEditPage.getProperties());
+        classEditPage.movePropertyDownWithKeyboard("testC");
+        assertEquals(List.of("testA", "testC", "testB"), classEditPage.getProperties());
+
+        classEditPage.clickSaveAndView();
+
+        classEditPage = setup.editClass(reference);
+        assertEquals(List.of("testA", "testC", "testB"), classEditPage.getProperties());
+    }
+
     private DocumentReference getTestClassDocumentReference(TestReference reference)
     {
         return new DocumentReference("TestClass", reference.getLastSpaceReference());

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/table/LayoutTableHeaderNames.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/table/LayoutTableHeaderNames.vue
@@ -304,6 +304,9 @@ export default {
 }
 
 .layout-table .column-name {
+  /* The column name is the handle the column is dragged from, so the whole of it, and not only the button it holds,
+  tells with the cursor that the column can be moved. */
+  cursor: grab;
   display: flex;
   font-weight: var(--font-weight-semibold);
   justify-content: space-between;
@@ -404,7 +407,6 @@ export default {
   color: currentColor;
   opacity: 0;
   padding-left: var(--table-cell-padding);
-  cursor: pointer;
 }
 
 .layout-table .sort-icon.sorted {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -1346,7 +1346,13 @@ core.editors.class.addProperty.inProgress=Adding property...
 core.editors.class.addProperty.done=Property added
 core.editors.class.addProperty.failed=Failed:
 
-core.editors.class.moveProperty.handle.label=Drag and drop to change the order
+core.editors.class.moveProperty.up.text=move up
+core.editors.class.moveProperty.up.tooltip=Move property {0} up
+core.editors.class.moveProperty.up.boundary=Property already at the top of the list
+core.editors.class.moveProperty.down.text=move down
+core.editors.class.moveProperty.down.tooltip=Move property {0} down
+core.editors.class.moveProperty.down.boundary=Property already at the bottom of the list
+core.editors.class.moveProperty.moved=Property moved to position {0} out of {1}
 
 core.editors.class.deleteProperty.text=delete
 core.editors.class.deleteProperty.tooltip=Delete property {0}
@@ -5731,6 +5737,14 @@ admin.pageandchildrenrights.info=These rights apply on this page {0}and all {1}i
 admin.pagerights.info=These rights apply on this page only.
 admin.pagerights.infoNonTerminalDoc=They do not affect the {0}children{1}.
 core.edit.autosave.every=every
+
+#######################################
+## until 18.8.0RC1
+#######################################
+## The move handle this key labeled was replaced by a move up button and a move down button, each carrying its own
+## label and tooltip, so the replacements are core.editors.class.moveProperty.up.tooltip and the down equivalent.
+#@deprecated core.editors.class.moveProperty.up.tooltip
+core.editors.class.moveProperty.handle.label=Drag and drop to change the order
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/editor/ClassEditPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/editor/ClassEditPage.java
@@ -22,6 +22,7 @@ package org.xwiki.test.ui.po.editor;
 import java.util.List;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.FindBy;
@@ -139,11 +140,193 @@ public class ClassEditPage extends EditPage
      */
     public void movePropertyBefore(String propertyToMove, String propertyBefore)
     {
-        WebElement moveToolSource = getDriver()
-            .findElementWithoutWaiting(By.id("xproperty_" + propertyToMove))
-            .findElement(By.cssSelector(".tool.move"));
         WebElement target = getDriver().findElementWithoutWaiting(By.id("xproperty_" + propertyBefore));
-        new Actions(getDriver().getWrappedDriver()).dragAndDrop(moveToolSource, target).perform();
+        new Actions(getDriver().getWrappedDriver()).dragAndDrop(getPropertyDragSource(propertyToMove), target)
+            .perform();
+    }
+
+    /**
+     * Clicks the move up button of the given property. The property keeps its position when it is already the first
+     * one.
+     *
+     * @param propertyToMove the property to move one position up
+     * @since 18.8.0RC1
+     */
+    public void movePropertyUp(String propertyToMove)
+    {
+        getMovePropertyUpButton(propertyToMove).click();
+    }
+
+    /**
+     * Clicks the move down button of the given property. The property keeps its position when it is already the last
+     * one.
+     *
+     * @param propertyToMove the property to move one position down
+     * @since 18.8.0RC1
+     */
+    public void movePropertyDown(String propertyToMove)
+    {
+        getMovePropertyDownButton(propertyToMove).click();
+    }
+
+    /**
+     * Presses the up arrow key on the move buttons of the given property, which both answer it. The property keeps its
+     * position when it is already the first one.
+     *
+     * @param propertyToMove the property to move one position up
+     * @since 18.8.0RC1
+     */
+    public void movePropertyUpWithKeyboard(String propertyToMove)
+    {
+        getMovePropertyUpButton(propertyToMove).sendKeys(Keys.ARROW_UP);
+    }
+
+    /**
+     * Presses the down arrow key on the move buttons of the given property, which both answer it. The property keeps
+     * its position when it is already the last one.
+     *
+     * @param propertyToMove the property to move one position down
+     * @since 18.8.0RC1
+     */
+    public void movePropertyDownWithKeyboard(String propertyToMove)
+    {
+        getMovePropertyDownButton(propertyToMove).sendKeys(Keys.ARROW_DOWN);
+    }
+
+    /**
+     * @param propertyName the name of a property of this class
+     * @return the button moving the given property one position up
+     * @since 18.8.0RC1
+     */
+    public WebElement getMovePropertyUpButton(String propertyName)
+    {
+        return getPropertyContainer(propertyName).findElement(By.cssSelector(".reorder-control-up"));
+    }
+
+    /**
+     * @param propertyName the name of a property of this class
+     * @return the button moving the given property one position down
+     * @since 18.8.0RC1
+     */
+    public WebElement getMovePropertyDownButton(String propertyName)
+    {
+        return getPropertyContainer(propertyName).findElement(By.cssSelector(".reorder-control-down"));
+    }
+
+    /**
+     * @param propertyName the name of a property of this class
+     * @return whether the button moving the given property up currently holds the focus
+     * @since 18.8.0RC1
+     */
+    public boolean isMovePropertyUpButtonFocused(String propertyName)
+    {
+        return getMovePropertyUpButton(propertyName).equals(getDriver().switchTo().activeElement());
+    }
+
+    /**
+     * @param propertyName the name of a property of this class
+     * @return the accessible name of the button moving the given property up, which is displayed to screen readers
+     *     only
+     * @since 18.8.0RC1
+     */
+    public String getMovePropertyUpButtonName(String propertyName)
+    {
+        return getButtonName(getMovePropertyUpButton(propertyName));
+    }
+
+    /**
+     * @param propertyName the name of a property of this class
+     * @return the accessible name of the button moving the given property down, which is displayed to screen readers
+     *     only
+     * @since 18.8.0RC1
+     */
+    public String getMovePropertyDownButtonName(String propertyName)
+    {
+        return getButtonName(getMovePropertyDownButton(propertyName));
+    }
+
+    /**
+     * @param propertyName the name of a property of this class
+     * @return the tooltip of the button moving the given property up
+     * @since 18.8.0RC1
+     */
+    public String getMovePropertyUpButtonTooltip(String propertyName)
+    {
+        return getMovePropertyUpButton(propertyName).getDomAttribute("title");
+    }
+
+    /**
+     * @param propertyName the name of a property of this class
+     * @return the tooltip of the button moving the given property down
+     * @since 18.8.0RC1
+     */
+    public String getMovePropertyDownButtonTooltip(String propertyName)
+    {
+        return getMovePropertyDownButton(propertyName).getDomAttribute("title");
+    }
+
+    /**
+     * @param propertyName the name of a property of this class
+     * @return the number of move buttons displayed for the given property, which stays at two however many times
+     *     properties are added to the editor
+     * @since 18.8.0RC1
+     */
+    public int getMovePropertyButtonCount(String propertyName)
+    {
+        return getPropertyContainer(propertyName).findElements(By.cssSelector(".reorder-control")).size();
+    }
+
+    /**
+     * @param button one of the move buttons
+     * @return the accessible name of the given button
+     */
+    private String getButtonName(WebElement button)
+    {
+        return button.findElement(By.className("sr-only")).getDomProperty("textContent");
+    }
+
+    /**
+     * Waits until the move buttons have announced the given text to the screen readers.
+     *
+     * @param announcement the expected announcement
+     * @since 18.8.0RC1
+     */
+    public void waitForReorderAnnouncement(String announcement)
+    {
+        getDriver().waitUntilCondition(driver -> announcement.equals(getReorderAnnouncement()));
+    }
+
+    /**
+     * Reads the announcement without waiting for it. The live region is emptied as soon as a move is performed and
+     * filled again shortly after, so this returns an empty string when it is called right after a move. Prefer
+     * {@link #waitForReorderAnnouncement(String)}, which waits for the announcement to be set.
+     *
+     * @return the text currently held by the live region the move buttons announce their moves in
+     * @since 18.8.0RC1
+     */
+    public String getReorderAnnouncement()
+    {
+        return getDriver().findElementWithoutWaiting(By.id("reorder-controls-live-region"))
+            .getDomProperty("textContent");
+    }
+
+    /**
+     * @param propertyName the name of a property of this class
+     * @return the part of the property title a drag has to start from, the move buttons being operated by a click
+     *     rather than by a drag
+     */
+    private WebElement getPropertyDragSource(String propertyName)
+    {
+        return getPropertyContainer(propertyName).findElement(By.cssSelector(".xproperty-title h2"));
+    }
+
+    /**
+     * @param propertyName the name of a property of this class
+     * @return the element holding the title and the content of the given property
+     */
+    private WebElement getPropertyContainer(String propertyName)
+    {
+        return getDriver().findElementWithoutWaiting(By.id("xproperty_" + propertyName));
     }
 
     private FormContainerElement getForm()

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
@@ -94,7 +94,7 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
   margin: 0;
 }
 
-.xobject-title:hover, .xclass-title:hover, .xproperty-title:hover {
+.xobject-title:hover, .xclass-title:hover {
   cursor: default;
 }
 
@@ -123,9 +123,13 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
   padding: 1em 0 1em 1em;
 }
 
+/* The title is the part of a property that is visible whether the property is expanded or collapsed, so it is the area
+users are expected to grab to drag the property. The grab cursor is what tells them the property can be dragged at all,
+now that there is no drag handle. The vertical padding widens that band, so that the drag is comfortable to start even
+though the title is a single line of text. */
 .xproperty-title {
-  cursor: default;
-  padding: 0px;
+  cursor: grab;
+  padding: 4px 0;
   overflow: hidden;
 }
 
@@ -229,7 +233,10 @@ The default state is collapsed for xobjects and xproperties, but expanded for xc
   padding-right: 3px;
 }
 
+/* The tools sit in the title but are clicked rather than dragged, so they keep the pointer cursor. Buttons need it
+spelled out, since they do not get it from the browser like links do. */
 .xproperty-title .tools .tool {
+  cursor: pointer;
   width: 16px;
   height: 16px;
   float: left;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
@@ -223,8 +223,10 @@ The default state is collapsed for xobjects and xproperties, but expanded for xc
   font-weight: 900;
 }
 
+/* The right padding leaves room for the focus indicator of the last tool, which the hidden overflow would cut off. */
 .xproperty-title .tools {
   align-self: center;
+  padding-right: 3px;
 }
 
 .xproperty-title .tools .tool {
@@ -235,8 +237,14 @@ The default state is collapsed for xobjects and xproperties, but expanded for xc
 }
 
 .xproperty-title .tools .move {
-  cursor: move;
   color: $theme.linkColor;
+}
+
+/* The move tools are buttons, so their default border and padding have to be removed to align them with the other
+tools. The background is already reset by the rule above. */
+.xproperty-title .tools button.tool {
+  border: none;
+  padding: 0;
 }
 
 .xproperty-title .tools .delete {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.js
@@ -773,7 +773,7 @@
           // keeps a drag from ever starting on a move button. A click or a tap that drifts by a pixel has to stay
           // a click, otherwise the buttons stop being an alternative to dragging.
           $('#xclassContent').sortable({
-            cursor: 'move',
+            cursor: 'grabbing',
             items: '.xproperty',
             start: self.startDrag,
             stop: self.endDrag,

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.js
@@ -18,7 +18,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 /*!
-#set ($icons = {'reposition': $services.icon.renderHTML('reposition')})
+#set ($icons = {'up': $services.icon.renderHTML('up'), 'down': $services.icon.renderHTML('down')})
 #[[*/
 // Start JavaScript-only code.
 
@@ -44,11 +44,18 @@
       'object.loadObject.inProgress',
       'object.loadObject.done',
       'object.loadObject.failed',
-      'class.moveProperty.handle.label',
+      'class.moveProperty.up.text',
+      'class.moveProperty.up.tooltip',
+      'class.moveProperty.up.boundary',
+      'class.moveProperty.down.text',
+      'class.moveProperty.down.tooltip',
+      'class.moveProperty.down.boundary',
+      'class.moveProperty.moved',
       'class.switchClass.confirm'
     ]
   });
-  require(['jquery','xwiki-meta','xwiki-l10n!dataeditors-translations','xwiki-events-bridge','jquery-ui'], function ($, xm, l10n) {
+  require(['jquery','xwiki-meta','xwiki-l10n!dataeditors-translations','xwiki-reorder-controls',
+    'xwiki-events-bridge','jquery-ui'], function ($, xm, l10n, reorderControls) {
     class XDataEditors {
       constructor() {
         let self = this;
@@ -720,7 +727,7 @@
       /* Class editor: xproperty ordering */
       makeSortable(element) {
         if (element.length > 0) {
-          // Hide the property number, as ordering can be done by drag and drop
+          // Hide the property number, as ordering can be done by drag and drop or with the move buttons
           element.find('.xproperty-content').each(function () {
             let item = $(this);
             item.find("input").each(function () {
@@ -734,33 +741,52 @@
               }
             });
           });
-          // Create and insert move button
-          element.find('.xproperty-title .tools').each(function () {
-            let item = $(this);
-            let movebutton = $('<span>', {
-              'class': 'tool move',
-              title: l10n['class.moveProperty.handle.label']
-            }).html(icons['reposition']);
-            item.css('position', 'relative');
-            item.append(movebutton);
-            movebutton.on('click', function (event) {
-              event.stopPropagation();
-            });
-          });
           let self = this;
+          // Create and insert the move up and move down buttons, which reorder the properties both with a single
+          // click and with the arrow keys.
+          reorderControls(element, {
+            item: '.xproperty',
+            buttonContainer: '.xproperty-title .tools',
+            buttonClass: 'tool move',
+            icons: {
+              up: icons['up'],
+              down: icons['down']
+            },
+            labels: function (item, direction) {
+              let propertyName = item.attr('id').substring('xproperty_'.length);
+              return {
+                text: l10n['class.moveProperty.' + direction + '.text'],
+                title: l10n.get('class.moveProperty.' + direction + '.tooltip', propertyName)
+              };
+            },
+            onMove: function () {
+              self.updateOrder($('#xclassContent'));
+            },
+            announce: function (item, newIndex, itemCount) {
+              return l10n.get('class.moveProperty.moved', newIndex + 1, itemCount);
+            },
+            announceBoundary: function (item, direction) {
+              return l10n['class.moveProperty.' + direction + '.boundary'];
+            }
+          });
+          // The cancel option is left to its default value on purpose: that value excludes buttons, which is what
+          // keeps a drag from ever starting on a move button. A click or a tap that drifts by a pixel has to stay
+          // a click, otherwise the buttons stop being an alternative to dragging.
           $('#xclassContent').sortable({
             cursor: 'move',
             items: '.xproperty',
             start: self.startDrag,
             stop: self.endDrag,
-            update: self.updateOrder
+            update: function () {
+              self.updateOrder(this);
+            }
           });
         }
       }
 
-      updateOrder() {
+      updateOrder(container) {
         let i = 1;
-        $(this).find(".xproperty-content").each(function () {
+        $(container).find(".xproperty-content").each(function () {
           let item = $(this);
           // the numberProperty data is actually a reference to an input.
           item.data('numberProperty').val(i++);

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/reorderControls.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/reorderControls.js
@@ -1,0 +1,188 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+/**
+ * Makes a list of items reorderable without dragging, by adding a move up button and a move down button to each item.
+ * Both buttons move the item with a single click or tap, and both also answer the up and down arrow keys once focused,
+ * so that a series of moves can be performed without leaving the button.
+ *
+ * Lists that can also be reordered by dragging and dropping keep their own drag and drop implementation and pass the
+ * same persistence callback to it, so that the two paths stay in sync.
+ */
+define('xwiki-reorder-controls', ['jquery'], function ($) {
+  'use strict';
+
+  const liveRegionId = 'reorder-controls-live-region';
+
+  // How long the live region is left empty before the announcement is set again. Screen readers announce a region
+  // whose content changed, so the same text has to be removed and set back to be announced twice in a row.
+  const liveRegionResetDelay = 100;
+
+  const offsets = {
+    'up': -1,
+    'down': 1
+  };
+
+  // The announcement waiting to be set in the live region, so that a new one can replace it.
+  let pendingAnnouncement;
+
+  /**
+   * @return {jQuery} the region used to announce the moves, created on the first call
+   */
+  function getLiveRegion() {
+    let liveRegion = $('#' + liveRegionId);
+    if (!liveRegion.length) {
+      liveRegion = $('<div></div>').attr({
+        'id': liveRegionId,
+        'aria-live': 'polite'
+      }).addClass('sr-only').appendTo(document.body);
+    }
+    return liveRegion;
+  }
+
+  /**
+   * Announces a text to the screen readers, and does nothing when there is nothing to announce.
+   *
+   * @param {string} [text] the text to announce
+   */
+  function announce(text) {
+    if (!text) {
+      return;
+    }
+    const liveRegion = getLiveRegion();
+    liveRegion.text('');
+    // A move performed while an announcement is still waiting replaces it, so that holding an arrow key down
+    // announces the position the item ended up at instead of every position it went through.
+    clearTimeout(pendingAnnouncement);
+    pendingAnnouncement = setTimeout(function () {
+      liveRegion.text(text);
+    }, liveRegionResetDelay);
+  }
+
+  /**
+   * @param {jQuery} button the button the user is operating
+   * @param {Object} options the options the button was created with
+   * @param {string} direction either up or down
+   */
+  function moveItem(button, options, direction) {
+    const item = button.closest(options.item);
+    // The reordered items are the siblings of the moved item that the caller declared as reorderable. Items that are
+    // not displayed are taken into account, because the drag and drop path moves the item among them too.
+    const items = item.parent().children(options.item);
+    const oldIndex = items.index(item);
+    const offset = offsets[direction];
+    const newIndex = oldIndex + offset;
+    if (oldIndex < 0) {
+      return;
+    }
+    if (newIndex < 0 || newIndex >= items.length) {
+      // The item is already at the end of the list it is moving towards. This is announced, because a keyboard user
+      // has no other way to tell that the button or the key press was taken into account.
+      announce(options.announceBoundary?.(item, direction));
+      return;
+    }
+    if (offset < 0) {
+      item.insertBefore(items.eq(newIndex));
+    } else {
+      item.insertAfter(items.eq(newIndex));
+    }
+    // Moving the item in the DOM moves the button with it, which makes some browsers drop the focus, so we set it back
+    // on the button in order to let the user perform several moves in a row.
+    button.trigger('focus');
+    options.onMove?.(item, oldIndex, newIndex);
+    announce(options.announce?.(item, newIndex, items.length));
+  }
+
+  /**
+   * @param {jQuery} item the item the button moves
+   * @param {Object} options the widget options
+   * @param {string} direction either up or down
+   * @return {jQuery} the button moving the given item in the given direction
+   */
+  function createButton(item, options, direction) {
+    const labels = options.labels(item, direction);
+    const button = $('<button></button>').attr({
+      'type': 'button',
+      'title': labels.title
+    }).addClass('reorder-control reorder-control-' + direction).addClass(options.buttonClass);
+    $('<span></span>').attr('role', 'presentation').html(options.icons[direction]).appendTo(button);
+    $('<span></span>').addClass('sr-only').text(labels.text).appendTo(button);
+    button.on('click', function (event) {
+      // The button sits among the other actions of the item, whose container may react to a click of its own.
+      event.stopPropagation();
+      moveItem(button, options, direction);
+    });
+    button.on('keydown', function (event) {
+      // Both buttons answer both arrow keys, so that an item moved one position too far can be moved back without
+      // moving the focus to the other button.
+      if (event.key === 'ArrowUp') {
+        moveItem(button, options, 'up');
+      } else if (event.key === 'ArrowDown') {
+        moveItem(button, options, 'down');
+      } else {
+        return;
+      }
+      // Prevent the arrow keys from scrolling the page while the user is reordering the list.
+      event.preventDefault();
+    });
+    return button;
+  }
+
+  /**
+   * Adds a move up button and a move down button to each reorderable item found in the given scope. Items that already
+   * have them are left untouched, so that the widget can be applied again after new items have been added to the list.
+   *
+   * @param {jQuery|Element|string} scope an element that is either a reorderable item itself or an ancestor of the
+   *          reorderable items to enhance
+   * @param {Object} options the widget options:
+   *          <dl>
+   *            <dt>item</dt><dd>the selector matching a reorderable item; the items it matches are expected to be
+   *              siblings, since an item moves among the children of its own parent</dd>
+   *            <dt>buttonContainer</dt><dd>the selector, relative to an item, of the element the buttons are appended
+   *              to</dd>
+   *            <dt>buttonClass</dt><dd>the CSS classes to set on both buttons</dd>
+   *            <dt>icons</dt><dd>the HTML of the icon displayed inside each button, as an object with an up and a down
+   *              entry</dd>
+   *            <dt>labels</dt><dd>a callback, called with an item and a direction, returning the accessible name of the
+   *              button as text and its tooltip as title</dd>
+   *            <dt>onMove</dt><dd>an optional callback, called with the moved item and its old and new indexes, that
+   *              persists the new order</dd>
+   *            <dt>announce</dt><dd>an optional callback, called with the moved item, its new index and the number of
+   *              items, that returns the text announced to screen readers after a move</dd>
+   *            <dt>announceBoundary</dt><dd>an optional callback, called with the item and the direction, that returns
+   *              the text announced to screen readers when the item is already at the end of the list it is moving
+   *              towards</dd>
+   *          </dl>
+   */
+  return function (scope, options) {
+    // The region is created before the first move, because a region that is inserted and filled in the same task is
+    // not announced.
+    getLiveRegion();
+    $(scope).find(options.item).addBack(options.item).each(function () {
+      const item = $(this);
+      // Only the first match is used, so that a nested list does not get the buttons of its ancestor item.
+      const buttonContainer = item.find(options.buttonContainer).first();
+      if (!buttonContainer.length || buttonContainer.find('.reorder-control').length) {
+        return;
+      }
+      buttonContainer.append(createButton(item, options, 'up'), createButton(item, options, 'down'));
+    });
+  };
+});


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24755

# Changes

## Description

* New `reorderControls` widget (`uicomponents/widgets/reorderControls.js`, registered as `xwiki-reorder-controls`), adding a **move up** and a **move down** `<button>` to each item of a list. A button moves its item on a click or tap and on the up and down arrow keys, keeps the focus so moves can be chained, and announces the new position in a shared polite live region.
* The class editor uses the widget in place of the non-focusable `<span class="tool move">` drag handle. The widget's `onMove` callback persists the change, so drag and drop and the buttons both end up in the existing `updateOrder()` and the hidden `Number` field stays in sync.
* Each button gets a screen-reader-only name and a tooltip naming its property (`Move property <name> up`), mirroring the delete tool.
* The buttons' default border and padding are reset so the three tools align, and the tools container gets 3px of right padding, since its `overflow: hidden` was clipping the last tool's focus indicator.
* `core.editors.class.moveProperty.handle.label` is deprecated in place, and the four `moveProperty.up/down.text/tooltip` keys are added.

## Clarifications

* **Two buttons rather than one keyboard-operable handle.** A handle answering the arrow keys closes [SC 2.1.1 Keyboard](https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html) but not [SC 2.5.7 Dragging Movements](https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html), which the issue also cites: keyboard equivalence only meets it if the equivalent operation "also provides controls that can be clicked or tapped with a pointer". Two clickable buttons satisfy both; the arrow keys stay as a convenience.
* **The buttons are not drag handles.** jQuery UI `sortable` keeps its default `cancel`, which excludes buttons, so an imprecise tap can never become a drag, which would defeat the point for the users SC 2.5.7 protects. Dragging still works from the property title, where `ClassEditPage.movePropertyBefore` now starts it.
* **The widget is meant to be reused.** The dashboard gadgets (`uicomponents/dashboard/dashboard.js`) are still pointer-only and the natural next consumer. The object editor would follow once XWIKI-5671 has a persistence model, which is out of scope here: an xobject's number *is* its reference and oldcore has no renumber API, so it needs a design decision first.
* Live Data column headers keep their own Vue implementation (`keyboardDragNDrop()`, XWIKI-21009); this widget targets plain DOM lists. The `Number` meta-property stays hidden, since the order is now operable without it.
* One gap left out on purpose: at 16x16 the tools are below the 24x24 of [SC 2.5.8 Target Size (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html). That size is pre-existing and shared with the delete tool, so enlarging only the new buttons would break the row's alignment. Filed separately.

# Screenshots & Video

| Before | After |
| --- | --- |
| <img width="1264" height="250" alt="before" src="https://github.com/user-attachments/assets/1dc3429f-aaf6-4bb4-aa3e-f096fa14cde6" /> | <img width="1264" height="250" alt="after" src="https://github.com/user-attachments/assets/2a71c7e3-c890-40a2-83aa-0668039b8cbc" /> |

The actions of a property title, on a class holding three properties: the delete link with the single drag handle, then the delete link with the two move buttons.

# Executed Tests

Built the changes with:
- `mvn clean install -Plegacy,integration-tests,quality` on `xwiki-platform-web-war`, `xwiki-platform-flamingo-skin-resources` and `xwiki-platform-test-ui` -- BUILD SUCCESS, 0 Checkstyle violations.
- `mvn checkstyle:check@default checkstyle:check@test -Pdocker,integration-tests` on `xwiki-platform-flamingo-skin-test-docker` -- 0 violations on both rulesets.
- `mvn test-compile -Plegacy,docker,integration-tests` on the same module -- BUILD SUCCESS.

Then tested them with:
- `mvn verify -Pdocker,integration-tests,legacy -pl <flamingo-skin-test-docker> -Dxwiki.test.ui.servletEngine=tomcat -Dxwiki.test.ui.database=postgresql -Dit.test='EditClassIT#reorderProperty+reorderPropertyWithoutDragging'` -- `2/2` tests pass.
  - `reorderPropertyWithoutDragging` is new: both controls are `button` elements with the expected screen-reader name and tooltip, a click moves the property up and down and leaves the focus on the button, the first property cannot move up and the last cannot move down, the arrow keys work on both buttons, and the new order survives a save and reload.
  - `reorderProperty` is the pre-existing drag and drop test, kept green now that the handle is gone and the drag starts from the property title.
- Checked on the running instance that the three tools share a baseline and that the move buttons' focus indicator renders unclipped, which is what the 3px of right padding fixes.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: none -- this changes the DOM of an editor and adds translation keys, so it is better left on master.
