### PR TITLE
XWIKI-24783: xwiki-platform-user-api shouldn't depend on xwiki-platform-security-authentication-api

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -200,6 +200,26 @@
                 </item>
               </differences>
             </revapi.differences>
+            <revapi.differences>
+              <justification>
+                UserManager#hasAccess() is an unstable API. Checking any right on a user through the user API was too
+                broad, checking view access makes sense but others are out of scope.
+                It is now replaced by UserManager#hasViewAccess().
+              </justification>
+              <criticality>documented</criticality>
+              <differences>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method boolean org.xwiki.user.UserManager::hasAccess(org.xwiki.security.authorization.Right, org.xwiki.user.UserReference, org.xwiki.user.UserReference)</old>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.addedToInterface</code>
+                  <new>method boolean org.xwiki.user.UserManager::hasViewAccess(org.xwiki.user.UserReference, org.xwiki.user.UserReference)</new>
+                </item>
+              </differences>
+            </revapi.differences>
           </analysisConfiguration>
         </configuration>
       </plugin>

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/pom.xml
@@ -51,11 +51,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.xwiki.platform</groupId>
-      <artifactId>xwiki-platform-security-authorization-api</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.sun.mail</groupId>
       <artifactId>jakarta.mail</artifactId>
     </dependency>

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/main/java/org/xwiki/user/UserManager.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/main/java/org/xwiki/user/UserManager.java
@@ -21,7 +21,6 @@ package org.xwiki.user;
 
 import org.xwiki.component.annotation.Role;
 import org.xwiki.model.reference.WikiReference;
-import org.xwiki.security.authorization.Right;
 import org.xwiki.stability.Unstable;
 
 /**
@@ -58,14 +57,14 @@ public interface UserManager
     }
 
     /**
-     * Checks whether {@code user} has {@code right} access on the data of {@code target}.
+     * Checks whether {@code user} is allowed to read the data of {@code target}.
      *
-     * @param right the access right to check
      * @param user the user whose access right is being checked
      * @param target the user whose data is being accessed
-     * @return {@code true} if {@code user} has {@code right} access on {@code target}'s data, {@code false} otherwise
-     * @since 18.2.0RC1
+     * @return {@code true} if {@code user} can read {@code target}'s data, {@code false} otherwise
+     * @since 18.4.5
+     * @since 18.8.0RC1
      */
     @Unstable
-    boolean hasAccess(Right right, UserReference user, UserReference target);
+    boolean hasViewAccess(UserReference user, UserReference target);
 }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/DefaultUserManager.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/DefaultUserManager.java
@@ -27,7 +27,6 @@ import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.model.reference.WikiReference;
-import org.xwiki.security.authorization.Right;
 import org.xwiki.user.CurrentUserReference;
 import org.xwiki.user.GuestUserReference;
 import org.xwiki.user.SuperAdminUserReference;
@@ -95,7 +94,7 @@ public class DefaultUserManager implements UserManager
     }
 
     @Override
-    public boolean hasAccess(Right right, UserReference user, UserReference target)
+    public boolean hasViewAccess(UserReference user, UserReference target)
     {
         boolean hasAccess;
 
@@ -110,16 +109,16 @@ public class DefaultUserManager implements UserManager
         }
 
         if (target == GuestUserReference.INSTANCE || target == SuperAdminUserReference.INSTANCE) {
-            // The target is not an actual resource, its metadata can only be read.
-            hasAccess = right == Right.VIEW;
+            // The target is not an actual resource, its metadata is always readable.
+            hasAccess = true;
         } else if (normalizedUserReference == CurrentUserReference.INSTANCE
             || normalizedTargetReference == CurrentUserReference.INSTANCE)
         {
             hasAccess = resolveUserManager(CurrentUserReference.INSTANCE)
-                .hasAccess(right, normalizedUserReference, normalizedTargetReference);
+                .hasViewAccess(normalizedUserReference, normalizedTargetReference);
         } else {
             // We know that "target" is an actual user resource, so we use it to resolve the manager.
-            hasAccess = resolveUserManager(target).hasAccess(right, normalizedUserReference, target);
+            hasAccess = resolveUserManager(target).hasViewAccess(normalizedUserReference, target);
         }
         return hasAccess;
     }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/CurrentUserManager.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/CurrentUserManager.java
@@ -26,7 +26,6 @@ import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
-import org.xwiki.security.authorization.Right;
 import org.xwiki.user.CurrentUserReference;
 import org.xwiki.user.GuestUserReference;
 import org.xwiki.user.SuperAdminUserReference;
@@ -86,7 +85,7 @@ public class CurrentUserManager implements UserManager
     }
 
     @Override
-    public boolean hasAccess(Right right, UserReference user, UserReference target)
+    public boolean hasViewAccess(UserReference user, UserReference target)
     {
         boolean hasAccess;
 
@@ -107,10 +106,10 @@ public class CurrentUserManager implements UserManager
         if (resolvedTargetReference == GuestUserReference.INSTANCE
             || resolvedTargetReference == SuperAdminUserReference.INSTANCE)
         {
-            // The target is not an actual resource, its metadata can only be read.
-            hasAccess = right == Right.VIEW;
+            // The target is not an actual resource, its metadata is always readable.
+            hasAccess = true;
         } else {
-            hasAccess = this.documentUserManager.hasAccess(right, resolvedUserReference, resolvedTargetReference);
+            hasAccess = this.documentUserManager.hasViewAccess(resolvedUserReference, resolvedTargetReference);
         }
 
         return hasAccess;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/DocumentUserManager.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/DocumentUserManager.java
@@ -144,11 +144,11 @@ public class DocumentUserManager implements UserManager
     }
 
     @Override
-    public boolean hasAccess(Right right, UserReference user, UserReference target)
+    public boolean hasViewAccess(UserReference user, UserReference target)
     {
         DocumentReference userReference = this.documentUserReferenceSerializer.serialize(user);
         DocumentReference targetReference = this.documentUserReferenceSerializer.serialize(target);
 
-        return this.authorizationManager.hasAccess(right, userReference, targetReference);
+        return this.authorizationManager.hasAccess(Right.VIEW, userReference, targetReference);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/DefaultUserManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/DefaultUserManagerTest.java
@@ -25,7 +25,6 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.jupiter.api.Test;
 import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.component.manager.ComponentManager;
-import org.xwiki.security.authorization.Right;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
@@ -40,7 +39,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -131,30 +129,27 @@ class DefaultUserManagerTest
     }
 
     @Test
-    void hasAccess() throws Exception
+    void hasViewAccess() throws Exception
     {
         UserManager customUserManager = mock(UserManager.class);
-        when(customUserManager.hasAccess(eq(Right.VIEW), any(TestUserReference.class),
-            any(TestUserReference.class))).thenReturn(true);
+        when(customUserManager.hasViewAccess(any(TestUserReference.class), any(TestUserReference.class)))
+            .thenReturn(true);
 
         when(this.contextComponentManager.getInstance(UserManager.class, TestUserReference.class.getName()))
             .thenReturn(customUserManager);
 
-        assertTrue(this.userManager.hasAccess(Right.VIEW, new TestUserReference(), new TestUserReference()));
+        assertTrue(this.userManager.hasViewAccess(new TestUserReference(), new TestUserReference()));
     }
 
     @Test
-    void hasAccessWhenNonResourceTarget()
+    void hasViewAccessWhenNonResourceTarget()
     {
-        assertTrue(this.userManager.hasAccess(Right.VIEW, mock(UserReference.class), SuperAdminUserReference.INSTANCE));
-        assertTrue(this.userManager.hasAccess(Right.VIEW, mock(UserReference.class), GuestUserReference.INSTANCE));
-        assertFalse(this.userManager.hasAccess(Right.EDIT, mock(UserReference.class),
-            SuperAdminUserReference.INSTANCE));
-        assertFalse(this.userManager.hasAccess(Right.EDIT, mock(UserReference.class), GuestUserReference.INSTANCE));
+        assertTrue(this.userManager.hasViewAccess(mock(UserReference.class), SuperAdminUserReference.INSTANCE));
+        assertTrue(this.userManager.hasViewAccess(mock(UserReference.class), GuestUserReference.INSTANCE));
     }
 
     @Test
-    void hasAccessWhenNoUserManager() throws Exception
+    void hasViewAccessWhenNoUserManager() throws Exception
     {
         when(this.contextComponentManager.getInstance(UserManager.class, TestUserReference.class.getName()))
             .thenThrow(new ComponentLookupException("error"));
@@ -162,7 +157,7 @@ class DefaultUserManagerTest
         TestUserReference userReference1 = new TestUserReference();
         TestUserReference userReference2 = new TestUserReference();
         Throwable exception = assertThrows(RuntimeException.class,
-            () -> this.userManager.hasAccess(Right.VIEW, userReference1, userReference2));
+            () -> this.userManager.hasViewAccess(userReference1, userReference2));
         assertEquals("Failed to find user manager for role [org.xwiki.user.UserManager] and hint "
             + "[org.xwiki.user.internal.DefaultUserManagerTest$TestUserReference]", exception.getMessage());
         assertEquals("ComponentLookupException: error", ExceptionUtils.getRootCauseMessage(exception));

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/CurrentUserManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/CurrentUserManagerTest.java
@@ -24,7 +24,6 @@ import javax.inject.Provider;
 
 import org.junit.jupiter.api.Test;
 import org.xwiki.model.reference.DocumentReference;
-import org.xwiki.security.authorization.Right;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
@@ -120,7 +119,7 @@ class CurrentUserManagerTest
     }
 
     @Test
-    void hasAccessWhenCurrentUser()
+    void hasViewAccessWhenCurrentUser()
     {
         XWikiContext xcontext = mock(XWikiContext.class);
         DocumentReference documentReference = new DocumentReference("wiki", "XWiki", "User");
@@ -131,13 +130,13 @@ class CurrentUserManagerTest
         when(this.userReferenceResolver.resolve(documentReference)).thenReturn(documentUserReference);
 
         DocumentUserReference targetUserReference = mock(DocumentUserReference.class);
-        this.manager.hasAccess(Right.VIEW, CurrentUserReference.INSTANCE, targetUserReference);
+        this.manager.hasViewAccess(CurrentUserReference.INSTANCE, targetUserReference);
 
-        verify(this.documentUserManager).hasAccess(Right.VIEW, documentUserReference, targetUserReference);
+        verify(this.documentUserManager).hasViewAccess(documentUserReference, targetUserReference);
     }
 
     @Test
-    void hasAccessWhenNoCurrentUser()
+    void hasViewAccessWhenNoCurrentUser()
     {
         XWikiContext xcontext = mock(XWikiContext.class);
         when(xcontext.getUserReference()).thenReturn(null);
@@ -145,13 +144,13 @@ class CurrentUserManagerTest
         when(this.userReferenceResolver.resolve(null)).thenReturn(GuestUserReference.INSTANCE);
 
         DocumentUserReference targetUserReference = mock(DocumentUserReference.class);
-        this.manager.hasAccess(Right.VIEW, CurrentUserReference.INSTANCE, targetUserReference);
+        this.manager.hasViewAccess(CurrentUserReference.INSTANCE, targetUserReference);
 
-        verify(this.documentUserManager).hasAccess(Right.VIEW, GuestUserReference.INSTANCE, targetUserReference);
+        verify(this.documentUserManager).hasViewAccess(GuestUserReference.INSTANCE, targetUserReference);
     }
 
     @Test
-    void hasAccessWhenCurrentTarget()
+    void hasViewAccessWhenCurrentTarget()
     {
         XWikiContext xcontext = mock(XWikiContext.class);
         DocumentReference documentReference = new DocumentReference("wiki", "XWiki", "User");
@@ -162,13 +161,13 @@ class CurrentUserManagerTest
         when(this.userReferenceResolver.resolve(documentReference)).thenReturn(documentUserReference);
 
         DocumentUserReference userUserReference = mock(DocumentUserReference.class);
-        this.manager.hasAccess(Right.VIEW, userUserReference, CurrentUserReference.INSTANCE);
+        this.manager.hasViewAccess(userUserReference, CurrentUserReference.INSTANCE);
 
-        verify(this.documentUserManager).hasAccess(Right.VIEW, userUserReference, documentUserReference);
+        verify(this.documentUserManager).hasViewAccess(userUserReference, documentUserReference);
     }
 
     @Test
-    void hasAccessWhenNoCurrentTarget()
+    void hasViewAccessWhenNoCurrentTarget()
     {
         XWikiContext xcontext = mock(XWikiContext.class);
         when(xcontext.getUserReference()).thenReturn(null);
@@ -176,7 +175,6 @@ class CurrentUserManagerTest
         when(this.userReferenceResolver.resolve(null)).thenReturn(GuestUserReference.INSTANCE);
 
         DocumentUserReference userUserReference = mock(DocumentUserReference.class);
-        assertTrue(this.manager.hasAccess(Right.VIEW, userUserReference, CurrentUserReference.INSTANCE));
-        assertFalse(this.manager.hasAccess(Right.EDIT, userUserReference, CurrentUserReference.INSTANCE));
+        assertTrue(this.manager.hasViewAccess(userUserReference, CurrentUserReference.INSTANCE));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/DocumentUserManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/DocumentUserManagerTest.java
@@ -242,22 +242,21 @@ class DocumentUserManagerTest
     }
 
     @Test
-    void hasAccess()
+    void hasViewAccess()
     {
         when(this.documentUserReferenceSerializer.serialize(this.documentUserReferenceCaptor.capture()))
             .then((Answer<DocumentReference>)
                 invocationOnMock -> this.documentUserReferenceCaptor.getValue().getReference());
 
-        Right mockRight = mock(Right.class);
         DocumentReference userReference = new DocumentReference("xwiki", "XWiki", "user1");
         DocumentReference targetReference = new DocumentReference("xwiki", "XWiki", "user2");
 
-        when(this.authorizationManager.hasAccess(mockRight, userReference, targetReference)).thenReturn(false);
-        assertFalse(this.userManager.hasAccess(mockRight, new DocumentUserReference(userReference, true),
+        when(this.authorizationManager.hasAccess(Right.VIEW, userReference, targetReference)).thenReturn(false);
+        assertFalse(this.userManager.hasViewAccess(new DocumentUserReference(userReference, true),
             new DocumentUserReference(targetReference, true)));
 
-        when(this.authorizationManager.hasAccess(mockRight, userReference, targetReference)).thenReturn(true);
-        assertTrue(this.userManager.hasAccess(mockRight, new DocumentUserReference(userReference, true),
+        when(this.authorizationManager.hasAccess(Right.VIEW, userReference, targetReference)).thenReturn(true);
+        assertTrue(this.userManager.hasViewAccess(new DocumentUserReference(userReference, true),
             new DocumentUserReference(targetReference, true)));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-default/src/main/java/org/xwiki/user/rest/internal/resources/UserResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-rest/xwiki-platform-user-rest-default/src/main/java/org/xwiki/user/rest/internal/resources/UserResourceImpl.java
@@ -33,7 +33,6 @@ import org.xwiki.component.annotation.Component;
 import org.xwiki.localization.ContextualLocalizationManager;
 import org.xwiki.rest.XWikiResource;
 import org.xwiki.rest.XWikiRestException;
-import org.xwiki.security.authorization.Right;
 import org.xwiki.user.CurrentUserReference;
 import org.xwiki.user.UserManager;
 import org.xwiki.user.UserReference;
@@ -81,7 +80,7 @@ public class UserResourceImpl extends XWikiResource implements UserResource
             UserReference userReference = this.userReferenceResolver.resolve(userId,
                 this.getXWikiContext().getWikiReference());
 
-            if (!this.userManager.hasAccess(Right.VIEW, CurrentUserReference.INSTANCE, userReference)) {
+            if (!this.userManager.hasViewAccess(CurrentUserReference.INSTANCE, userReference)) {
                 throw new WebApplicationException(Response.Status.UNAUTHORIZED);
             }
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-24783

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
Backport for https://github.com/xwiki/xwiki-platform/pull/6284 targeting 18.4.x.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

N/A

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: N/A