### PR TITLE
[Misc] Make the image style administration page object fail explicitly and diagnosably

### DIFF
--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-test/xwiki-platform-image-style-test-pageobjects/src/main/java/org/xwiki/image/style/test/po/ImageStyleAdministrationPage.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-test/xwiki-platform-image-style-test-pageobjects/src/main/java/org/xwiki/image/style/test/po/ImageStyleAdministrationPage.java
@@ -19,12 +19,15 @@
  */
 package org.xwiki.image.style.test.po;
 
+import java.net.URI;
 import java.util.Map;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.WikiReference;
+import org.xwiki.test.ui.TestUtils;
 import org.xwiki.test.ui.XWikiWebDriver;
 import org.xwiki.test.ui.po.FormContainerElement;
 import org.xwiki.test.ui.po.ViewPage;
@@ -47,6 +50,61 @@ public class ImageStyleAdministrationPage extends ViewPage
      * hitting the validation page is slow on a loaded machine.
      */
     private static final int VALIDATION_TIMEOUT_SECONDS = 30;
+
+    /**
+     * Waits for the section to be displayed and checks that it carries the fields of the configuration object.
+     * <p>
+     * The wait matters because this page object is also built right after clicking a link, i.e. possibly before the
+     * browser left the previous page. The check turns a section rendered without those fields into an explicit
+     * failure, instead of letting a later interaction report an opaque "element not found" on one of them. The section
+     * renders that way when {@code Image.Style.Code.ConfigurationClass} is not visible to the server, which leaves the
+     * property labels as unevaluated Velocity and both fields empty.
+     *
+     * @since 18.8.0RC1
+     */
+    public ImageStyleAdministrationPage()
+    {
+        XWikiWebDriver driver = getDriver();
+        driver.waitUntilElementIsVisible(By.id(DEFAULT_IMAGE_STYLE_FORM_ID));
+        if (!driver.hasElementWithoutWaiting(By.name(DEFAULT_IMAGE_STYLE_FIELD_NAME))) {
+            throw new AssertionError("The image style administration section was rendered without the fields of the "
+                + "[Image.Style.Code.ConfigurationClass] object, which means that object or its class was not visible "
+                + "to the server while rendering the section.\n"
+                + "Section rendered by the server:\n" + getDefaultImageStyleFormMarkup() + '\n'
+                + "Configuration document as served by REST:\n" + getConfigurationDocumentFromRest());
+        }
+    }
+
+    /**
+     * @return the markup of the default image style form, as the server rendered it, so that a failure shows which of
+     *     the fields and labels of the configuration object are missing
+     */
+    private String getDefaultImageStyleFormMarkup()
+    {
+        try {
+            return getDriver().findElementWithoutWaiting(By.id(DEFAULT_IMAGE_STYLE_FORM_ID))
+                .getAttribute("outerHTML");
+        } catch (Exception e) {
+            return String.format("could not be read: %s", ExceptionUtils.getRootCauseMessage(e));
+        }
+    }
+
+    /**
+     * @return the REST representation of the configuration document, objects included. REST does not read the document
+     *     through the same code path as the rendering of the section, so comparing the two tells whether the object is
+     *     missing from the database or only invisible to the request that rendered the section
+     */
+    private String getConfigurationDocumentFromRest()
+    {
+        TestUtils testUtils = getUtil();
+        String uri = String.format("%s/wikis/%s/spaces/Image/spaces/Style/spaces/Code/pages/Configuration/objects",
+            testUtils.rest().getBaseURL(), testUtils.getCurrentWiki());
+        try {
+            return testUtils.rest().executeGet(URI.create(uri)).getResponseBodyAsString();
+        } catch (Exception e) {
+            return String.format("[%s] could not be read: %s", uri, ExceptionUtils.getRootCauseMessage(e));
+        }
+    }
 
     /**
      * @param wikiReference the reference of the wiki containing the admin to access


### PR DESCRIPTION
# Jira URL

None — `[Misc]`. This is test tooling only: it changes no production code and does not change what the test asserts.

Context, for a reviewer who wants it: this page object is the one that fails in the recurring `ImageStyleIT#imageStyleAdministration` CI flicker (~2.8% since mid-August). That flicker is **not** fixed here and cannot be fixed here — the section is already rendered without the configuration fields ~30 s before the assertion fails, so it is server-side state, not a UI wait. See XWIKI-24720 for the (different, already mitigated) flicker originally reported on that test, and XWIKI-24778 for the store robustness defect whose failure shape matches what the CI screenshots show.

# Changes

## Description

* Wait for the default image style form to be displayed before considering the section loaded. `ImageStyleConfigurationForm#clickBackToTheAdministration()` clicks a link and immediately builds this page object, and `BasePage`'s `waitUntilPageIsReady()` can return while the browser is still on the previous page.
* Fail immediately, with an explicit message, when the section renders without the fields of the `Image.Style.Code.ConfigurationClass` object, instead of letting a later interaction spend the whole implicit wait and then report an opaque `NoSuchElementException` on one of them.
* Put the markup the server produced for the section, and the REST representation of the configuration document with its objects, into that message.

## Clarifications

* The two changes are one commit because they are the same method: the second is the failure branch of the check the first one added. Splitting them would mean two PRs editing the same lines.
* The point of dumping both sources is that they do not read the document the same way. REST does not go through the rendering path, so on the next CI occurrence the message says which of the two situations we are in: the xobject is genuinely absent from the database, or it is present but invisible to the request that rendered the section. Guessing between those is what has been blocking the diagnosis.
* Both dumps are best-effort: each is wrapped so that a failure to read it degrades to a note in the message rather than replacing the original assertion failure with an unrelated exception.
* The check is deliberately left in the constructor only, and not added to `getDefaultStyle()`. Every failure observed on the CI so far happens at the first `getDefaultStyle()` call right after `clickBackToTheAdministration()`, i.e. where the constructor runs, and adding a second non-waiting check after `submitDefaultStyleForm()` would risk reporting a page that is merely still reloading.

# Screenshots & Video

No UI change — this is a test page object.

# Executed Tests

```bash
# Module build, Checkstyle and Revapi
mvn -B -ntp install -f xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/pom.xml -DskipTests

# The functional test itself, on both browsers
cd xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-test/xwiki-platform-image-style-test-docker
mvn -B -ntp install -Dit.test=AllIT -Dxwiki.test.ui.browser=firefox
mvn -B -ntp install -Dit.test=AllIT -Dxwiki.test.ui.browser=chrome
```

The diagnostic message is only produced on the failure path, which a passing run never reaches, so it was also validated by temporarily inverting the condition so that it fires on a healthy instance, and checking that the message actually carries the rendered form markup and the REST payload.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
