### PR TITLE
XWIKI-21734: LightboxIT.disabledLightbox is flickering

### DIFF
--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/src/test/it/org/xwiki/image/lightbox/test/ui/LightboxIT.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/src/test/it/org/xwiki/image/lightbox/test/ui/LightboxIT.java
@@ -46,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Functional tests for the image lightbox.
@@ -98,6 +99,10 @@ class LightboxIT
 
         // Make sure that the images are displayed.
         lightboxPage.reloadPage();
+
+        // Not finding a popover below only means that the lightbox is disabled if the page was rendered with the
+        // lightbox disabled in the first place.
+        assertFalse(LightboxPage.isLightboxEnabled(), "The page was rendered with the lightbox enabled");
 
         ImagePopover imagePopover = lightboxPage.hoverImage(0);
         assertThrows(TimeoutException.class, imagePopover::waitUntilReady);
@@ -477,10 +482,26 @@ class LightboxIT
         testUtils.rest().update(userObject);
     }
 
+    /**
+     * Set the lightbox configuration, and make sure that pages are then rendered with it.
+     * <p>
+     * The lightbox is added to a page by a UI extension that reads the configuration document on every render, so
+     * every assertion of these tests depends on the new value being the one those renders see. A copy of the
+     * configuration document read while it is being saved can outlive the save in the document cache and keep the
+     * previous value in effect for the rest of the test; saving the document again is what drops that copy. So save
+     * until the page the save action lands on is itself rendered with the expected configuration.
+     */
     private void enableLightbox(TestUtils testUtils, boolean enable)
     {
-        testUtils.updateObject(LIGHTBOX_CONFIGURATION_REFERENCE, LIGHTBOX_CONFIGURATION_CLASSNAME, 0,
-            "isLightboxEnabled", enable ? "1" : "0");
+        for (int attempt = 0; attempt < 3; attempt++) {
+            testUtils.updateObject(LIGHTBOX_CONFIGURATION_REFERENCE, LIGHTBOX_CONFIGURATION_CLASSNAME, 0,
+                "isLightboxEnabled", enable ? "1" : "0");
+            if (LightboxPage.isLightboxEnabled() == enable) {
+                return;
+            }
+        }
+        fail(String.format("Failed to %s the lightbox: pages are still rendered with the lightbox %s.",
+            enable ? "enable" : "disable", enable ? "disabled" : "enabled"));
     }
 
     private String getSimpleImage(String image)

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/LightboxPage.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/LightboxPage.java
@@ -40,6 +40,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class LightboxPage extends ViewPage
 {
     /**
+     * The JSON configuration that the lightbox UI extension only adds to a page when the lightbox is enabled, and
+     * without which the lightbox JavaScript is neither loaded nor able to build a popover.
+     */
+    private static final By LIGHTBOX_CONFIGURATION = By.id("lightbox-config");
+
+    /**
+     * Static so that it can be called on a page for which no page object is wanted, e.g. right after saving the
+     * lightbox configuration, to check that the new configuration is the one pages are rendered with.
+     *
+     * @return {@code true} when the page currently displayed in the browser has been rendered with the lightbox
+     *     enabled, i.e. when hovering one of its images is expected to display an {@link ImagePopover}
+     * @since 18.8.0RC1
+     */
+    public static boolean isLightboxEnabled()
+    {
+        return getUtil().getDriver().hasElementWithoutWaitingWithoutScrolling(LIGHTBOX_CONFIGURATION);
+    }
+
+    /**
      * Hovers on an image until the popover is displayed. We don't wait for a popover to be displayed, because we don't
      * know if the feature is activated. If you want to make sure that a popover is displayed after the hover, you
      * should call {@link ImagePopover#waitUntilReady()} before calling any other method of {@link ImagePopover}.


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-21734

# Changes

## Description

* `LightboxIT.disabledLightbox` failed because the popover *did* appear: the page had been rendered with the lightbox enabled although the test had just set `isLightboxEnabled` to `0`. So the test was reporting a configuration problem as a lightbox defect.
* `enableLightbox()` now verifies that the value it saved is the one page renders see, and saves again when it is not. The check happens on the page the save action already lands on, so it costs no extra page load. After 3 attempts it fails with an explicit message.
* New `LightboxPage.isLightboxEnabled()` tells whether the displayed page was rendered with the lightbox, from the `#lightbox-config` script that the UI extension only emits when the lightbox is enabled.
* `disabledLightbox` now asserts that precondition before hovering: not finding a popover only means the lightbox is disabled if the page was rendered without it.

Test-only change, no product code touched.

## Clarifications

**Why the configuration change was not in effect.** `disabledLightbox` is `@Order(1)`, the first test of the class, and in every failing build it is the *only* test that fails — every later test re-saves the configuration and passes. On master build 1359: Tomcat came up at 02:46:20, the test extensions (including `xwiki-platform-image-lightbox-ui`, which ships the configuration document) were provisioned through the REST install job from 02:46:14 to 02:46:35, and the test started at 02:46:56. So the suite's first configuration save lands about 20s after a XAR install, while background indexing is still reading every freshly installed document. That points at a copy of the configuration document, read while the save was running, outliving it in the document cache and keeping the previous value in effect for the rest of the test. Saving the document again is what drops that copy, which is what `enableLightbox()` now does.

I could not prove that exact mechanism from the CI artefacts — what is proven is that the configuration change was not visible to the renderer. The `fail()` after 3 attempts is there for that reason: if the problem turns out to be something the re-save does not clear, the build still fails, but it names the real problem instead of reporting "the popover appeared".

**Why this is not a weaker test.** No assertion was removed, relaxed or wrapped in a retry — only the fixture repairs itself, and the behaviour under test is still asserted once, after the fixture is established. The new `assertFalse` is an *added* assertion: `assertThrows(TimeoutException.class, …)` alone passes whenever no popover appears for *any* reason, so pinning down the reason makes the test more specific, not less.

**Choices.** `isLightboxEnabled()` is static so it can be called without instantiating a page object — building one would pull `XWiki.Lightbox.LightboxConfiguration` into the WCAG validation set and change what the build asserts. It uses `hasElementWithoutWaitingWithoutScrolling`, so it cannot introduce a wait or a flicker of its own.

**Unrelated second flicker in the same test.** 3 of the 12 recorded `disabledLightbox` failures are a different problem: an upload timeout at `LightboxPage.attachFile:89` (`AttachmentsPane.waitForUploadToFinish`), unrelated to the lightbox configuration. Not addressed here.

# Screenshots & Video

The failure as CI captured it — the image toolbar popover displayed on the "Disabled Lightbox" page, which is only possible if the page was rendered with the lightbox enabled:

![disabledLightbox popover on a disabled page](https://jira.xwiki.org/secure/attachment/45323/disabledLightbox-popover-on-disabled-page.png)

No UI change in this PR (test-only).

# Executed Tests

Run in a worktree on `master`:

```
# Full class, Chrome — 15/15 pass
mvn clean install -B -ntp -Dit.test='AllIT$NestedLightboxIT' -Dxwiki.test.ui.browser=chrome

# 3 tests, Firefox — 3/3 pass
mvn clean install -B -ntp -Dxwiki.test.ui.browser=firefox \
  -Dit.test='AllIT$NestedLightboxIT#disabledLightbox+openImageWithoutDescription+verifyPartiallyDisabledLightbox'

# disabledLightbox with @RepeatedTest(value = 10, failureThreshold = 1), against a running
# instance, on both browsers — 10/10 pass each (the @RepeatedTest was reverted afterwards)
mvn compiler:testCompile failsafe:integration-test -B -ntp -Dxwiki.test.ui.servletEngine=external \
  -Dit.test='AllIT$NestedLightboxIT#disabledLightbox' -Dxwiki.test.ui.browser=chrome
mvn compiler:testCompile failsafe:integration-test -B -ntp -Dxwiki.test.ui.servletEngine=external \
  -Dit.test='AllIT$NestedLightboxIT#disabledLightbox' -Dxwiki.test.ui.browser=firefox
```

Checkstyle clean on both modified modules.

No SonarCloud PR analysis: both modified modules sit under `xwiki-platform-image-lightbox-test`, which is only built with the `integration-tests` profile and is therefore not part of the SonarCloud analysis.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  *

🤖 Generated with [Claude Code](https://claude.com/claude-code)
