### PR TITLE
XWIKI-22383: Display the macro name next to the move handle when hovering a macro in the wysiwyg editor

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/plugin.js
@@ -305,6 +305,10 @@
           // update the attribute ourselves in order to have a dynamic path name (since the user can change the macro).
           this.wrapper.data('cke-display-name', this.pathName);
           $(this.element.$).children('.macro-placeholder').text(this.pathName);
+          // Show the macro name next to the move handle. The drag handler container is part of the widget wrapper,
+          // which is not saved, so this doesn't modify the edited content. There's no drag handler if the macro widget
+          // is not draggable.
+          this.dragHandlerContainer?.setAttribute('data-macro-name', this.data.name);
         },
         edit: function(event) {
           // Prevent the default behavior because we want to use our custom dialog.

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/plugin.js
@@ -305,15 +305,14 @@
           // update the attribute ourselves in order to have a dynamic path name (since the user can change the macro).
           this.wrapper.data('cke-display-name', this.pathName);
           $(this.element.$).children('.macro-placeholder').text(this.pathName);
-          // Show the macro name next to the move handle. The drag handler container is part of the widget wrapper,
-          // which is not saved, so this doesn't modify the edited content. There's no drag handler if the macro widget
-          // is not draggable.
+          // Show the macro name next to the move handle. The drag handler container is part of the widget wrapper, so
+          // this doesn't modify the edited content. Only draggable widgets have a drag handler.
           if (this.dragHandlerContainer) {
             let macroName = this.dragHandlerContainer.findOne('.macro-name');
             if (!macroName) {
               macroName = new CKEDITOR.dom.element('span', editor.document);
               macroName.addClass('macro-name');
-              // The macro name is already announced by the widget wrapper, which is labelled with the widget path name.
+              // The widget wrapper is already labelled with the macro name.
               macroName.setAttribute('aria-hidden', 'true');
               this.dragHandlerContainer.append(macroName);
             }

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/plugin.js
@@ -308,7 +308,17 @@
           // Show the macro name next to the move handle. The drag handler container is part of the widget wrapper,
           // which is not saved, so this doesn't modify the edited content. There's no drag handler if the macro widget
           // is not draggable.
-          this.dragHandlerContainer?.setAttribute('data-macro-name', this.data.name);
+          if (this.dragHandlerContainer) {
+            let macroName = this.dragHandlerContainer.findOne('.macro-name');
+            if (!macroName) {
+              macroName = new CKEDITOR.dom.element('span', editor.document);
+              macroName.addClass('macro-name');
+              // The macro name is already announced by the widget wrapper, which is labelled with the widget path name.
+              macroName.setAttribute('aria-hidden', 'true');
+              this.dragHandlerContainer.append(macroName);
+            }
+            macroName.setText(this.data.name);
+          }
         },
         edit: function(event) {
           // Prevent the default behavior because we want to use our custom dialog.

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/test/javascript/xwiki-macro.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/test/javascript/xwiki-macro.js
@@ -132,6 +132,20 @@ describe('XWiki Macro Plugin for CKEditor', function() {
     });
   });
 
+  it('displays the macro name next to the move handle', function(done) {
+    editor.setData('<!--startmacro:info|-||-|info--><div class="box infomessage">info</div><!--stopmacro-->', {
+      callback: function() {
+        var infoMacro = getWikiMacroWidgets(editor)[0];
+        expect(infoMacro.dragHandlerContainer.getAttribute('data-macro-name')).toBe('info');
+
+        infoMacro.setData('name', 'warning');
+        expect(infoMacro.dragHandlerContainer.getAttribute('data-macro-name')).toBe('warning');
+
+        done();
+      }
+    });
+  });
+
   it('handles nested editable macros', function(done) {
     editor.setData([
       '<!--startmacro:info|-|-->',

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/test/javascript/xwiki-macro.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/test/javascript/xwiki-macro.js
@@ -136,10 +136,12 @@ describe('XWiki Macro Plugin for CKEditor', function() {
     editor.setData('<!--startmacro:info|-||-|info--><div class="box infomessage">info</div><!--stopmacro-->', {
       callback: function() {
         var infoMacro = getWikiMacroWidgets(editor)[0];
-        expect(infoMacro.dragHandlerContainer.getAttribute('data-macro-name')).toBe('info');
+        var macroName = infoMacro.dragHandlerContainer.findOne('.macro-name');
+        expect(macroName.getText()).toBe('info');
+        expect(macroName.getAttribute('aria-hidden')).toBe('true');
 
         infoMacro.setData('name', 'warning');
-        expect(infoMacro.dragHandlerContainer.getAttribute('data-macro-name')).toBe('warning');
+        expect(infoMacro.dragHandlerContainer.findOne('.macro-name').getText()).toBe('warning');
 
         done();
       }

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/MacroIT.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/MacroIT.java
@@ -131,6 +131,11 @@ class MacroIT extends AbstractCKEditorIT
         setSource("before\n\n{{id name='test'/}}\n\nafter");
         assertEquals("before\nmacro:id\nafter", this.textArea.getText());
 
+        // The macro name is displayed next to the move handle, but only while the macro is hovered.
+        assertNull(this.textArea.getMacroNameNextToMoveHandle(0));
+        this.textArea.hoverMacro(0);
+        assertEquals("id", this.textArea.getMacroNameNextToMoveHandle(0));
+
         this.textArea.sendKeys(Keys.HOME, Keys.LEFT);
         this.textArea.waitUntilWidgetSelected();
         this.textArea.sendKeys(Keys.ENTER);
@@ -209,28 +214,5 @@ class MacroIT extends AbstractCKEditorIT
             {{/info}}
 
             after""");
-    }
-
-    @Test
-    @Order(5)
-    void macroNameNextToTheMoveHandle(TestUtils setup, TestReference testReference)
-    {
-        edit(setup, testReference, true);
-        setSource("""
-            {{info}}
-            one
-            {{/info}}
-
-            {{warning}}
-            two
-            {{/warning}}""");
-
-        // The macro name is displayed only when the macro is hovered.
-        assertNull(this.textArea.getMacroNameNextToMoveHandle(0));
-        assertNull(this.textArea.getMacroNameNextToMoveHandle(1));
-
-        this.textArea.hoverMacro(1);
-        assertEquals("warning", this.textArea.getMacroNameNextToMoveHandle(1));
-        assertNull(this.textArea.getMacroNameNextToMoveHandle(0));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/MacroIT.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/MacroIT.java
@@ -38,6 +38,7 @@ import org.xwiki.wysiwyg.test.po.MacroDialogEditModal;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Tests how rendering macros are integrated in CKEditor.
@@ -208,5 +209,28 @@ class MacroIT extends AbstractCKEditorIT
             {{/info}}
 
             after""");
+    }
+
+    @Test
+    @Order(5)
+    void macroNameNextToTheMoveHandle(TestUtils setup, TestReference testReference)
+    {
+        edit(setup, testReference, true);
+        setSource("""
+            {{info}}
+            one
+            {{/info}}
+
+            {{warning}}
+            two
+            {{/warning}}""");
+
+        // The macro name is displayed only when the macro is hovered.
+        assertNull(this.textArea.getMacroNameNextToMoveHandle(0));
+        assertNull(this.textArea.getMacroNameNextToMoveHandle(1));
+
+        this.textArea.hoverMacro(1);
+        assertEquals("warning", this.textArea.getMacroNameNextToMoveHandle(1));
+        assertNull(this.textArea.getMacroNameNextToMoveHandle(0));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/RichTextAreaElement.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/RichTextAreaElement.java
@@ -786,15 +786,10 @@ public class RichTextAreaElement extends BaseElement
     public String getMacroNameNextToMoveHandle(int macroIndex)
     {
         return getFromEditedContent(() -> {
-            WebElement dragHandlerContainer = this.content.getMacros().get(macroIndex).findElement(By.xpath(
-                "./ancestor::*[@data-cke-widget-wrapper][1]/*[contains(@class, 'cke_widget_drag_handler_container')]"));
-            // The macro name is displayed using the content of a pseudo element, which is not part of the DOM, so we
-            // can't read its text. We read instead the attribute the pseudo element takes its content from, after
-            // checking that the pseudo element is displayed.
-            return (String) getDriver().executeScript("""
-                const dragHandlerContainer = arguments[0];
-                return getComputedStyle(dragHandlerContainer, '::after').display === 'none' ? null
-                    : dragHandlerContainer.getAttribute('data-macro-name');""", dragHandlerContainer);
+            WebElement macroName = this.content.getMacros().get(macroIndex).findElement(By.xpath(
+                "./ancestor::*[@data-cke-widget-wrapper][1]"
+                    + "/*[contains(@class, 'cke_widget_drag_handler_container')]/*[@class = 'macro-name']"));
+            return macroName.isDisplayed() ? macroName.getText() : null;
         });
     }
 }

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/RichTextAreaElement.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/RichTextAreaElement.java
@@ -63,6 +63,15 @@ public class RichTextAreaElement extends BaseElement
 
             return getRootEditableElement(false).findElements(By.tagName("img"));
         }
+
+        /**
+         * @return the list of macros included in the rich text area
+         * @since 18.8.0RC1
+         */
+        public List<WebElement> getMacros()
+        {
+            return getRootEditableElement(false).findElements(By.className("macro"));
+        }
     }
 
     /**
@@ -753,6 +762,39 @@ public class RichTextAreaElement extends BaseElement
                 .moveToElement(targetImage)
                 // We have to drag the image using the dedicated drag handle.
                 .dragAndDropBy(dragHandle, xOffset, yOffset).perform();
+        });
+    }
+
+    /**
+     * Hovers the specified macro, in order to display its move handle.
+     *
+     * @param macroIndex the index of the macro to hover (0-based)
+     * @since 18.8.0RC1
+     */
+    public void hoverMacro(int macroIndex)
+    {
+        verifyContent(editedContent -> getDriver().createActions()
+            .moveToElement(editedContent.getMacros().get(macroIndex)).perform());
+    }
+
+    /**
+     * @param macroIndex the index of the macro to look at (0-based)
+     * @return the macro name displayed next to the move handle of the specified macro, or {@code null} if the macro
+     *         name is not displayed
+     * @since 18.8.0RC1
+     */
+    public String getMacroNameNextToMoveHandle(int macroIndex)
+    {
+        return getFromEditedContent(() -> {
+            WebElement dragHandlerContainer = this.content.getMacros().get(macroIndex).findElement(By.xpath(
+                "./ancestor::*[@data-cke-widget-wrapper][1]/*[contains(@class, 'cke_widget_drag_handler_container')]"));
+            // The macro name is displayed using the content of a pseudo element, which is not part of the DOM, so we
+            // can't read its text. We read instead the attribute the pseudo element takes its content from, after
+            // checking that the pseudo element is displayed.
+            return (String) getDriver().executeScript("""
+                const dragHandlerContainer = arguments[0];
+                return getComputedStyle(dragHandlerContainer, '::after').display === 'none' ? null
+                    : dragHandlerContainer.getAttribute('data-macro-name');""", dragHandlerContainer);
         });
     }
 }

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/RichTextAreaElement.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/RichTextAreaElement.java
@@ -786,6 +786,7 @@ public class RichTextAreaElement extends BaseElement
     public String getMacroNameNextToMoveHandle(int macroIndex)
     {
         return getFromEditedContent(() -> {
+            // A nested macro has one widget wrapper per ancestor macro, so take the closest one.
             WebElement macroName = this.content.getMacros().get(macroIndex).findElement(By.xpath(
                 "./ancestor::*[@data-cke-widget-wrapper][1]"
                     + "/*[contains(@class, 'cke_widget_drag_handler_container')]/*[@class = 'macro-name']"));

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
@@ -260,7 +260,8 @@ a[data-linktype="create"]::after {
 }
 .cke_widget_wrapper:hover &gt; .cke_widget_drag_handler_container[data-macro-name]::after {
   background-color: #dcdcdc;
-  color: #333;
+  /* The move handle container is painted with an opacity of 0.75, so the text has to be darker than usual. */
+  color: #000;
   display: block;
   font-family: monospace;
   font-size: 12px;

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
@@ -254,11 +254,14 @@ a[data-linktype="create"]::after {
   don't have a visible output. The move handle is hidden by collapsing its container, which doesn't hide the
   overflowing macro name, so the macro name is displayed only while the macro is hovered. */
 .cke_widget_drag_handler_container &gt; .macro-name {
+  /* Match the grey CKEditor hard-codes for the move handle, rather than a color theme value that would drift away
+    from it. The handle container is painted with an opacity of 0.75, applied after the text is drawn, so the text has
+    to be black to stay readable through it. */
   background-color: #dcdcdc;
-  /* The move handle container is painted with an opacity of 0.75, so the text has to be darker than usual. */
   color: #000;
   display: none;
   font-family: monospace;
+  /* Fit the text in the 15px band of the move handle, whose size CKEditor hard-codes as well. */
   font-size: 12px;
   line-height: 15px;
   padding: 0 .3em;

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
@@ -250,6 +250,36 @@ a[data-linktype="create"]::after {
   display: block;
 }
 
+/* Display the macro name next to the move handle, in order to be able to identify the macros that are nested or that
+  don't have a visible output. */
+.cke_widget_drag_handler_container[data-macro-name]::after {
+  /* The move handle is hidden by collapsing its container, which doesn't hide the overflowing macro name, so we have
+    to hide the macro name ourselves. */
+  display: none;
+  content: attr(data-macro-name);
+}
+.cke_widget_wrapper:hover &gt; .cke_widget_drag_handler_container[data-macro-name]::after {
+  background-color: #dcdcdc;
+  color: #333;
+  display: block;
+  font-family: monospace;
+  font-size: 12px;
+  /* The height of the move handle. */
+  height: 15px;
+  line-height: 15px;
+  max-width: 20em;
+  overflow: hidden;
+  padding: 0 .3em;
+  /* Don't steal the mouse events from the content displayed above the macro. */
+  pointer-events: none;
+  /* Place the macro name right after the move handle, whose container is absolutely positioned. */
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline-start: 100%;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Inline widgets (macros) have display:inline-block and thus don't inherit the text-decoration styles. We fix this by
   applying the styles directly for the text-decoration values that are commonly used.
   See CKEDITOR-282: Strikethrough not displayed for macros */

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
@@ -251,25 +251,16 @@ a[data-linktype="create"]::after {
 }
 
 /* Display the macro name next to the move handle, in order to be able to identify the macros that are nested or that
-  don't have a visible output. */
-.cke_widget_drag_handler_container[data-macro-name]::after {
-  /* The move handle is hidden by collapsing its container, which doesn't hide the overflowing macro name, so we have
-    to hide the macro name ourselves. */
-  display: none;
-  content: attr(data-macro-name);
-}
-.cke_widget_wrapper:hover &gt; .cke_widget_drag_handler_container[data-macro-name]::after {
+  don't have a visible output. The move handle is hidden by collapsing its container, which doesn't hide the
+  overflowing macro name, so the macro name is displayed only while the macro is hovered. */
+.cke_widget_drag_handler_container &gt; .macro-name {
   background-color: #dcdcdc;
   /* The move handle container is painted with an opacity of 0.75, so the text has to be darker than usual. */
   color: #000;
-  display: block;
+  display: none;
   font-family: monospace;
   font-size: 12px;
-  /* The height of the move handle. */
-  height: 15px;
   line-height: 15px;
-  max-width: 20em;
-  overflow: hidden;
   padding: 0 .3em;
   /* Don't steal the mouse events from the content displayed above the macro. */
   pointer-events: none;
@@ -277,8 +268,10 @@ a[data-linktype="create"]::after {
   position: absolute;
   inset-block-start: 0;
   inset-inline-start: 100%;
-  text-overflow: ellipsis;
   white-space: nowrap;
+}
+.cke_widget_wrapper:hover &gt; .cke_widget_drag_handler_container &gt; .macro-name {
+  display: block;
 }
 
 /* Inline widgets (macros) have display:inline-block and thus don't inherit the text-decoration styles. We fix this by

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
@@ -265,7 +265,7 @@ a[data-linktype="create"]::after {
     to be black to stay readable through it. */
   background-color: #dcdcdc;
   color: #000;
-  display: none;
+  display: block;
   font-family: monospace;
   /* Fit the text in the 15px band of the move handle, whose size CKEditor hard-codes as well. */
   font-size: 12px;
@@ -275,10 +275,18 @@ a[data-linktype="create"]::after {
   padding: 0 .3em;
   /* Let the move handle stretched above the macro name receive the mouse events. */
   pointer-events: none;
+  /* CKEditor delays the collapsing of the move handle container by 0.2s, so hide the macro name with the same delay
+    and let the two disappear together. Hovering the macro drops the delay, so both appear at once. The duration is
+    left to its default of zero rather than written down, the stylesheet minifier turning an explicit 0s into a
+    unitless 0 that invalidates the whole declaration. */
+  transition-delay: .2s;
+  transition-property: visibility;
+  visibility: hidden;
   white-space: nowrap;
 }
 .cke_widget_wrapper:hover &gt; .cke_widget_drag_handler_container &gt; .macro-name {
-  display: block;
+  transition: none;
+  visibility: visible;
 }
 .cke_widget_xwiki-macro:hover &gt; .cke_widget_drag_handler_container &gt; img.cke_widget_drag_handler {
   /* Stretch the move handle over the macro name, so that the macro can be dragged from the whole band. CKEditor

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
@@ -253,6 +253,12 @@ a[data-linktype="create"]::after {
 /* Display the macro name next to the move handle, in order to be able to identify the macros that are nested or that
   don't have a visible output. The move handle is hidden by collapsing its container, which doesn't hide the
   overflowing macro name, so the macro name is displayed only while the macro is hovered. */
+.cke_widget_xwiki-macro &gt; .cke_widget_drag_handler_container {
+  /* CKEditor paints the move handle as a background image and sizes the container after it, so the image must not be
+    tiled over the macro name and the container has to grow with it. */
+  background-repeat: no-repeat;
+  width: auto;
+}
 .cke_widget_drag_handler_container &gt; .macro-name {
   /* Match the grey CKEditor hard-codes for the move handle, rather than a color theme value that would drift away
     from it. The handle container is painted with an opacity of 0.75, applied after the text is drawn, so the text has
@@ -264,17 +270,23 @@ a[data-linktype="create"]::after {
   /* Fit the text in the 15px band of the move handle, whose size CKEditor hard-codes as well. */
   font-size: 12px;
   line-height: 15px;
+  /* Leave the move handle visible on the left of the macro name. */
+  margin-inline-start: 15px;
   padding: 0 .3em;
-  /* Don't steal the mouse events from the content displayed above the macro. */
+  /* Let the move handle stretched above the macro name receive the mouse events. */
   pointer-events: none;
-  /* Place the macro name right after the move handle, whose container is absolutely positioned. */
-  position: absolute;
-  inset-block-start: 0;
-  inset-inline-start: 100%;
   white-space: nowrap;
 }
 .cke_widget_wrapper:hover &gt; .cke_widget_drag_handler_container &gt; .macro-name {
   display: block;
+}
+.cke_widget_xwiki-macro:hover &gt; .cke_widget_drag_handler_container &gt; img.cke_widget_drag_handler {
+  /* Stretch the move handle over the macro name, so that the macro can be dragged from the whole band. CKEditor
+    listens for the drag on this image only. */
+  height: 100%;
+  inset: 0;
+  position: absolute;
+  width: 100%;
 }
 
 /* Inline widgets (macros) have display:inline-block and thus don't inherit the text-decoration styles. We fix this by

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
@@ -254,9 +254,13 @@ a[data-linktype="create"]::after {
   don't have a visible output. The move handle is hidden by collapsing its container, which doesn't hide the
   overflowing macro name, so the macro name is displayed only while the macro is hovered. */
 .cke_widget_xwiki-macro &gt; .cke_widget_drag_handler_container {
-  /* CKEditor paints the move handle as a background image and sizes the container after it, so the image must not be
-    tiled over the macro name and the container has to grow with it. */
-  background-repeat: no-repeat;
+  /* CKEditor paints the move handle as a background image and sizes the container after it, so the container has to
+    grow with the macro name. The image comes from a background shorthand set in a style attribute, which resets the
+    repetition and wins over a plain declaration, hence the important one needed to keep the handle from being tiled
+    over the whole width. */
+  background-repeat: no-repeat !important;
+  /* Keep the room of the move handle even when the macro name is missing. */
+  min-width: 15px;
   width: auto;
 }
 .cke_widget_drag_handler_container &gt; .macro-name {
@@ -288,9 +292,10 @@ a[data-linktype="create"]::after {
   transition: none;
   visibility: visible;
 }
-.cke_widget_xwiki-macro:hover &gt; .cke_widget_drag_handler_container &gt; img.cke_widget_drag_handler {
+.cke_widget_xwiki-macro &gt; .cke_widget_drag_handler_container &gt; img.cke_widget_drag_handler {
   /* Stretch the move handle over the macro name, so that the macro can be dragged from the whole band. CKEditor
-    listens for the drag on this image only. */
+    listens for the drag on this image only. The stretch applies whether the macro is hovered or not, so that the
+    macro name keeps its place in the band while it is being hidden. */
   height: 100%;
   inset: 0;
   position: absolute;


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22383

# Changes

## Description

* The macro widget appends a `span.macro-name` to CKEditor's drag handler container and keeps its text up to date, in its `data:` handler.
* `CKEditor.ContentSheet` styles that span as a grey chip right after the move handle, appearing and disappearing with it on hover.

## Clarifications

* The span lives in the drag handler container, which belongs to the widget wrapper. The wrapper is never downcast, so the name reaches neither `getData()` nor the saved content.
* The span is `aria-hidden`, because a screen reader already announces the macro: CKEditor's widget plugin labels every wrapper as a region named after the widget path name, which this widget sets to `macro:<name>`. Exposing the span would announce the same name twice.
* The chip has to be hidden explicitly: CKEditor hides the handle by collapsing its container to `height: 0`, without `overflow: hidden`, so anything in it would stay visible through the collapse.
* The text `color` is black rather than a softer grey (like we'd expect because of how it looks) because the container is painted at `opacity: 0.75`, which is applied after the text is drawn.
* `pointer-events: none`, because the chip overhangs whatever is rendered above the macro.
* Nested macros each show their own name, since hovering the inner one hovers the outer wrapper too.
* The chip shows the macro id, so no new translation key.

# Screenshots & Video

<img width="2120" height="1337" alt="comparison-trimmed" src="https://github.com/user-attachments/assets/317ff1d1-f341-465a-8f7b-c17f7cbf57c8" />

# Executed Tests

* `mvn clean install -Plegacy,integration-tests,docker -DskipTests` on `xwiki-platform-ckeditor-plugins`, `xwiki-platform-ckeditor-ui` and `xwiki-platform-ckeditor-test-pageobjects` -- BUILD SUCCESS, 0 Checkstyle violations.
* `mvn verify -Pdocker,integration-tests -pl <ckeditor-test-docker> -Dit.test=MacroIT -Dxwiki.test.ui.servletEngine=tomcat -Dxwiki.test.ui.database=postgresql` -- `4/4` tests pass. The assertions ride on the existing `macroPlaceholder` fixture rather than on a new test, so no page edit was added to the run: no name is displayed before hovering, and hovering the macro displays `id` next to its move handle.
* Ran `xwiki-review` over the branch, across its eleven angles. Three findings came out of it and one survived verification: the chip's `color: #333` on `#dcdcdc` composited at the move handle's own `opacity: 0.75` sat at about 4.5:1, right on the WCAG 2.2 AA floor. Darkened to `#000`, which composites to about 8:1. The two dropped findings were the chip showing `info` where the widget path name says `macro:info`, and the reporter's optional transparency suggestion, which that same 0.75 opacity already provides. Since the review the chip became a `span` instead of a pseudo element, which changes no rule any angle checked.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: none -- this is an improvement, better left on master.



