### PR TITLE
XWIKI-24485: The Icon theme REST API doesn't indicate the skin extensions required by the returned icons

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -209,6 +209,27 @@
                 </item>
               </differences>
             </revapi.differences>
+            <revapi.differences>
+              <justification>
+                No real breakage: the API return type changed, but it's the REST API and the actual return type
+                didn't change, we only encapsulate it in a Response to also allow setting a header.
+              </justification>
+              <criticality>allowed</criticality>
+              <differences>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.returnTypeChanged</code>
+                  <old>method org.xwiki.icon.rest.model.jaxb.Icons org.xwiki.icon.rest.IconThemesResource::getIcons(java.lang.String, java.util.List&lt;java.lang.String&gt;)</old>
+                  <new>method javax.ws.rs.core.Response org.xwiki.icon.rest.IconThemesResource::getIcons(java.lang.String, java.util.List&lt;java.lang.String&gt;)</new>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.returnTypeChanged</code>
+                  <old>method org.xwiki.icon.rest.model.jaxb.Icons org.xwiki.icon.rest.IconThemesResource::getIconsByTheme(java.lang.String, java.lang.String, java.util.List&lt;java.lang.String&gt;)</old>
+                  <new>method javax.ws.rs.core.Response org.xwiki.icon.rest.IconThemesResource::getIconsByTheme(java.lang.String, java.lang.String, java.util.List&lt;java.lang.String&gt;)</new>
+                </item>
+              </differences>
+            </revapi.differences>
           </analysisConfiguration>
         </configuration>
       </plugin>

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-rest/xwiki-platform-icon-rest-api/src/main/java/org/xwiki/icon/rest/IconThemesResource.java
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-rest/xwiki-platform-icon-rest-api/src/main/java/org/xwiki/icon/rest/IconThemesResource.java
@@ -25,8 +25,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
-
-import org.xwiki.icon.rest.model.jaxb.Icons;
+import javax.ws.rs.core.Response;
 
 /**
  * Exposes the wiki icon themes and their icons through REST.
@@ -47,7 +46,7 @@ public interface IconThemesResource
      */
     @GET
     @Path("/{iconTheme}/icons")
-    Icons getIconsByTheme(@PathParam("wikiName") String wikiName, @PathParam("iconTheme") String iconTheme,
+    Response getIconsByTheme(@PathParam("wikiName") String wikiName, @PathParam("iconTheme") String iconTheme,
         @QueryParam("name") List<String> names);
 
     /**
@@ -59,5 +58,5 @@ public interface IconThemesResource
      */
     @GET
     @Path("/icons")
-    Icons getIcons(@PathParam("wikiName") String wikiName, @QueryParam("name") List<String> names);
+    Response getIcons(@PathParam("wikiName") String wikiName, @QueryParam("name") List<String> names);
 }

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-rest/xwiki-platform-icon-rest-default/src/main/java/org/xwiki/icon/internal/DefaultIconThemesResource.java
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-rest/xwiki-platform-icon-rest-default/src/main/java/org/xwiki/icon/internal/DefaultIconThemesResource.java
@@ -32,6 +32,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.icon.IconException;
 import org.xwiki.icon.IconManager;
+import org.xwiki.icon.IconRenderer;
 import org.xwiki.icon.IconSet;
 import org.xwiki.icon.IconSetManager;
 import org.xwiki.icon.rest.IconThemesResource;
@@ -42,6 +43,7 @@ import org.xwiki.model.ModelContext;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.WikiReference;
 import org.xwiki.rest.XWikiRestComponent;
+import org.xwiki.skinx.RequiredSkinExtensionsRecorder;
 import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 import org.xwiki.wiki.manager.WikiManagerException;
 
@@ -72,19 +74,25 @@ public class DefaultIconThemesResource implements IconThemesResource, XWikiRestC
     @Inject
     private WikiDescriptorManager wikiDescriptorManager;
 
+    @Inject
+    private RequiredSkinExtensionsRecorder skinExtensionsRecorder;
+
+    @Inject
+    private IconRenderer iconRenderer;
+
     @Override
-    public Icons getIconsByTheme(String wikiId, String iconTheme, List<String> names)
+    public Response getIconsByTheme(String wikiId, String iconTheme, List<String> names)
     {
         return iconsByTheme(wikiId, iconTheme, names);
     }
 
     @Override
-    public Icons getIcons(String wikiName, List<String> names)
+    public Response getIcons(String wikiName, List<String> names)
     {
         return iconsByTheme(wikiName, null, names);
     }
 
-    private Icons iconsByTheme(String wikiId, String iconTheme, List<String> iconNames)
+    private Response iconsByTheme(String wikiId, String iconTheme, List<String> iconNames)
     {
         wikiExists(wikiId);
 
@@ -93,11 +101,12 @@ public class DefaultIconThemesResource implements IconThemesResource, XWikiRestC
         try {
             // Set the requested wiki.
             this.modelContext.setCurrentEntityReference(new WikiReference(wikiId));
-
+            this.skinExtensionsRecorder.start();
             IconSet iconSet = getIconSet(iconTheme);
             if (iconSet == null) {
                 throw new WebApplicationException(Response.Status.NOT_FOUND);
             }
+            this.iconRenderer.use(iconSet);
             String iconSetName = iconSet.getName();
             ObjectFactory objectFactory = new ObjectFactory();
             Icons icons = objectFactory.createIcons();
@@ -111,8 +120,10 @@ public class DefaultIconThemesResource implements IconThemesResource, XWikiRestC
                     icons.getMissingIcons().add(iconName);
                 }
             }
-
-            return icons;
+            String skinExtensions = this.skinExtensionsRecorder.stop();
+            return Response.ok(icons)
+                .header(RequiredSkinExtensionsRecorder.XWIKI_SKIN_EXTENSIONS_DEFAULT_HEADER, skinExtensions)
+                .build();
         } catch (IconException e) {
             throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
         } finally {

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-rest/xwiki-platform-icon-rest-default/src/test/java/org/xwiki/icon/internal/DefaultIconThemesResourceTest.java
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-rest/xwiki-platform-icon-rest-default/src/test/java/org/xwiki/icon/internal/DefaultIconThemesResourceTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.xwiki.icon.IconException;
 import org.xwiki.icon.IconManager;
+import org.xwiki.icon.IconRenderer;
 import org.xwiki.icon.IconSet;
 import org.xwiki.icon.IconSetManager;
 import org.xwiki.icon.rest.model.jaxb.Icon;
@@ -40,6 +42,7 @@ import org.xwiki.icon.rest.model.jaxb.ObjectFactory;
 import org.xwiki.model.ModelContext;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.WikiReference;
+import org.xwiki.skinx.RequiredSkinExtensionsRecorder;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
@@ -85,6 +88,12 @@ class DefaultIconThemesResourceTest
     @MockComponent
     private WikiDescriptorManager wikiDescriptorManager;
 
+    @MockComponent
+    private RequiredSkinExtensionsRecorder skinExtensionsRecorder;
+
+    @MockComponent
+    private IconRenderer iconRenderer;
+
     @BeforeEach
     void setUp() throws Exception
     {
@@ -108,25 +117,30 @@ class DefaultIconThemesResourceTest
     @Test
     void getIconsByThemeNoNames() throws Exception
     {
-        when(this.iconSetManager.getIconSet("testTheme")).thenReturn(new IconSet("testTheme"));
+        IconSet iconSet = new IconSet("testTheme");
+        when(this.iconSetManager.getIconSet("testTheme")).thenReturn(iconSet);
 
-        Icons response = this.iconThemesResource.getIconsByTheme("wikiTest", "testTheme", singletonList(null));
+        Response response = this.iconThemesResource.getIconsByTheme("wikiTest", "testTheme", singletonList(null));
 
         Icons expected = new ObjectFactory().createIcons();
-        assertEquals(marshal(expected), marshal(response));
+        assertEquals(marshal(expected), marshal(response.getEntity()));
         verify(this.modelContext).setCurrentEntityReference(new WikiReference("wikiTest"));
         verify(this.modelContext).setCurrentEntityReference(CURRENT_ENTITY);
+        verify(this.iconRenderer).use(iconSet);
     }
 
     @Test
     void getIconCurrentTheme() throws Exception
     {
-        when(this.iconSetManager.getDefaultIconSet()).thenReturn(new IconSet("testTheme"));
+        IconSet iconSet = new IconSet("testTheme");
+        when(this.iconSetManager.getDefaultIconSet()).thenReturn(iconSet);
         when(this.iconManager.hasIcon("testTheme", "plus")).thenReturn(true);
         Map<String, Object> metadata = new HashMap<>();
         metadata.put(META_DATA_ICON_SET_TYPE, "icon");
         when(this.iconManager.getMetaData("plus", "testTheme")).thenReturn(metadata);
-        Icons response = this.iconThemesResource.getIcons("wikiTest", singletonList("plus"));
+        String skinExtensions = "my skin extensions";
+        when(this.skinExtensionsRecorder.stop()).thenReturn(skinExtensions);
+        Response response = this.iconThemesResource.getIcons("wikiTest", singletonList("plus"));
 
         ObjectFactory objectFactory = new ObjectFactory();
         Icons expected = objectFactory.createIcons();
@@ -135,9 +149,13 @@ class DefaultIconThemesResourceTest
         icon.setIconSetType("icon");
         icon.setIconSetName("testTheme");
         expected.getIcons().add(icon);
-        assertEquals(marshal(expected), marshal(response));
+        assertEquals(marshal(expected), marshal(response.getEntity()));
+        assertEquals(skinExtensions,
+            response.getHeaderString(RequiredSkinExtensionsRecorder.XWIKI_SKIN_EXTENSIONS_DEFAULT_HEADER));
         verify(this.modelContext).setCurrentEntityReference(new WikiReference("wikiTest"));
         verify(this.modelContext).setCurrentEntityReference(CURRENT_ENTITY);
+        verify(this.iconRenderer).use(iconSet);
+        verify(this.skinExtensionsRecorder).start();
     }
 
     @Test
@@ -154,13 +172,16 @@ class DefaultIconThemesResourceTest
         iconBMetaData.put("url", "http://test/url");
         iconBMetaData.put("cssClass", "");
 
-        when(this.iconSetManager.getIconSet("testTheme")).thenReturn(new IconSet("testTheme"));
+        IconSet iconSet = new IconSet("testTheme");
+        when(this.iconSetManager.getIconSet("testTheme")).thenReturn(iconSet);
         when(this.iconManager.hasIcon("testTheme","iconA")).thenReturn(true);
         when(this.iconManager.hasIcon("testTheme", "iconB")).thenReturn(true);
         when(this.iconManager.getMetaData("iconA", "testTheme")).thenReturn(iconAMetaData);
         when(this.iconManager.getMetaData("iconB", "testTheme")).thenReturn(iconBMetaData);
+        String skinExtensions = "my skin extensions";
+        when(this.skinExtensionsRecorder.stop()).thenReturn(skinExtensions);
 
-        Icons response = this.iconThemesResource
+        Response response = this.iconThemesResource
             .getIconsByTheme("wikiTest", "testTheme", asList("iconA", "unknownIcon", "iconB"));
 
         ObjectFactory objectFactory = new ObjectFactory();
@@ -178,9 +199,13 @@ class DefaultIconThemesResourceTest
         iconB.setUrl("http://test/url");
         expected.getIcons().add(iconB);
         expected.getMissingIcons().add("unknownIcon");
-        assertEquals(marshal(expected), marshal(response));
+        assertEquals(marshal(expected), marshal(response.getEntity()));
+        assertEquals(skinExtensions,
+            response.getHeaderString(RequiredSkinExtensionsRecorder.XWIKI_SKIN_EXTENSIONS_DEFAULT_HEADER));
         verify(this.modelContext).setCurrentEntityReference(new WikiReference("wikiTest"));
         verify(this.modelContext).setCurrentEntityReference(CURRENT_ENTITY);
+        verify(this.iconRenderer).use(iconSet);
+        verify(this.skinExtensionsRecorder).start();
     }
 
     @Test
@@ -197,13 +222,17 @@ class DefaultIconThemesResourceTest
         iconBMetaData.put("url", "http://test/url");
         iconBMetaData.put("cssClass", "");
 
-        when(this.iconSetManager.getCurrentIconSet()).thenReturn(new IconSet("testTheme"));
+        IconSet iconSet = new IconSet("testTheme");
+        when(this.iconSetManager.getCurrentIconSet()).thenReturn(iconSet);
         when(this.iconManager.hasIcon("testTheme", "iconA")).thenReturn(true);
         when(this.iconManager.hasIcon("testTheme", "iconB")).thenReturn(true);
         when(this.iconManager.getMetaData("iconA", "testTheme")).thenReturn(iconAMetaData);
         when(this.iconManager.getMetaData("iconB", "testTheme")).thenReturn(iconBMetaData);
 
-        Icons response = this.iconThemesResource.getIcons("wikiTest", asList("iconA", "unknownIcon", "iconB"));
+        String skinExtensions = "my skin extensions";
+        when(this.skinExtensionsRecorder.stop()).thenReturn(skinExtensions);
+
+        Response response = this.iconThemesResource.getIcons("wikiTest", asList("iconA", "unknownIcon", "iconB"));
 
         ObjectFactory objectFactory = new ObjectFactory();
         Icons expected = objectFactory.createIcons();
@@ -220,10 +249,14 @@ class DefaultIconThemesResourceTest
         iconB.setUrl("http://test/url");
         expected.getIcons().add(iconB);
         expected.getMissingIcons().add("unknownIcon");
-        assertEquals(marshal(expected), marshal(response));
+        assertEquals(marshal(expected), marshal(response.getEntity()));
+        assertEquals(skinExtensions,
+            response.getHeaderString(RequiredSkinExtensionsRecorder.XWIKI_SKIN_EXTENSIONS_DEFAULT_HEADER));
         verify(this.modelContext).setCurrentEntityReference(new WikiReference("wikiTest"));
         verify(this.modelContext).setCurrentEntityReference(CURRENT_ENTITY);
         verify(this.iconSetManager, never()).getDefaultIconSet();
+        verify(this.iconRenderer).use(iconSet);
+        verify(this.skinExtensionsRecorder).start();
     }
 
     @Test
@@ -266,7 +299,7 @@ class DefaultIconThemesResourceTest
         assertEquals(WikiManagerException.class, webApplicationException.getCause().getClass());
     }
 
-    private String marshal(Icons icons) throws JAXBException
+    private String marshal(Object icons) throws JAXBException
     {
         // We need to marshal because jaxb generated objects does not have equalily operations.
         JAXBContext jaxbContext = JAXBContext.newInstance(Icons.class);

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-api/src/main/java/org/xwiki/skinx/RequiredSkinExtensionsRecorder.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-api/src/main/java/org/xwiki/skinx/RequiredSkinExtensionsRecorder.java
@@ -33,6 +33,15 @@ import org.xwiki.stability.Unstable;
 public interface RequiredSkinExtensionsRecorder
 {
     /**
+     * Default header to be used to inject the skin extensions.
+     *
+     * @since 18.8.0RC1
+     * @since 18.4.5
+     */
+    @Unstable
+    String XWIKI_SKIN_EXTENSIONS_DEFAULT_HEADER = "X-XWIKI-HTML-HEAD";
+
+    /**
      * Start recording.
      */
     void start();


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

 * https://jira.xwiki.org/browse/XWIKI-24485

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

  * Expose the header name used for skin extensions in the RequiredSkinExtensionRecorder interface to ease its reuse
  * Use RequiredSkinExtensionRecorder in the icon REST API and inject the skin extensions in the header
  * Change the REST API to use a Response and provide the revapi ignores
  * Cover all that in tests

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

`mvn clean install -Pquality` executed in `xwiki-platform-icon-rest` and `xwiki-platform-icon-test-docker`.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 18.4.x