### PR TITLE
[stable-17.10.x] XWIKI-24785: PrefilteringLiveNotificationEmailDispatcherTest#addEvent is still flickering

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/email/live/PrefilteringLiveNotificationEmailDispatcherTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/email/live/PrefilteringLiveNotificationEmailDispatcherTest.java
@@ -19,19 +19,22 @@
  */
 package org.xwiki.notifications.notifiers.internal.email.live;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Named;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.xwiki.component.manager.ComponentLifecycleException;
 import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.component.manager.ComponentManager;
-import org.xwiki.component.phase.InitializationException;
+import org.xwiki.context.Execution;
 import org.xwiki.context.ExecutionContextManager;
 import org.xwiki.eventstream.Event;
 import org.xwiki.eventstream.internal.DefaultEvent;
@@ -42,14 +45,15 @@ import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
  * Validate {@link PrefilteringLiveNotificationEmailDispatcher}.
- * 
+ *
  * @version $Id$
  */
 @ComponentTest
@@ -68,20 +72,35 @@ public class PrefilteringLiveNotificationEmailDispatcherTest
     @Named("context")
     private ComponentManager componentManager;
 
+    private final List<Runnable> scheduledTasks = new ArrayList<>();
+
     @BeforeComponent
     void beforeComponent() throws ComponentLookupException
     {
         ExecutionContextManager executionContextManager = mock(ExecutionContextManager.class);
         when(this.componentManager.getInstance(ExecutionContextManager.class)).thenReturn(executionContextManager);
+        // The dispatch tasks are run by the test thread, so the execution context they set up and tear down must be
+        // available there too.
+        Execution execution = mock(Execution.class);
+        when(this.componentManager.getInstance(Execution.class)).thenReturn(execution);
+    }
+
+    @BeforeEach
+    void beforeEach() throws IllegalAccessException
+    {
+        // Replace the asynchronous scheduler with one which only records the dispatch tasks, so that the test decides
+        // when they run instead of racing them.
+        ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+        when(scheduler.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class))).thenAnswer(invocation -> {
+            this.scheduledTasks.add(invocation.getArgument(0));
+            return null;
+        });
+        FieldUtils.writeField(this.dispatcher, "processingService", scheduler, true);
     }
 
     @Test
     void addEvent()
-        throws IllegalAccessException, ComponentLifecycleException, InitializationException
     {
-        // Force a very short grace period so that the test does not take 1 minute
-        FieldUtils.writeField(this.dispatcher, "grace", 100, true);
-
         //////
         // One event
 
@@ -128,26 +147,22 @@ public class PrefilteringLiveNotificationEmailDispatcherTest
         this.dispatcher.addEvent(similarevent, userReference);
         this.dispatcher.addEvent(otherevent, userReference);
 
-        // Wait until the sendMails() method is called with the right parameters or until it times out.
-        // We need the wait because there's the grace period and processing the event can also take some time.
         events = new HashMap<>();
         events.put(userReference, List.of(event, similarevent, otherevent));
         verifySendMailsCalled(events);
     }
 
-    private void resetDispatcher() throws ComponentLifecycleException, InitializationException, IllegalAccessException
+    private void verifySendMailsCalled(Map<DocumentReference, List<Event>> events)
     {
-        this.dispatcher.dispose();
-        this.dispatcher.initialize();
-        FieldUtils.writeField(this.dispatcher, "grace", 100, true);
+        runScheduledTasks();
+
+        verify(this.sender).sendMails(events);
     }
 
-    private void verifySendMailsCalled(Map<DocumentReference, List<Event>> events)
-        throws ComponentLifecycleException, InitializationException, IllegalAccessException
+    private void runScheduledTasks()
     {
-        // Wait until the sendMails() method is called with the right parameters or until it times out.
-        // We need the wait because there's the grace period and processing the event can also take some time.
-        verify(this.sender, timeout(5000).times(1)).sendMails(events);
-        resetDispatcher();
+        List<Runnable> tasks = new ArrayList<>(this.scheduledTasks);
+        this.scheduledTasks.clear();
+        tasks.forEach(Runnable::run);
     }
 }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24785

# Changes

## Description

Manual backport of e0a47eca4d5e5eafc4c643c903c65385dd4245c2 (#6290) — the automatic backport action could not cherry-pick it (`merge-conflict-exception` on the test file).

* Replace the dispatcher's `ScheduledExecutorService` with a mock which only records the dispatch tasks, and run them from the test once all the events of a step have been added, so that the test drives the dispatch instead of racing it.
* Remove the `timeout(5000)` waits and the `resetDispatcher()` workaround they needed, the test being deterministic now.
* Mock the `Execution` component too, since the dispatch tasks now set up and tear down their execution context in the test thread.

## Clarifications

`PrefilteringLiveNotificationEmailDispatcher.addEvent()` schedules the dispatch with a delay expressed in **seconds**, while the test forced `grace = 100` (ms) to keep itself fast — so `duration.getSeconds()` truncated to **0** and the dispatch task was runnable immediately. The test then relied on the test thread reaching the next `addEvent()` call before the scheduler thread picked up that already-runnable task. When the scheduler won, the queue entry for the first event had already been consumed and separate `sendMails()` calls were produced instead of the single grouped call. Full analysis in #6290.

**Why it conflicted, and how it was resolved:** this branch does not carry the `[Misc]` S5786 package-private cleanup and still has the `//////` step separators in the test. The resolution takes master's version of the file as the semantic source of truth and re-applies those two branch-local cosmetic conventions, so the diff reproduces the original commit's `--stat` exactly (35 insertions, 20 deletions). No other adaptation was needed: no new module or pom, no `@since`, and no Java-level-sensitive API in the change.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

* Module build with the quality profile on this branch, using this branch's JDK:

  ```
  mvn -B -ntp clean install -Pquality,legacy
  ```

* On master, under CPU load (3x the core count in busy loops) and converted to a `@RepeatedTest`, the test failed **10 times out of 300** before the change and passes **400/400** after it.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None — this *is* the backport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
