### PR TITLE
XWIKI-24761: CommentsIT#commentsAreOrderedByDate fails when the test runner's timezone is not UTC

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/CommentsIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/CommentsIT.java
@@ -19,8 +19,9 @@
  */
 package org.xwiki.flamingo.test.docker;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterAll;
@@ -68,7 +69,13 @@ class CommentsIT
 
     private static final String COMMENT_REPLACED_CONTENT = "Some replaced content";
 
-    private static final SimpleDateFormat DEFAULT_DATE_FORMAT = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
+    /**
+     * The dates sent to the server are parsed by the server in its own timezone, and the dates asserted below are
+     * expressed in UTC (the test sets the wiki timezone to UTC). Thus the dates must be formatted in UTC and not in
+     * the timezone of the machine running the test, otherwise the assertions are off by that timezone's offset.
+     */
+    private static final DateTimeFormatter DEFAULT_DATE_FORMAT =
+        DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss").withZone(ZoneOffset.UTC);
 
     @BeforeEach
     void beforeEach(TestUtils setup)
@@ -191,7 +198,7 @@ class CommentsIT
 
     private String getDateString(int seconds)
     {
-        return DEFAULT_DATE_FORMAT.format(new Date(seconds * 1000L));
+        return DEFAULT_DATE_FORMAT.format(Instant.ofEpochSecond(seconds));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24761

# Changes

## Description

* `CommentsIT#commentsAreOrderedByDate` builds the comment dates it sends to the server with a
  `SimpleDateFormat` that has no timezone set, so the dates are formatted in the default timezone of
  the machine running the test. The assertions, on the other hand, expect the dates displayed in UTC
  (the test sets the wiki `timezone` preference to `UTC`). Both parameterized cases therefore fail on
  any host that is not in UTC, shifted by that host's UTC offset.
* Format those dates in UTC, by replacing the host-zone `SimpleDateFormat` with a `DateTimeFormatter`
  pinned to `ZoneOffset.UTC`.

## Clarifications

* On a `Europe/Paris` host the failure is `expected: <1970/01/01 00:00> but was: <1970/01/01 01:00>`:
  `getDateString(24)` sends `01/01/1970 01:00:24` instead of `01/01/1970 00:00:24`.
* **The CI agents run in UTC, so the offset is zero there and the test passes regardless.** This
  failure is invisible to CI by construction and only ever hits developers running the test locally,
  which is why it went unnoticed since the test was added (XWIKI-22978, oldest affected release
  16.4.8).
* The server parses the date string in `DateClass.fromString()`, which also sets no timezone and thus
  parses in the *server's* timezone — UTC in the test container. The wiki `timezone` preference is
  correctly applied to the *display*; only the input side of the test was wrong, so this is a test
  fix and not a product fix.

# Screenshots & Video

Not applicable — no UI change.

# Executed Tests

Run on a `Europe/Paris` host, where both cases failed before this change and pass with it:

```
mvn verify -Dit.test='CommentsIT#commentsAreOrderedByDate' -Dxwiki.test.ui.servletEngine=tomcat
  -> Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 (141.9 s)

mvn test-compile checkstyle:check@default
  -> 0 Checkstyle violations
```

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  *

Generated with Claude Code
