### PR TITLE
XWIKI-24762: Add a page object for the Live Data Properties advanced panel

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/LiveDataElement.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/LiveDataElement.java
@@ -252,6 +252,19 @@ public class LiveDataElement extends BaseElement
     }
 
     /**
+     * Open the panel listing the properties, from which a property is displayed as a column or hidden.
+     *
+     * @return an instance of {@link PropertiesPanelElement} once it's opened.
+     * @since 18.8.0RC1
+     */
+    public PropertiesPanelElement openPropertiesPanel()
+    {
+        openDropDownMenu().findElement(By.linkText("Properties...")).click();
+        return new PropertiesPanelElement(this,
+            getRootElement().findElement(By.className("livedata-advanced-panel-properties")));
+    }
+
+    /**
      * Open the panel for advanced sorting and returns it.
      * @return an instance of {@link SortPanelElement} once it's opened.
      * @since 16.3.0RC1

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/PropertiesPanelElement.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/PropertiesPanelElement.java
@@ -1,0 +1,108 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.xwiki.livedata.test.po;
+
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+/**
+ * Represents the advanced panel listing the properties of a live data, from which a property is displayed as a column
+ * or hidden. The panel offers the properties the live data declares, each one ticked when it is displayed.
+ *
+ * @version $Id$
+ * @since 18.8.0RC1
+ */
+public class PropertiesPanelElement extends AbstractLiveDataAdvancedPanelElement
+{
+    private static final By PROPERTY_NAME = By.className("property-name");
+
+    /**
+     * Default constructor.
+     *
+     * @param liveData the live data of the panel
+     * @param container the container of the panel
+     */
+    public PropertiesPanelElement(LiveDataElement liveData, WebElement container)
+    {
+        super(liveData, container);
+    }
+
+    /**
+     * @return the label of every property the panel offers, in the order they are offered
+     */
+    public List<String> getPropertyNames()
+    {
+        return getProperties().stream().map(property -> property.findElement(PROPERTY_NAME).getText()).toList();
+    }
+
+    /**
+     * @param propertyName the label of a property
+     * @return {@code true} if the panel offers that property, {@code false} otherwise
+     */
+    public boolean hasProperty(String propertyName)
+    {
+        return getPropertyNames().contains(propertyName);
+    }
+
+    /**
+     * @param propertyName the label of a property the panel offers
+     * @return {@code true} if that property is displayed as a column, {@code false} if it is hidden
+     */
+    public boolean isPropertyDisplayed(String propertyName)
+    {
+        return getCheckbox(propertyName).isSelected();
+    }
+
+    /**
+     * Displays or hides the column of a property, the way ticking or unticking its checkbox does.
+     *
+     * @param propertyName the label of a property the panel offers
+     * @param displayed {@code true} to display the property as a column, {@code false} to hide it
+     */
+    public void setPropertyDisplayed(String propertyName, boolean displayed)
+    {
+        if (isPropertyDisplayed(propertyName) != displayed) {
+            getCheckbox(propertyName).click();
+        }
+    }
+
+    private WebElement getCheckbox(String propertyName)
+    {
+        return getProperty(propertyName).findElement(By.cssSelector("input[type='checkbox']"));
+    }
+
+    private WebElement getProperty(String propertyName)
+    {
+        return getProperties().stream()
+            .filter(property -> property.findElement(PROPERTY_NAME).getText().equals(propertyName))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException(
+                String.format("The properties panel does not offer any property named [%s]. It offers %s.",
+                    propertyName, getPropertyNames())));
+    }
+
+    private List<WebElement> getProperties()
+    {
+        return this.container.findElements(By.className("property"));
+    }
+}


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-24762

## Problem

`xwiki-platform-livedata-test-pageobjects` covers two of the three Live Data advanced panels — `FiltersPanelElement` and `SortPanelElement`, opened by `LiveDataElement#openFiltersPanel()` / `#openSortPanel()`. The Properties panel, which is how a reader displays a column back or hides one, has no page object.

A functional test that needs to assert what that panel offers, or to display a property back, therefore has to reach for `getDriver()` and raw `By` lookups in the test class, which the [testing strategy](https://dev.xwiki.org/xwiki/bin/view/Community/Testing/) forbids.

This came up writing a test for an xwiki-contrib extension whose Live Data hides two columns by default: asserting that they remain reachable from the panel could not be expressed through a page object.

## Change

- `PropertiesPanelElement extends AbstractLiveDataAdvancedPanelElement`, beside the other two panels, exposing what the panel does: `getPropertyNames()`, `hasProperty(String)`, `isPropertyDisplayed(String)` and `setPropertyDisplayed(String, boolean)`.
- `LiveDataElement#openPropertiesPanel()`, mirroring `openFiltersPanel()` / `openSortPanel()`.

`setPropertyDisplayed` is a no-op when the property is already in the requested state, so a test states the state it wants rather than a toggle.

Both carry `@since 18.8.0RC1`. Test-only module, no production API affected.

## Checks

`mvn install -Pquality` on `xwiki-platform-livedata-test-pageobjects`: BUILD SUCCESS, 0 Checkstyle violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)