### PR TITLE
[Misc] Avoid a page load when logging in as a user that is already logged in, in the test framework

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
@@ -423,36 +423,45 @@ public class TestUtils
      */
     public void loginAndGotoPage(String username, String password, String pageURL, boolean checkLoginSuccess)
     {
-        // Get rid of the currently displayed page before switching the user, see unloadCurrentPage().
-        unloadCurrentPage();
-
-        // ensure to be on a wiki page before performing check on the username.
-        getDriver().get(getURL("XWiki", "Register", "register", "_=" + new Date().getTime()));
+        // Check on the currently displayed page whether the requested user is already logged in, so that the common
+        // case of a fixture defensively logging in as a user that is already logged in costs no page load at all.
+        // A page showing the requested user as logged in is a definitive answer, since only a page that the server
+        // rendered for that user can show them as logged in. The opposite is not definitive, because the displayed
+        // page may not be a wiki page (or not be skinned) and thus not show any login state at all, so it only means
+        // that we have to load a wiki page and ask again, which is what the block below does.
         if (!username.equals(getLoggedInUserName())) {
-            // The Register page loaded above is now the page we're leaving behind, so unload it in turn before
-            // actually switching the user.
+            // Get rid of the currently displayed page before switching the user, see unloadCurrentPage().
             unloadCurrentPage();
 
-            // Log in and direct to the Register page again, so that we can check below that the login succeeded and
-            // re-cache the CSRF token without any extra page load.
-            String destUrl = getURL("XWiki", "Register", "register", "_=" + new Date().getTime());
-            getDriver().get(getURLToLoginAndGotoPage(username, password, destUrl));
+            // ensure to be on a wiki page before performing check on the username.
+            getDriver().get(getURL("XWiki", "Register", "register", "_=" + new Date().getTime()));
+            if (!username.equals(getLoggedInUserName())) {
+                // The Register page loaded above is now the page we're leaving behind, so unload it in turn before
+                // actually switching the user.
+                unloadCurrentPage();
 
-            if (checkLoginSuccess && !getDriver().getCurrentUrl().startsWith(destUrl)) {
-                throw new RuntimeException(
-                    String.format("Login failed with credentials: [%s] / [%s]. Was expecting to be on URL [%s] but "
-                        + "was on [%s]. Page source is [%s]", username, password, destUrl,
-                        getDriver().getCurrentUrl(), getDriver().getPageSource()));
+                // Log in and direct to the Register page again, so that we can check below that the login succeeded
+                // and re-cache the CSRF token without any extra page load.
+                String destUrl = getURL("XWiki", "Register", "register", "_=" + new Date().getTime());
+                getDriver().get(getURLToLoginAndGotoPage(username, password, destUrl));
 
+                if (checkLoginSuccess && !getDriver().getCurrentUrl().startsWith(destUrl)) {
+                    throw new RuntimeException(
+                        String.format("Login failed with credentials: [%s] / [%s]. Was expecting to be on URL [%s] but "
+                            + "was on [%s]. Page source is [%s]", username, password, destUrl,
+                            getDriver().getCurrentUrl(), getDriver().getPageSource()));
+
+                }
             }
         }
 
-        // Whether we logged in or not, a Register page is displayed (the one loaded above or the one the login
+        // Whether we logged in or not, a fully skinned wiki page is displayed (the page that was already displayed
+        // when the requested user was already logged in, otherwise the Register page loaded above or the one the login
         // redirected to), so re-cache the CSRF token for the current user without any extra page load. Doing this also
         // when no login was performed is important because the cached token may belong to a different user, in which
         // case the server rejects it: e.g. createUserAndLogin() caches the token of the user it creates, so a
         // subsequent login as the user that was logged in before it would otherwise keep using that token.
-        recacheSecretTokenWhenOnRegisterPage();
+        recacheSecretTokenFromDisplayedPage();
 
         if (pageURL != null) {
             // Go to the page asked, whether a login was needed or not: callers of this method expect to end up on that
@@ -460,8 +469,9 @@ public class TestUtils
             getDriver().get(pageURL);
         }
 
-        // When no page is asked we stay on the Register page: it's already loaded, it's cheap and, being fully skinned,
-        // it shows the login state on screenshots and screen recordings, unlike a blank xpage=plain page.
+        // When no page is asked we stay on the page that is already displayed: either the one the caller was on when
+        // the requested user turned out to be already logged in, or the Register page. Both are fully skinned, so they
+        // show the login state on screenshots and screen recordings, unlike a blank xpage=plain page.
 
         // Always synchronize the REST client credentials with the requested user, even when the browser was already
         // logged in as that user and thus skipped the browser login above. The browser session and the REST client
@@ -668,7 +678,7 @@ public class TestUtils
 
         // We're on the Register page: re-cache the CSRF token for the new user's session (the token cached for the
         // previous user is no longer valid) before it's used e.g. by updateObject below.
-        recacheSecretTokenWhenOnRegisterPage();
+        recacheSecretTokenFromDisplayedPage();
 
         if (properties.length > 0) {
             updateObject("XWiki", username, USER_CLASS_NAME, 0, properties);
@@ -1655,12 +1665,12 @@ public class TestUtils
         String previousURL = getDriver().getCurrentUrl();
         // Go to the registration page because the registration form uses secret token.
         gotoPage(getCurrentWiki(), "Register", "register");
-        recacheSecretTokenWhenOnRegisterPage();
+        recacheSecretTokenFromDisplayedPage();
         // Return to the previous page.
         getDriver().get(previousURL);
     }
 
-    private void recacheSecretTokenWhenOnRegisterPage()
+    private void recacheSecretTokenFromDisplayedPage()
     {
         try {
             WebElement htmlElement = getDriver().findElement(By.tagName("html"));


### PR DESCRIPTION
# Jira URL

N/A — `[Misc]` change, limited to the functional-test framework.

# Changes

## Description

* `TestUtils.loginAndGotoPage()` always loaded `XWiki.Register` before checking whether the requested
  user was already logged in, so the very common case of a fixture defensively calling
  `loginAsSuperAdmin()` when superadmin is already logged in paid a full page load of a fully skinned
  page for nothing.
* Perform that check on the page that is already displayed. When it says the requested user is logged
  in, no page is unloaded and no page is loaded at all: the displayed page already carries the
  anti-CSRF token of that user, which is all the rest of the method needs.
* Rename the private `recacheSecretTokenWhenOnRegisterPage()` to `recacheSecretTokenFromDisplayedPage()`,
  since it reads the token from the `<html>` element of whatever skinned page is displayed and is no
  longer called only on the Register page.

## Clarifications

* **The check is safe in the only direction it is used.** A displayed page that shows the requested
  user as logged in is a *definitive* answer, because only a page the server rendered for that user
  can show them as logged in. The opposite is not definitive — the displayed page may not be a wiki
  page, or not be skinned, and thus show no login state at all — so a negative answer changes nothing:
  it falls through to the pre-existing path, which loads `XWiki.Register` and asks again exactly as
  before. There is therefore no way to wrongly skip a login.
* `unloadCurrentPage()` is now skipped in that fast path, which is correct by its own contract: its
  Javadoc explains it exists to keep in-flight requests of the previous page from arriving *after a
  login invalidated the session*. When no login is performed there is no session invalidation to
  protect against, and no navigation happens either.
* **Behaviour change to be aware of:** when the requested user is already logged in and no `pageURL`
  is asked, the browser now stays on the page the caller was on instead of ending up on the Register
  page. Both are fully skinned, so screenshots and screen recordings still show the login state.

# Screenshots & Video

Not applicable — no product change, only the test framework.

# Executed Tests

Measured with temporary instrumentation inside `loginAndGotoPage()` (not committed), on a
containerized Tomcat, since end-to-end wall clock is dominated by noise for a change of this size.
`BreadcrumbsIT` makes four `loginAsSuperAdmin()` calls and exercises both paths in the same run:

| call | duration | path taken |
| --- | --- | --- |
| 1st — nobody logged in yet | 1111 ms | real login |
| 2nd — displayed page unusable for the check | 460 ms | unchanged path: unload + Register load, no login |
| 3rd | 96 ms | new fast path |
| 4th | 101 ms | new fast path |

The 2nd call is the cost this method had for *every* already-logged-in call before this change, and it
was measured in the same run on the same machine, so an already-logged-in call goes from **~460 ms to
~100 ms**.

Correctness:

```
mvn clean install    (xwiki-platform-test-ui)  -> 0 Checkstyle violations, Revapi OK
mvn verify -Dit.test='LoginIT'       -Dxwiki.test.ui.servletEngine=tomcat  -> 6/6 pass
mvn verify -Dit.test='BreadcrumbsIT' -Dxwiki.test.ui.servletEngine=tomcat  -> 2/2 pass
```

(Asking for both classes in a single invocation fails in `beforeAll` with
`Extension [org.xwiki.platform:xwiki-platform-index-tree-macro] is already installed on namespace
[wiki:xwiki]`, which is a provisioning conflict of the local run and unrelated to this change; each
class passes when run on its own.)

`LoginIT` is the direct gate for this change (it logs in and out as several users) and passes in full.
One run showed `LoginIT.redirectBackAfterLogin` erroring on `ElementNotInteractableException` while
clicking `#tmLogout`; it passes on re-run, the full class passes on `master` and with this change
alike, and Develocity shows that method at 1284 passed / 3 failed over the last 12 months of CI, so
that is a pre-existing low-rate flake unrelated to this change.

**This touches every functional test in the platform, so a full CI run is the real gate — the local
runs above only cover the flamingo-skin module.**

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  *

Generated with Claude Code
