### PR TITLE
XWIKI-24785: PrefilteringLiveNotificationEmailDispatcherTest#addEvent is still flickering

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/email/live/PrefilteringLiveNotificationEmailDispatcherTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/email/live/PrefilteringLiveNotificationEmailDispatcherTest.java
@@ -19,19 +19,22 @@
  */
 package org.xwiki.notifications.notifiers.internal.email.live;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Named;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.xwiki.component.manager.ComponentLifecycleException;
 import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.component.manager.ComponentManager;
-import org.xwiki.component.phase.InitializationException;
+import org.xwiki.context.Execution;
 import org.xwiki.context.ExecutionContextManager;
 import org.xwiki.eventstream.Event;
 import org.xwiki.eventstream.internal.DefaultEvent;
@@ -42,14 +45,15 @@ import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
  * Validate {@link PrefilteringLiveNotificationEmailDispatcher}.
- * 
+ *
  * @version $Id$
  */
 @ComponentTest
@@ -68,20 +72,35 @@ class PrefilteringLiveNotificationEmailDispatcherTest
     @Named("context")
     private ComponentManager componentManager;
 
+    private final List<Runnable> scheduledTasks = new ArrayList<>();
+
     @BeforeComponent
     void beforeComponent() throws ComponentLookupException
     {
         ExecutionContextManager executionContextManager = mock(ExecutionContextManager.class);
         when(this.componentManager.getInstance(ExecutionContextManager.class)).thenReturn(executionContextManager);
+        // The dispatch tasks are run by the test thread, so the execution context they set up and tear down must be
+        // available there too.
+        Execution execution = mock(Execution.class);
+        when(this.componentManager.getInstance(Execution.class)).thenReturn(execution);
+    }
+
+    @BeforeEach
+    void beforeEach() throws IllegalAccessException
+    {
+        // Replace the asynchronous scheduler with one which only records the dispatch tasks, so that the test decides
+        // when they run instead of racing them.
+        ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+        when(scheduler.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class))).thenAnswer(invocation -> {
+            this.scheduledTasks.add(invocation.getArgument(0));
+            return null;
+        });
+        FieldUtils.writeField(this.dispatcher, "processingService", scheduler, true);
     }
 
     @Test
     void addEvent()
-        throws IllegalAccessException, ComponentLifecycleException, InitializationException
     {
-        // Force a very short grace period so that the test does not take 1 minute
-        FieldUtils.writeField(this.dispatcher, "grace", 100, true);
-
         // One event
 
         DocumentReference userReference = new DocumentReference("wiki", "XWiki", "user");
@@ -125,26 +144,22 @@ class PrefilteringLiveNotificationEmailDispatcherTest
         this.dispatcher.addEvent(similarevent, userReference);
         this.dispatcher.addEvent(otherevent, userReference);
 
-        // Wait until the sendMails() method is called with the right parameters or until it times out.
-        // We need the wait because there's the grace period and processing the event can also take some time.
         events = new HashMap<>();
         events.put(userReference, List.of(event, similarevent, otherevent));
         verifySendMailsCalled(events);
     }
 
-    private void resetDispatcher() throws ComponentLifecycleException, InitializationException, IllegalAccessException
+    private void verifySendMailsCalled(Map<DocumentReference, List<Event>> events)
     {
-        this.dispatcher.dispose();
-        this.dispatcher.initialize();
-        FieldUtils.writeField(this.dispatcher, "grace", 100, true);
+        runScheduledTasks();
+
+        verify(this.sender).sendMails(events);
     }
 
-    private void verifySendMailsCalled(Map<DocumentReference, List<Event>> events)
-        throws ComponentLifecycleException, InitializationException, IllegalAccessException
+    private void runScheduledTasks()
     {
-        // Wait until the sendMails() method is called with the right parameters or until it times out.
-        // We need the wait because there's the grace period and processing the event can also take some time.
-        verify(this.sender, timeout(5000).times(1)).sendMails(events);
-        resetDispatcher();
+        List<Runnable> tasks = new ArrayList<>(this.scheduledTasks);
+        this.scheduledTasks.clear();
+        tasks.forEach(Runnable::run);
     }
 }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24785

# Changes

## Description

* Replace the dispatcher's `ScheduledExecutorService` with a mock which only records the dispatch tasks, and run them from the test once all the events of a step have been added, so that the test drives the dispatch instead of racing it.
* Remove the `timeout(5000)` waits and the `resetDispatcher()` workaround they needed, the test being deterministic now.
* Mock the `Execution` component too, since the dispatch tasks now set up and tear down their execution context in the test thread.

## Clarifications

`PrefilteringLiveNotificationEmailDispatcher.addEvent()` schedules the dispatch with a delay expressed in **seconds**:

```java
Instant instant = event.getDate().toInstant().plusMillis(this.grace);
Duration duration = Duration.between(Instant.now(), instant);
this.processingService.schedule(new ExecutionContextRunnable(this::dispatch, this.componentManager),
    duration.getSeconds(), TimeUnit.SECONDS);
```

The test forced `grace = 100` (ms) so that it would not take a minute, which means `duration.getSeconds()` truncated to **0** and the dispatch task was runnable immediately. The test then relied on the test thread reaching the next `addEvent()` call before the scheduler thread picked up that already-runnable task — an unsynchronised race with no margin at all (the whole test ran in under 0.5s locally, despite nominally waiting 100ms three times).

When the scheduler won the race, the queue entry for the first event had already been consumed by `dispatch()`, the following event could no longer be merged into it, and separate `sendMails()` calls were produced instead of the single grouped call the test expects. That is the CI failure of [build 8909](https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/8909/):

```
Argument(s) are different! Wanted:
sender.sendMails({wiki:XWiki.user = [... id id], wiki:XWiki.user2 = [... id id]});
Actual invocations have different arguments:
sender.sendMails({wiki:XWiki.user = [... id id]});
sender.sendMails({wiki:XWiki.user2 = [... id id]});
```

Over the last ~6 months of master builds the test recorded 877 passes, 5 failures and 1 flaky run (~0.7% failure rate), all of them after XWIKI-18982 was closed — that fix reduced but did not remove the race. Driving the scheduler from the test removes it entirely rather than widening the window.

This is a test-only change; no production code is touched. The three assertions are unchanged (one event / one event with two users / three events grouped), and the change costs no coverage: `PrefilteringLiveNotificationEmailDispatcher` stays at 182/182 covered instructions (100%), every method included, before and after.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

* Full module build with the quality profile, green (42 tests, 0 Checkstyle violations, JaCoCo check passing):

  ```
  mvn -B -ntp clean install -Pquality
  ```

* SonarCloud PR analysis: quality gate **OK**, 0 open issues.
* JaCoCo, comparing the old and the new test on the same module: `PrefilteringLiveNotificationEmailDispatcher` covered 182 instructions and missed 0 in both cases.
* Flicker reproduction and validation. With the machine loaded (3x the core count in busy loops), the test converted to a `@RepeatedTest`:
  * **before this change**: 10 failures out of 300, with exactly the CI message above;
  * **after this change**: 400/400 passes, 8.4s total.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * `stable-18.7.x`, `stable-18.4.x`, `stable-17.10.x`, `stable-16.10.x` — the test flickers on all of them and `PrefilteringLiveNotificationEmailDispatcher` is identical there, so the fix is valid as-is. The cherry-pick is clean on `stable-18.7.x`; the others carry small cosmetic differences in the test file (`public class` instead of package-private, and `//////` separators) and `stable-16.10.x` additionally predates XWIKI-18982, so those may need a manual touch-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
