### PR TITLE
XRENDERING-814: Support supplementary characters when validating XML names

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-war-legacydependencies/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-war-legacydependencies/pom.xml
@@ -63,6 +63,7 @@
                     <exclude>org.xwiki.commons:xwiki-commons-job-default:*:jar:*</exclude>
                     <exclude>org.xwiki.rendering:xwiki-rendering-api:*:jar:*</exclude>
                     <exclude>org.xwiki.rendering:xwiki-rendering-transformation-macro:*:jar:*</exclude>
+                    <exclude>org.xwiki.rendering:xwiki-rendering-wikimodel:*:jar:*</exclude>
                     <exclude>org.xwiki.platform:xwiki-platform-extension-handler-xar:*:jar:*</exclude>
                     <exclude>org.xwiki.platform:xwiki-platform-office-importer:*:jar:*</exclude>
                     <exclude>org.xwiki.platform:xwiki-platform-oldcore:*:jar:*</exclude>
@@ -141,6 +142,10 @@
         <exclusion>
           <groupId>org.xwiki.rendering</groupId>
           <artifactId>xwiki-rendering-transformation-macro</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.xwiki.rendering</groupId>
+          <artifactId>xwiki-rendering-wikimodel</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.xwiki.platform</groupId>
@@ -241,6 +246,18 @@
         <exclusion>
           <groupId>org.xwiki.commons</groupId>
           <artifactId>xwiki-commons-properties</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.rendering</groupId>
+      <artifactId>xwiki-rendering-legacy-wikimodel</artifactId>
+      <version>${rendering.version}</version>
+      <!-- Exclude transitive dependencies which are conflicting with legacy dependencies -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.xwiki.rendering</groupId>
+          <artifactId>xwiki-rendering-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XRENDERING-814

# Changes

## Description

Companion of https://github.com/xwiki/xwiki-rendering/pull/426, which introduces a new
`xwiki-rendering-legacy-wikimodel` module. That module weaves `xwiki-rendering-wikimodel` with
AspectJ to re-add the deprecated `char` based `WikiPageUtil#isValidXmlNameChar` /
`#isValidXmlNameStartChar` signatures, so its jar is a full **replacement** of the clean one and the
two must not both end up in the WAR.

In `xwiki-platform-distribution-war-legacydependencies`:

* ban `org.xwiki.rendering:xwiki-rendering-wikimodel:*:jar:*` in the `bannedDependencies` enforcer
  rule, so the build fails if the clean jar ever comes back;
* exclude it from `xwiki-platform-distribution-war-dependencies`, which pulled it in transitively
  through `xwiki-platform-annotation-core` → `xwiki-rendering-syntax-xhtml` →
  `xwiki-rendering-syntax-wikimodel`;
* depend on `xwiki-rendering-legacy-wikimodel` instead.

## Clarifications

* This mirrors exactly how `xwiki-rendering-api` / `xwiki-rendering-legacy-api` and
  `xwiki-rendering-transformation-macro` / `xwiki-rendering-legacy-transformation-macro` are already
  handled in this pom.
* **Must be merged together with the xwiki-rendering PR** — `xwiki-rendering-legacy-wikimodel` does
  not exist without it.

# Screenshots & Video

N/A — build configuration only.

# Executed Tests

```
cd xwiki-platform-distribution/xwiki-platform-distribution-war-legacydependencies
mvn -B -ntp validate      # runs the bannedDependencies enforcer rule -> BUILD SUCCESS
mvn -B -ntp dependency:list | grep -i wikimodel
```

The resolved list contains `xwiki-rendering-legacy-wikimodel:jar` and
`xwiki-rendering-syntax-wikimodel:jar`, and `xwiki-rendering-wikimodel` only as the `pom`-type
trigger dependency — no clean jar.

# Expected merging strategy

Prefers squash: Yes. No backport.

# Related

* https://github.com/xwiki/xwiki-rendering/pull/426

---
_Generated with [Claude Code](https://claude.com/claude-code)_
