### PR TITLE
XWIKI-24588: Create/check for automated tests for "Subwiki: Deny the rights for a user at page level and give the rights to a group"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/UsersGroupsRightsManagementIT.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/UsersGroupsRightsManagementIT.java
@@ -886,6 +886,75 @@ class UsersGroupsRightsManagementIT
         wikiRightsPane.setRight(userName, EditRightsPane.Right.EDIT, EditRightsPane.State.NONE);
     }
 
+    /**
+     * Verify that a right denied to a user at page level takes precedence over that same right granted at page level
+     * to a group the user is a member of: the user has no Edit option on that page but still has one on the other
+     * pages of the wiki. The scenario is also run on a subwiki, with a user local to that subwiki.
+     */
+    @ParameterizedTest
+    @Order(16)
+    @WikisSource(extensions = { "org.xwiki.platform:xwiki-platform-administration-ui" })
+    void denyUserRightAtPageLevelWhenAllowedToGroupAtPageLevel(WikiReference wiki, TestUtils setup)
+    {
+        setup.loginAsSuperAdmin();
+        setup.setCurrentWiki(wiki.getName());
+
+        String userName = "userDeniedAtPageLevel";
+        String groupName = "groupOfUserDeniedAtPageLevel";
+
+        // The page the rights are set on, and a page located outside of it and thus not covered by those rights.
+        DocumentReference testPage = new DocumentReference(wiki.getName(), "DenyUserAtPageLevel", "WebHome");
+        DocumentReference otherPage = new DocumentReference(wiki.getName(), "DenyUserAtPageLevelOther", "WebHome");
+
+        // Make sure the user, the group and the pages don't exist yet.
+        setup.deletePage("XWiki", userName);
+        setup.deletePage("XWiki", groupName);
+        setup.deletePage(testPage);
+        setup.deletePage(otherPage);
+
+        // Create a new user, a new group and add the user to the group.
+        setup.createUser(userName, userName, "");
+        GroupsPage groupsPage = GroupsPage.gotoPage();
+        groupsPage = groupsPage.addNewGroup(groupName);
+        groupsPage.clickEditGroup(groupName).addMember(userName, true).close();
+
+        // Create the page on which the rights are set, and the page on which they aren't.
+        setup.createPage(testPage, "Group allowed content", "Group Allowed Page");
+        setup.createPage(otherPage, "No right set content", "No Right Set Page");
+
+        // Give the "view", "comment" and "edit" rights to the group and deny the "edit" right to the user, both from
+        // Administer Page > Users & Rights > Rights: Page, so that both rules are set at the same level.
+        AdministrationPage pageAdministrationPage =
+            AdministrationPage.gotoSpaceAdministrationPage(testPage.getLastSpaceReference());
+        pageAdministrationPage.clickSection("Users & Rights", "Rights: Page");
+        EditRightsPane pageRightsPane = new EditRightsPane();
+        pageRightsPane.switchToGroups();
+        pageRightsPane.getRightsTable().filterColumn("name", groupName);
+        assertTrue(pageRightsPane.hasEntity(groupName));
+        pageRightsPane.setRight(groupName, EditRightsPane.Right.VIEW, EditRightsPane.State.ALLOW);
+        pageRightsPane.setRight(groupName, EditRightsPane.Right.COMMENT, EditRightsPane.State.ALLOW);
+        pageRightsPane.setRight(groupName, EditRightsPane.Right.EDIT, EditRightsPane.State.ALLOW);
+        pageRightsPane.switchToUsers();
+        pageRightsPane.getRightsTable().filterColumn("name", userName);
+        assertTrue(pageRightsPane.hasEntity(userName));
+        pageRightsPane.setRight(userName, EditRightsPane.Right.EDIT, EditRightsPane.State.DENY);
+
+        setup.login(userName, userName);
+
+        // The rule targeting the user takes precedence over the one targeting its group: the user still views the
+        // page, since "view" is only granted through the group, but has no Edit option on it.
+        ViewPage viewPage = setup.gotoPage(testPage);
+        assertEquals("Group allowed content", viewPage.getContent());
+        assertFalse(viewPage.isEditAvailable(),
+            "The Edit option should not be available since \"edit\" is denied to the user at page level");
+
+        // The deny is limited to that page: the Edit option is still available on the other pages of the wiki.
+        viewPage = setup.gotoPage(otherPage);
+        assertEquals("No right set content", viewPage.getContent());
+        assertTrue(viewPage.isEditAvailable(),
+            "The Edit option should be available on a page on which \"edit\" is not denied to the user");
+    }
+
     private void assertRightsTableShowsUsersAndGroups(EditRightsPane editRightsPane)
     {
         // Select Users: the user listing is displayed (default Admin user present).


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24588

# Changes

## Description

* Automate the manual test [Subwiki: Deny the rights for a user at page level and give the rights to a group](https://test.xwiki.org/xwiki/bin/view/Security%20Tests/Subwiki%3A%20Deny%20the%20rights%20for%20a%20user%20at%20document%20level%20and%20give%20the%20rights%20to%20a%20group), as a new `denyUserRightAtPageLevelWhenAllowedToGroupAtPageLevel` test in `UsersGroupsRightsManagementIT`.
* The test grants "view", "comment" and "edit" to a group and denies "edit" to a member of that group, both from *Administer Page > Users & Rights > Rights: Page* so that both rules sit at the same level, and verifies that the rule targeting the user wins: the user can still view the page (view is only granted through the group) but has no Edit option on it, while the Edit option remains available on a page outside of that scope.
* The scenario runs on both the main wiki and a subwiki, with a user local to that subwiki.

## Clarifications

* **No existing test covered this.** The closest ones are:
  * `DefaultAuthorizationManagerIntegrationTest#userDenyEditAtDocumentLevel` and `#groupDenyEditAtDocumentLevel` — a deny at document level, but with no rule targeting the other entity type at that same level;
  * `DefaultAuthorizationManagerIntegrationTest#groupRightsAtSpaceLevelVersusUserDenyAtWikiLevel` — a group allow and a user deny, but at two different levels;
  * `UsersGroupsRightsManagementIT#allowGroupRightsAtPageLevelWhenUserRightDeniedAtWikiLevel` — a page level group allow beating a **wiki** level user deny, i.e. the level precedence rather than the user-over-group precedence tested here.
* **Why a new test method rather than an addition to an existing one.** The scenario could not be folded into `allowGroupRightsAtPageLevelWhenUserRightDeniedAtWikiLevel`: that test asserts the opposite outcome, it is a plain `@Test` while this one needs `@ParameterizedTest` for the subwiki dimension, and merging them would mean setting and then resetting a wiki level deny in the middle of the test. It is however added to that same class, which already owns the rights pane tests and provides the `@UITest` setup they need.
* **Why `@WikisSource` rather than the wiki creation UI.** The manual test starts by creating a subwiki through the Wiki Creation UI, which `SubWikiIT` does but at a significant cost. `@WikisSource` gives the same thing — a user local to a subwiki — for the price of a wiki creation over REST, and is the pattern already used by the two other parameterized tests of this class.

# Screenshots & Video

Not applicable: no UI change, this PR only adds a test.

# Executed Tests

```
mvn -B -ntp verify -Dit.test='UsersGroupsRightsManagementIT#denyUserRightAtPageLevelWhenAllowedToGroupAtPageLevel*'
```

`Tests run: 2, Failures: 0, Errors: 0, Skipped: 0` — the two invocations being the main wiki and the subwiki. Checkstyle reports no violation on the module.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  *

🤖 Generated with [Claude Code](https://claude.com/claude-code)
