### PR TITLE
XWIKI-23503: 'Submit' button is active although no document is uploaded in the Office Document Viewer Macro

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -250,6 +250,27 @@
                 </item>
               </differences>
             </revapi.differences>
+            <revapi.differences>
+              <justification>No retro compatibility impact, only makes the macro parameter mandatory in the macro
+                parameter descriptor.</justification>
+              <criticality>allowed</criticality>
+              <differences>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.annotation.added</code>
+                  <old>method void org.xwiki.rendering.macro.office.OfficeMacroParameters::setAttachment(java.lang.String)</old>
+                  <new>method void org.xwiki.rendering.macro.office.OfficeMacroParameters::setAttachment(java.lang.String)</new>
+                  <annotation>@org.xwiki.properties.annotation.PropertyFeature(value = "reference", mandatory = true)</annotation>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.annotation.added</code>
+                  <old>method void org.xwiki.rendering.macro.office.OfficeMacroParameters::setReference(org.xwiki.rendering.listener.reference.ResourceReference)</old>
+                  <new>method void org.xwiki.rendering.macro.office.OfficeMacroParameters::setReference(org.xwiki.rendering.listener.reference.ResourceReference)</new>
+                  <annotation>@org.xwiki.properties.annotation.PropertyFeature(value = "reference", mandatory = true)</annotation>
+                </item>
+              </differences>
+            </revapi.differences>
           </analysisConfiguration>
         </configuration>
       </plugin>

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-macro/src/main/java/org/xwiki/rendering/macro/office/OfficeMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-macro/src/main/java/org/xwiki/rendering/macro/office/OfficeMacroParameters.java
@@ -22,6 +22,7 @@ package org.xwiki.rendering.macro.office;
 import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.properties.annotation.PropertyDescription;
 import org.xwiki.properties.annotation.PropertyDisplayType;
+import org.xwiki.properties.annotation.PropertyFeature;
 import org.xwiki.rendering.listener.reference.ResourceReference;
 import org.xwiki.rendering.listener.reference.ResourceType;
 
@@ -91,6 +92,7 @@ public class OfficeMacroParameters
     @PropertyDescription("The office attachment to be viewed. Use an attachment string reference to specify which "
         + "office file should be viewed: file.ppt, Page@file.doc, Space.Page@file.xls or wiki:Space.Page@file.odt.")
     @PropertyDisplayType(AttachmentReference.class)
+    @PropertyFeature(value = "reference", mandatory = true)
     @Deprecated
     public void setAttachment(String attachment)
     {
@@ -119,6 +121,7 @@ public class OfficeMacroParameters
         + " attach:file.ppt, attach:Page@file.doc, attach:Space.Page@file.xls, attach:wiki:Space.Page@file.odt,"
         + " url:http://some/remote/file.ppt.")
     @PropertyDisplayType(OfficeResourceReference.class)
+    @PropertyFeature(value = "reference", mandatory = true)
     public void setReference(ResourceReference reference)
     {
         this.reference = reference;

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-webjar/src/main/webjar/macro/macroEditor.js
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-webjar/src/main/webjar/macro/macroEditor.js
@@ -217,6 +217,12 @@ define('xwiki-wysiwyg-macro-parameter-tree-displayer', [
     </div>`,
 
   displayGroup = function (parametersMap, groupNode) {
+    let children = groupNode.children.map(nodeKey => parametersMap[nodeKey]);
+    let visibleChildren = children.filter(child => !child.hidden);
+    // A feature with a single visible member offers no choice, so there is nothing to put a titled box around.
+    if (groupNode.featureOnly && visibleChildren.length === 1 && visibleChildren[0].type === 'PARAMETER') {
+      return displaySingleGroupParameter(parametersMap, groupNode, children, visibleChildren[0]);
+    }
     let isFeature = groupNode.featureOnly;
     let name = (isFeature) ? groupNode.featureName : groupNode.name;
     let output = $(macroFeatureContainerTemplate);
@@ -234,6 +240,20 @@ define('xwiki-wysiwyg-macro-parameter-tree-displayer', [
         groupNode.children.map(nodeKey =>
             createGroupNodeValue(parametersMap, nodeKey, groupNode.id, useRadioButtons, groupNode.mandatory)
     ));
+    return output;
+  },
+
+  displaySingleGroupParameter = function (parametersMap, groupNode, children, visibleChild) {
+    let output = $();
+    // The hidden members are displayed too, hidden, since the macro call is built from the displayed parameters.
+    children.forEach(child => {
+      let childOutput = displayMacroParameterTreeNode(parametersMap, child, null);
+      if (child === visibleChild && groupNode.mandatory) {
+        childOutput.addClass('mandatory');
+        childOutput.find('.mandatory').first().text('(' + translations.get('required') + ')');
+      }
+      output = output.add(childOutput);
+    });
     return output;
   },
 


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-23503

# Changes

## Description

* `OfficeMacroParameters#setReference` and the deprecated `#setAttachment` are both annotated `@PropertyFeature(value = "reference", mandatory = true)`, so the descriptor declares the office file as required, satisfied by either parameter.
* `macroEditor.js` now displays a feature holding a single visible parameter just like that parameter alone, carrying the mandatory marker, instead of a titled box around one property only.
* A Revapi ignore for the two `java.annotation.added` differences, criticality `allowed`.

## Clarifications

* **Used a feature mandatory rather than `@PropertyMandatory`**, so existing `{{office attachment="file.doc"/}}` content keeps working: `DefaultBeanManager#checkFeatureMandatory` only throws when no parameter of the feature is set. Same shape as `IncludeMacroParameters`.
* Two or more visible parameters keep the feature mandatory specific UI.
* The runtime check in `OfficeMacro#getResourceReference` is kept, since the feature check tests presence and `attachment=""` satisfies it.

# Screenshots & Video

<img width="1420" height="676" alt="before-after" src="https://github.com/user-attachments/assets/dd0f15b0-116c-4489-8183-9e47f935edd4" />

# Executed Tests

- `mvn clean install -Plegacy,quality` on `xwiki-platform-office-macro` and on `xwiki-platform-wysiwyg-webjar` -- BUILD SUCCESS.
- Checked on an 18.8.0-SNAPSHOT instance with both jars swapped in: with no file selected the field is marked `(Required)`, Submit flags it and does not insert anything (it used to insert a macro failing at render time); the parameter shows without a feature box; an existing `{{office attachment="file.doc"/}}` keeps the feature description box because there's two feature options displayed.
- Ran `xwiki-review` over 10 angles, each finding challenged by a skeptic scoring from 0 to 100: restrict the collapse to features (50, applied anyway), add a Jasmine test for the displayer (50, needs a test harness in the module -- too heavy to be worth here), assert the refused insertion in `QuickActionsIT#include` (35, not done).

# Expected merging strategy

Prefers squash: Yes
Backport:
* None

