### PR TITLE
[Misc] Avoid loading the class editor when setting a property in XWiki.XWikiPreferences

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
@@ -2331,8 +2331,9 @@ public class TestUtils
     /**
      * Add and set a property into XWiki.XWikiPreferences. Create XWiki.XWikiPreferences if it does not exist.
      * <p>
-     * The property is set over REST, and thus with the REST credentials rather than as the user currently logged in
-     * the browser, and the page displayed in the browser is left untouched.
+     * The property value is set over REST, and thus with the REST credentials rather than as the user currently logged
+     * in the browser. Adding the property to the class still goes through the browser, which is therefore left on
+     * another page: a page chosen to load fast, since no caller has any use for it.
      *
      * @param propertyName name of the property to set
      * @param propertyType the type of the property to add
@@ -2343,7 +2344,13 @@ public class TestUtils
     {
         // The property may not be defined in the XWiki.XWikiPreferences class (e.g. "core.hierarchyMode"), in which
         // case it must be added to the class before it can be set on the object.
-        addClassProperty("XWiki", "XWikiPreferences", propertyName, propertyType);
+        //
+        // The "propadd" action redirects to the class editor of the document it modified, and loading that editor for
+        // XWiki.XWikiPreferences (a class with dozens of properties) is by far the most expensive part of setting a
+        // preference: more than 3 seconds, against about 200 ms for everything else this method does. No caller has
+        // any use for that editor, so send the browser to a page that loads fast instead.
+        gotoPage("XWiki", "XWikiPreferences", "propadd", "propname", propertyName, "proptype", propertyType,
+            "xredirect", getURLToNonExistentPage());
         try {
             setWikiPreference(propertyName, Objects.toString(value, null));
         } catch (Exception e) {


### PR DESCRIPTION
# Jira URL

N/A — `[Misc]` change, limited to the functional-test framework.

# Changes

## Description

* `TestUtils.setPropertyInXWikiPreferences()` adds the property to the `XWiki.XWikiPreferences` class
  through the browser, with the `propadd` action. That action ends with
  `Utils.getRedirect("edit", "editor=class", context)`, so the browser is then made to load the **class
  editor of `XWiki.XWikiPreferences`** — a class with dozens of properties. Loading that editor is by
  far the most expensive thing this method does, and no caller has any use for it.
* Pass an `xredirect` to the existing `TestUtils.getURLToNonExistentPage()` ("a non existent page that
  loads very fast", already used elsewhere in `TestUtils`), so the browser lands there instead.
  `Utils.getRedirect()` honours `xredirect` ahead of its default, so nothing else about the action
  changes.
* Fix the Javadoc of `setPropertyInXWikiPreferences()`, which claimed the page displayed in the browser
  was left untouched. That was never true: the `propadd` navigation always happens.

## Clarifications

* Rebased onto `master` after #6266 (which reworks the same method) was merged, so this PR is now a
  single self-contained commit.
* The `propadd` action needs a valid `form_token`, which `TestUtils.getURL()` takes from the *browser*
  session, so this step cannot simply be moved to the REST/HTTP client — its requests belong to a
  different session and would fail the CSRF check and be redirected to the resubmission page. Keeping
  the browser and only making its landing page cheap is what makes this both safe and effective.
* The saving applies to the case where the property is **not yet** in the class (e.g.
  `core.hierarchyMode`). When it is already there, `propadd` answers early with a small HTTP 400
  (`action.addClassProperty.error.alreadyExists`) and never redirects, so that case was already cheap
  (34–69 ms measured) and is unaffected.
* A possible follow-up, deliberately not done here to keep the blast radius small: `addClassProperty()`
  itself has the same problem for its ~30 callers across many modules, but several of those tests go on
  to use the class editor, so changing it needs a per-caller check.

# Screenshots & Video

Not applicable — no product change, only the test framework.

# Executed Tests

Measured with temporary instrumentation (not committed) around the `propadd` navigation and around
`setHierarchyMode()`, on a containerized Tomcat — `BreadcrumbsIT` sets `core.hierarchyMode`, which is
not defined in the `XWikiPreferences` class and therefore exercises the property-adding path:

| | before | after |
| --- | --- | --- |
| `propadd` navigation (property not yet in the class) | 3320 ms | **292 ms** |
| `setHierarchyMode()` end to end, 1st call | 4005 ms | **584 ms** |

```
mvn clean install    (xwiki-platform-test-ui)  -> 0 Checkstyle violations, Revapi OK
mvn verify -Dit.test='BreadcrumbsIT' -Dxwiki.test.ui.servletEngine=tomcat  -> 2/2 pass
```

`BreadcrumbsIT` is a meaningful functional check here and not only a timing harness: it asserts the
breadcrumb rendered in `parentchild` mode, which only happens if `core.hierarchyMode` was really added
to the class and set, so its passing shows the redirect does not swallow the class modification.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  *

Generated with Claude Code
