### PR TITLE
XWIKI-24779: FeedPlugin.EntriesComparator never sorts anything because it reads both objects from the first entry

### DIFF
--- a/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/pom.xml
@@ -31,7 +31,7 @@
   <name>XWiki Platform - Feed - API</name>
   <description>API for feeds (RSS, ATOM, etc)</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.13</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.18</xwiki.jacoco.instructionRatio>
     <!-- TODO: Remove once the tests have been fixed to not output anything to the console! -->
     <xwiki.surefire.captureconsole.skip>true</xwiki.surefire.captureconsole.skip>
   </properties>

--- a/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
@@ -102,44 +102,45 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
 
     private static final String FULL_CONTENT = "fullContent";
 
+    private static final String DATE = "date";
+
+    /**
+     * Orders feed entries by published date, most recent first, entries without a date coming last.
+     */
     public static class SyndEntryComparator implements Comparator<SyndEntry>
     {
+        private static final Comparator<SyndEntry> ORDER =
+            Comparator.comparing(SyndEntry::getPublishedDate, Comparator.nullsLast(Comparator.reverseOrder()));
+
         @Override
         public int compare(SyndEntry entry1, SyndEntry entry2)
         {
-            if ((entry1.getPublishedDate() == null) && (entry2.getPublishedDate() == null)) {
-                return 0;
-            }
-            if (entry1.getPublishedDate() == null) {
-                return 1;
-            }
-            if (entry2.getPublishedDate() == null) {
-                return -1;
-            }
-
-            return entry2.getPublishedDate().compareTo(entry1.getPublishedDate());
+            return ORDER.compare(entry1, entry2);
         }
     }
 
+    /**
+     * Orders {@code XWiki.FeedEntryClass} objects by their {@code date} property, most recent first, entries without
+     * a date coming last.
+     */
     public static class EntriesComparator implements Comparator<com.xpn.xwiki.api.Object>
     {
+        private static final Comparator<com.xpn.xwiki.api.Object> ORDER =
+            Comparator.comparing(EntriesComparator::getDate, Comparator.nullsLast(Comparator.reverseOrder()));
+
         @Override
         public int compare(com.xpn.xwiki.api.Object entry1, com.xpn.xwiki.api.Object entry2)
         {
-            BaseObject bobj1 = entry1.getXWikiObject();
-            BaseObject bobj2 = entry1.getXWikiObject();
+            return ORDER.compare(entry1, entry2);
+        }
 
-            if ((bobj1.getDateValue("date") == null) && (bobj2.getDateValue("date") == null)) {
-                return 0;
-            }
-            if (bobj1.getDateValue("date") == null) {
-                return 1;
-            }
-            if (bobj2.getDateValue("date") == null) {
-                return -1;
-            }
+        private static Date getDate(com.xpn.xwiki.api.Object entry)
+        {
+            // Read the property through the API object instead of through getXWikiObject(), which returns null
+            // whenever the caller doesn't have programming rights and would thus fail the whole comparison.
+            java.lang.Object value = entry.getValue(DATE);
 
-            return bobj2.getDateValue("date").compareTo(bobj1.getDateValue("date"));
+            return value instanceof Date date ? date : null;
         }
     }
 
@@ -388,7 +389,7 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
                     context.remove(FEEDIMGURL);
                 }
                 obj.set("nb", nb, context);
-                obj.set("date", new Date(), context);
+                obj.set(DATE, new Date(), context);
 
                 // Update original document
                 context.getWiki().saveDocument(doc, context);
@@ -731,7 +732,7 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
             edate = new Date();
         }
 
-        obj.setDateValue("date", edate);
+        obj.setDateValue(DATE, edate);
         obj.setStringValue("url", entry.getLink());
         obj.setStringValue(AUTHOR, entry.getAuthor());
         obj.setStringValue("feedurl", feedurl);

--- a/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/test/java/com/xpn/xwiki/plugin/feed/FeedPluginTest.java
+++ b/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/test/java/com/xpn/xwiki/plugin/feed/FeedPluginTest.java
@@ -1,0 +1,163 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.plugin.feed;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndEntryImpl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link FeedPlugin}.
+ *
+ * @version $Id$
+ */
+class FeedPluginTest
+{
+    private static final Date OLD = new Date(1_000_000L);
+
+    private static final Date RECENT = new Date(2_000_000L);
+
+    private static SyndEntry syndEntry(Date publishedDate)
+    {
+        SyndEntry entry = new SyndEntryImpl();
+        entry.setPublishedDate(publishedDate);
+
+        return entry;
+    }
+
+    private static com.xpn.xwiki.api.Object feedEntry(Date date)
+    {
+        com.xpn.xwiki.api.Object entry = mock();
+        when(entry.getValue("date")).thenReturn(date);
+
+        return entry;
+    }
+
+    @Test
+    void syndEntryComparatorSortsMostRecentFirst()
+    {
+        SyndEntry old = syndEntry(OLD);
+        SyndEntry recent = syndEntry(RECENT);
+        List<SyndEntry> entries = new ArrayList<>(Arrays.asList(old, recent));
+
+        entries.sort(new FeedPlugin.SyndEntryComparator());
+
+        assertEquals(Arrays.asList(recent, old), entries);
+    }
+
+    @Test
+    void syndEntryComparatorSortsEntriesWithoutDateLast()
+    {
+        SyndEntry undated = syndEntry(null);
+        SyndEntry old = syndEntry(OLD);
+        SyndEntry recent = syndEntry(RECENT);
+        List<SyndEntry> entries = new ArrayList<>(Arrays.asList(undated, old, recent));
+
+        entries.sort(new FeedPlugin.SyndEntryComparator());
+
+        assertEquals(Arrays.asList(recent, old, undated), entries);
+    }
+
+    @Test
+    void syndEntryComparatorReturnsZeroForEqualDates()
+    {
+        assertEquals(0, new FeedPlugin.SyndEntryComparator().compare(syndEntry(OLD), syndEntry(OLD)));
+        assertEquals(0, new FeedPlugin.SyndEntryComparator().compare(syndEntry(null), syndEntry(null)));
+    }
+
+    @Test
+    void entriesComparatorSortsMostRecentFirst()
+    {
+        com.xpn.xwiki.api.Object old = feedEntry(OLD);
+        com.xpn.xwiki.api.Object recent = feedEntry(RECENT);
+        List<com.xpn.xwiki.api.Object> entries = new ArrayList<>(Arrays.asList(old, recent));
+
+        entries.sort(new FeedPlugin.EntriesComparator());
+
+        assertEquals(Arrays.asList(recent, old), entries);
+    }
+
+    @Test
+    void entriesComparatorSortsEntriesWithoutDateLast()
+    {
+        com.xpn.xwiki.api.Object undated = feedEntry(null);
+        com.xpn.xwiki.api.Object old = feedEntry(OLD);
+        com.xpn.xwiki.api.Object recent = feedEntry(RECENT);
+        List<com.xpn.xwiki.api.Object> entries = new ArrayList<>(Arrays.asList(undated, old, recent));
+
+        entries.sort(new FeedPlugin.EntriesComparator());
+
+        assertEquals(Arrays.asList(recent, old, undated), entries);
+    }
+
+    @Test
+    void entriesComparatorReturnsZeroForEqualDates()
+    {
+        assertEquals(0, new FeedPlugin.EntriesComparator().compare(feedEntry(OLD), feedEntry(OLD)));
+        assertEquals(0, new FeedPlugin.EntriesComparator().compare(feedEntry(null), feedEntry(null)));
+    }
+
+    /**
+     * The comparator used to read both of its operands from the first entry, which made it always return 0 and left
+     * the list in its original order.
+     */
+    @Test
+    void entriesComparatorReadsTheDateOfBothEntries()
+    {
+        com.xpn.xwiki.api.Object old = feedEntry(OLD);
+        com.xpn.xwiki.api.Object recent = feedEntry(RECENT);
+
+        assertEquals(-1, Integer.signum(new FeedPlugin.EntriesComparator().compare(recent, old)));
+        assertEquals(1, Integer.signum(new FeedPlugin.EntriesComparator().compare(old, recent)));
+
+        verify(old, times(2)).getValue("date");
+        verify(recent, times(2)).getValue("date");
+    }
+
+    /**
+     * {@code com.xpn.xwiki.api.Object#getXWikiObject()}, which the comparator used to call, returns null without
+     * programming rights.
+     */
+    @Test
+    void entriesComparatorDoesNotNeedProgrammingRights()
+    {
+        com.xpn.xwiki.api.Object old = feedEntry(OLD);
+        com.xpn.xwiki.api.Object recent = feedEntry(RECENT);
+        when(old.getXWikiObject()).thenReturn(null);
+        when(recent.getXWikiObject()).thenReturn(null);
+        List<com.xpn.xwiki.api.Object> entries = new ArrayList<>(Arrays.asList(old, recent));
+
+        entries.sort(new FeedPlugin.EntriesComparator());
+
+        assertEquals(Arrays.asList(recent, old), entries);
+    }
+}


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24779

# Changes

## Description

`FeedPlugin.EntriesComparator` read **both** of the objects it compares from the *first* entry:

```java
BaseObject bobj1 = entry1.getXWikiObject();
BaseObject bobj2 = entry1.getXWikiObject();   // should be entry2
```

`com.xpn.xwiki.api.Object#getXWikiObject()` returns the wrapped instance without copying it, so every
comparison compared one article's date with itself, the comparator always returned `0`, and the
`Collections.sort(apiObjs, new EntriesComparator())` in `FeedPlugin#search(String, XWikiContext)` was a
no-op. The HQL behind that search carries no `ORDER BY` either, so callers got raw database order
instead of most-recent-first. The typo dates back to `d3ede03523a` (2009).

This PR:

* Reads the date of the **second** entry, so the results are really ordered by descending date.
* Reads the `date` property through `com.xpn.xwiki.api.Collection#getValue(String)` instead of through
  `getXWikiObject()`. The latter returns `null` when the caller has no programming rights, which made
  the comparator throw a `NullPointerException` and the whole sort fail — the second half of the issue.
* Expresses both comparators with `Comparator.comparing(…, Comparator.nullsLast(Comparator.reverseOrder()))`.
  The ordering ("most recent first, undated entries last") is now stated by the code rather than encoded
  in a negated comparison, and the two comparators keep exactly their previous null semantics: `0` for two
  undated entries, undated entries sorted last.
* Adds `FeedPluginTest`, the first test to exercise either comparator.

`SyndEntryComparator` had no behavioural bug; it is rewritten the same way because leaving the two
sibling comparators of the same class in two different styles would be worse, and because it removes
the `-a.compareTo(b)` pattern (`java:S2676`) from the file for good.

## Clarifications

* **Supersedes the two `FeedPlugin` hunks of #6279** (now merged). That PR rewrote these same two
  `return` lines as `-a.compareTo(b)` → `b.compareTo(a)` for `java:S2676`; this branch is rebased on top
  of it and removes both comparison expressions outright, so the rule has no site left to flag here.
  Note that #6279's swap was behaviour-preserving but could not fix anything: with the `bobj2` typo in
  place, `bobj2.getDateValue("date").compareTo(bobj1.getDateValue("date"))` still compares a date with
  itself and still always returns `0`.
* No `@since` tag: no API is added or deprecated, `EntriesComparator` and `SyndEntryComparator` keep
  their signatures, and Revapi passes.
* `getValue(String)` obfuscates only *sensitive* properties, which a Date property is not, so reading
  the date through it returns the same value as before for every caller that previously worked.
* The module's `xwiki.jacoco.instructionRatio` was stale at `0.13` (the module already achieved
  `0.1713`); the new tests bring it to `0.1802` and the property is raised to `0.18`. Both comparator
  classes are now at 100% instruction coverage.

# Screenshots & Video

N/A — no visible result. `FeedPlugin#search` is not exposed by `FeedPluginApi`, so the affected path is
reachable from Java code only (this plugin and third-party plugins), not from wiki scripts.

# Executed Tests

```
mvn -B -ntp clean install -pl xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api -Pquality
```

`BUILD SUCCESS` — 16 tests green, 0 Checkstyle violations, `revapi:check` and `jacoco:check` passing.

The new tests were verified to be red against the unfixed code: reverting `FeedPlugin.java` to master and
re-running `FeedPluginTest` fails all 5 `EntriesComparator` tests. `entriesComparatorReadsTheDateOfBothEntries`
additionally asserts, with `verify(…, times(2)).getValue("date")`, that both entries are read — which is the
typo itself, rather than only its symptom.

# Expected merging strategy

Prefers squash: Yes. No backport requested — the bug is 17 years old and its impact is limited to a
deprecated plugin's Java-only entry point, so it does not seem worth churning the stable branches. Happy
to add `backport stable-*` labels if a committer disagrees.

---
_Generated with [Claude Code](https://claude.ai/code)_
