### PR TITLE
XWIKI-24371: Skip the force edit lock confirmation when joining a realtime collaboration session with BlockNote

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/edit/EditModeResolver.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/edit/EditModeResolver.java
@@ -87,8 +87,10 @@ public class EditModeResolver
     private Provider<ComponentManager> componentManagerProvider;
 
     /**
-     * @return the edit mode that is going to be used to edit the current document, in lower case; one of
-     *         {@link #WYSIWYG}, {@link #INPLACE}, {@link #WIKI} or {@link #INLINE}
+     * @return the edit mode that is going to be used to edit the current document, in lower case; usually one of
+     *         {@link #WYSIWYG}, {@link #INPLACE}, {@link #WIKI} or {@link #INLINE}, but it can be any value when the
+     *         edit mode is specified explicitly, e.g. through the {@code editor} request parameter (the object editor
+     *         is reached with {@code editor=object})
      */
     public String getEditMode()
     {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/doc/lock/LockContext.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/doc/lock/LockContext.java
@@ -77,7 +77,8 @@ public interface LockContext
     Locale getRealLocale();
 
     /**
-     * @return the edit mode that is going to be used to edit the specified document translation
+     * @return the edit mode that is going to be used to edit the specified document translation, or {@code null} if
+     *         that edit mode is not one of the {@link EditMode} values (e.g. the object editor)
      */
     EditMode getEditMode();
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/internal/document/lock/DefaultLockContext.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/internal/document/lock/DefaultLockContext.java
@@ -21,6 +21,8 @@ package org.xwiki.internal.document.lock;
 
 import java.util.Locale;
 
+import org.apache.commons.lang3.EnumUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.xwiki.doc.lock.LockContext;
 import org.xwiki.edit.Editor;
 import org.xwiki.edit.EditorManager;
@@ -86,7 +88,9 @@ public class DefaultLockContext implements LockContext
     {
         if (!this.editModeResolved) {
             String editModeString = this.editModeResolver.getEditMode();
-            this.editMode = editModeString == null ? null : EditMode.valueOf(editModeString.toUpperCase());
+            // The resolved edit mode is not necessarily one of the modes we know about: the editor request parameter
+            // can name any edit mode, including one contributed by an extension (e.g. "object" or "class").
+            this.editMode = EnumUtils.getEnum(EditMode.class, StringUtils.upperCase(editModeString));
             this.editModeResolved = true;
         }
         return this.editMode;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/document/lock/DefaultLockContextTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/document/lock/DefaultLockContextTest.java
@@ -109,6 +109,20 @@ class DefaultLockContextTest
     }
 
     @Test
+    void getEditModeWhenUnknown()
+    {
+        when(this.editModeResolver.getEditMode()).thenReturn("object");
+
+        assertNull(this.lockContext.getEditMode());
+    }
+
+    @Test
+    void getEditModeWhenNone()
+    {
+        assertNull(this.lockContext.getEditMode());
+    }
+
+    @Test
     void getContentEditorIsResolvedOnlyOnce()
     {
         when(this.editModeResolver.getEditMode()).thenReturn(EditModeResolver.INPLACE);


### PR DESCRIPTION
## Jira issue

https://jira.xwiki.org/browse/XWIKI-24371 — follow-up fix on that (unreleased) change.

## Problem

`DefaultLockContext#getEditMode()` does `EditMode.valueOf(editMode.toUpperCase())` on whatever `EditModeResolver` returns. That resolver returns the raw `editor` request parameter, which is not restricted to the four `LockContext.EditMode` values, so `?editor=object` (and `class`, `rights`, …) makes it throw:

```
java.lang.IllegalArgumentException: No enum constant org.xwiki.doc.lock.LockContext.EditMode.OBJECT
  at org.xwiki.internal.document.lock.DefaultLockContext.getEditMode(DefaultLockContext.java:89)
  ... EditConfirmationScriptService.check ... environment:/skins/flamingo/edit.vm
```

`XWikiDocumentLockEditConfirmationChecker` only builds a `LockContext` when the document is already locked by someone else, so the result is a **server error page instead of the object / class / rights editor whenever the document carries another user's edit lock**.

That is what makes `VersionIT#testDeleteVersionDontMessUpRights` and `#testDeleteVersionDontMessUpRightsWithCancellingEvent` fail on CI since build 8888. The error page has no RequireJS, so `waitUntilPageIsReady()` times out and its debug helper then reports the misleading `ReferenceError: require is not defined`.

## Fix

Resolve the edit mode with `EnumUtils.getEnum(...)` so an unknown mode yields `null` instead of throwing. Both existing unlock rules (`NetfluxUnlockRule`, `BlockNoteUnlockRule`) compare with `==`, so `null` simply means "no rule unlocks", i.e. the confirmation is shown — the correct behaviour for the object editor.

Javadoc of `LockContext#getEditMode()` and `EditModeResolver#getEditMode()` updated accordingly.

## Tests

Two unit tests added to `DefaultLockContextTest` (unknown edit mode, no edit mode). `mvn test -Dtest=DefaultLockContextTest` on `xwiki-platform-oldcore` passes (8 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
