### PR TITLE
XWIKI-15360: Usage of the "fieldset" and "legend" tags in generated control groups

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BooleanClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BooleanClass.java
@@ -323,9 +323,12 @@ public class BooleanClass extends PropertyClass
             radioNone.setChecked(true);
         }
 
+        StringBuilder groupContent = new StringBuilder();
         for (div input : inputs) {
-            buffer.append(input.toString());
+            groupContent.append(input.toString());
         }
+
+        buffer.append(displayControlGroup(groupContent.toString(), context));
     }
 
     public void displayCheckboxEdit(StringBuffer buffer, String name, String prefix, BaseCollection object,

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
@@ -852,6 +852,7 @@ public abstract class ListClass extends PropertyClass
         }
 
         // Add options from Set
+        StringBuilder groupContent = new StringBuilder();
         int count = 0;
         for (Object rawvalue : list) {
             String value = getElementValue(rawvalue);
@@ -868,11 +869,11 @@ public abstract class ListClass extends PropertyClass
             }
             radio.addElement(display);
 
-            buffer.append("<label class=\"xwiki-form-listclass\" for=\"xwiki-form-")
+            groupContent.append("<label class=\"xwiki-form-listclass\" for=\"xwiki-form-")
                 .append(XMLUtils.escape(name)).append('-').append(object.getNumber()).append('-')
                 .append(count++).append("\">");
-            buffer.append(radio.toString());
-            buffer.append("</label>");
+            groupContent.append(radio.toString());
+            groupContent.append("</label>");
         }
 
         // We need a hidden input with an empty value to be able to clear the selected values when no value is selected
@@ -880,7 +881,9 @@ public abstract class ListClass extends PropertyClass
         org.apache.ecs.xhtml.input hidden = new input(input.hidden, prefix + name, "");
         hidden.setAttributeFilter(new XMLAttributeValueFilter());
         hidden.setDisabled(isDisabled());
-        buffer.append(hidden);
+        groupContent.append(hidden);
+
+        buffer.append(displayControlGroup(groupContent.toString(), context));
     }
 
     protected class MapComparator implements Comparator<String>

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
@@ -25,6 +25,7 @@ import javax.script.ScriptContext;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
+import org.apache.ecs.xhtml.div;
 import org.apache.ecs.xhtml.input;
 import org.dom4j.Element;
 import org.dom4j.dom.DOMElement;
@@ -88,6 +89,8 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
     private static final String PARAGRAPH_START = "<p>";
 
     private static final String PARAGRAPH_END = "</p>";
+
+    private static final String ARIA_LABEL = "aria-label";
 
     private static final String NAME = "name";
     private static final String VALUE = "value";
@@ -299,6 +302,33 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
     }
 
     /**
+     * Wraps a set of related controls, such as the radio buttons or the checkboxes of a list property, in a group
+     * named after the property. Assistive technologies then announce what the controls have in common before announcing
+     * the controls themselves, instead of presenting a flat run of unrelated controls. This is the ARIA equivalent of a
+     * {@code fieldset} element labelled by a {@code legend} element. The ARIA form is used because a property is always
+     * displayed inside a caption structure provided by the surrounding sheet, so a {@code legend} would duplicate that
+     * caption and every sheet wrapping a property display would have to be adapted.
+     *
+     * @param content the markup of the controls to group, already escaped
+     * @param context the XWiki context
+     * @return the markup of the group wrapping the given content
+     * @since 18.8.0RC1
+     */
+    protected String displayControlGroup(String content, XWikiContext context)
+    {
+        div group = new div();
+        group.setAttributeFilter(new XMLAttributeValueFilter());
+        group.addAttribute("role", "group");
+        // The group is named after the property so that its name matches the caption the surrounding sheet displays,
+        // the way a legend repeats the heading of the controls it groups. No sheet labels the group itself, so this
+        // name is what Assistive Techs announce when entering the group.
+        group.addAttribute(ARIA_LABEL, getTranslatedPrettyName(context));
+        group.addElement(content);
+
+        return group.toString();
+    }
+
+    /**
      * Display a hidden input for the given property of the given object and returns it in a string.
      * @param name the name of the property to display
      * @param prefix the prefix to use for the name of the field
@@ -422,7 +452,7 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
             scontext.setAttribute("type", type, ScriptContext.ENGINE_SCOPE);
             // This is a text alternative fallback to explain what the input is about. 
             // If the input has already been labelled in another way, this fallback will be ignored by Assistive Techs.
-            scontext.setAttribute("aria-label",
+            scontext.setAttribute(ARIA_LABEL,
                 localizePlainOrKey("core.model.xclass.editClassProperty.textAlternative",
                     this.getTranslatedPrettyName(context)), ScriptContext.ENGINE_SCOPE);
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/BooleanClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/BooleanClassTest.java
@@ -34,6 +34,7 @@ import com.xpn.xwiki.test.junit5.mockito.InjectMockitoOldcore;
 import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 /**
@@ -153,5 +154,37 @@ class BooleanClassTest
         prop.setValue(2);
         metaProperty.displayView(out, "prop", "", obj, this.oldcore.getXWikiContext());
         assertEquals("Dunno", out.toString());
+    }
+
+    /**
+     * The radio buttons of a boolean property are related controls, so they must be exposed as a group named after the
+     * property.
+     */
+    @Test
+    void displayEditRadioWrapsTheControlsInAGroupNamedAfterTheProperty()
+    {
+        DocumentReference classReference =
+            new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "Some", "Class");
+        when(this.entityReferenceSerializer.serialize(classReference)).thenReturn("Some.Class");
+        when(this.contextualLocalizationManager.getTranslationPlain("Some.Class_prop")).thenReturn("Is active");
+
+        BooleanClass metaProperty = new BooleanClass();
+        metaProperty.setDisplayFormType(BooleanClass.DISPLAY_RADIO);
+        metaProperty.setName("prop");
+        BaseClass cls = new BaseClass();
+        cls.setDocumentReference(classReference);
+        metaProperty.setObject(cls);
+
+        BaseObject object = new BaseObject();
+        IntegerProperty property = new IntegerProperty();
+        property.setValue(1);
+        object.safeput("prop", property);
+
+        StringBuffer out = new StringBuffer();
+        metaProperty.displayEdit(out, "prop", "", object, this.oldcore.getXWikiContext());
+
+        assertTrue(out.toString().startsWith("<div role='group' aria-label='Is active'>"),
+            "The controls are not wrapped in a group named after the property: " + out);
+        assertTrue(out.toString().endsWith("</div>"), "The group is not closed: " + out);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/StaticListClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/StaticListClassTest.java
@@ -193,6 +193,7 @@ class StaticListClassTest
     void testDisplayEditRadio()
     {
         StringBuilder expectedHTML = new StringBuilder();
+        expectedHTML.append("<div role='group' aria-label='Static List'>");
         expectedHTML.append("<label class=\"xwiki-form-listclass\" for=\"xwiki-form-b&#38;a&#60;r-0-0\">");
         expectedHTML.append("<input id='xwiki-form-b&#38;a&#60;r-0-0' value='a&#60;b&#62;c'");
         expectedHTML.append(" name='w&#62;vb&#38;a&#60;r' type='radio'/>c&#62;b&#60;a</label>");
@@ -203,6 +204,7 @@ class StaticListClassTest
         expectedHTML.append("<input id='xwiki-form-b&#38;a&#60;r-0-2' value='x&#123;y&#38;z'");
         expectedHTML.append(" name='w&#62;vb&#38;a&#60;r' type='radio'/>z&#38;y&#123;x</label>");
         expectedHTML.append("<input name='w&#62;vb&#38;a&#60;r' type='hidden' value=''/>");
+        expectedHTML.append("</div>");
         testDisplayEdit("radio", Arrays.asList(VALUES_WITH_HTML_SPECIAL_CHARS.get(1)), expectedHTML.toString());
     }
 
@@ -213,6 +215,7 @@ class StaticListClassTest
     void testDisplayEditCheckbox()
     {
         StringBuilder expectedHTML = new StringBuilder();
+        expectedHTML.append("<div role='group' aria-label='Static List'>");
         expectedHTML.append("<label class=\"xwiki-form-listclass\" for=\"xwiki-form-b&#38;a&#60;r-0-0\">");
         expectedHTML.append("<input id='xwiki-form-b&#38;a&#60;r-0-0' value='a&#60;b&#62;c'");
         expectedHTML.append(" name='w&#62;vb&#38;a&#60;r' type='checkbox'/>c&#62;b&#60;a</label>");
@@ -223,6 +226,7 @@ class StaticListClassTest
         expectedHTML.append("<input id='xwiki-form-b&#38;a&#60;r-0-2' value='x&#123;y&#38;z'");
         expectedHTML.append(" name='w&#62;vb&#38;a&#60;r' type='checkbox'/>z&#38;y&#123;x</label>");
         expectedHTML.append("<input name='w&#62;vb&#38;a&#60;r' type='hidden' value=''/>");
+        expectedHTML.append("</div>");
         testDisplayEdit("checkbox", Arrays.asList(VALUES_WITH_HTML_SPECIAL_CHARS.get(1)), expectedHTML.toString());
     }
 


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-15360

# Changes

## Description

Radio and checkbox groups generated for an XClass property were emitted as a flat run of `<label><input></label>` pairs with nothing tying them together and no accessible name, so assistive technologies presented them as unrelated controls.

`PropertyClass` gains a `displayControlGroup` helper that wraps such a set of controls in a group named after the property:

```html
<div role="group" aria-label="Categories">
  <label class="xwiki-form-listclass" for="…">…</label>
  …
</div>
```

It is used by the two displayers that generate these groups:

* `ListClass.displayRadioEdit`, for static and database lists whose `displayType` is `radio` or `checkbox`
* `BooleanClass.displayRadioEdit`

## Clarifications

**Why `role="group"` and not `fieldset`/`legend`, which the issue title asks for.** A property display is always emitted inside a caption structure supplied by the surrounding sheet — `<dt><label>Categories</label></dt><dd>…</dd>` in the object editor, and the same shape in `AppWithinMinutes/ClassEditSheet.xml` and `XWiki/AdminFieldsDisplaySheet.xml`. A `<legend>` would duplicate that caption, and every sheet wrapping a property display would have to be adapted in step — the breakage this issue's 2023 comment warns about. `role="group"` plus an accessible name is the ARIA counterpart of `fieldset`+`legend` (WAI-ARIA `group`, technique ARIA17), needs no cooperation from the wrapper, and carries none of `fieldset`'s user-agent styling or its `min-width: min-content` behaviour in flex and grid containers. H71 is a technique rather than a normative requirement of SC 1.3.1 / 3.3.2.

`role="group"` is used for the single-select radio case too, rather than `role="radiogroup"`. Native radios sharing a `name` attribute already form a radio group in HTML, so position is announced either way, and `radiogroup` is a composite widget role with expectations about the elements it owns. `ListClass.displayRadioEdit` also emits checkboxes when `DISPLAYTYPE_CHECKBOX` or `isMultiSelect()` applies, where `group` is the correct role.

The group is named with `getTranslatedPrettyName(context)` so that the name matches the caption the sheet displays, the way a legend repeats the heading of the controls it groups. The `core.model.xclass.editClassProperty.textAlternative` string already used for the `input` and `select` display types was not reused here: it reads `Edit the property "{0}".`, which works as the name of a single control but not as the common name of a set of them.

**Deliberately left out of this PR:**

* `Rendering/RenderingConfigClass.xml` has a `customDisplay` for `disabledSyntaxes` that hand-writes the same checkbox run and so bypasses `displayRadioEdit` entirely. It has the same defect but is not a generated control group, and fixing it means editing a XAR page.
* For the radio and checkbox display types, no generated element carries the id that the sheets' `<label for="${class}_${number}_${property}">` points at, so that caption is an orphan label. The `aria-label` above names the group regardless. Fixing the label properly means having the sheets emit an id'd caption and referencing it with `aria-labelledby`, which is a sheet-side change.

Both deserve their own issues.

# Screenshots & Video

N/A -- there is no visible change

# Executed Tests

`mvn clean install -B -ntp -Plegacy,quality -fae -pl xwiki-platform-core/xwiki-platform-oldcore,xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore` -- BUILD SUCCESS for both modules, 0 Checkstyle violations across the `default`, `test` and `blocker` rulesets, and the JaCoCo ratio check passes. Run again after rebasing onto current master.

`mvn test -B -ntp -pl xwiki-platform-core/xwiki-platform-oldcore -Dtest='BooleanClassTest,StaticListClassTest,ListClassTest,LevelsClassTest,GroupsClassTest,UsersClassTest,DBListClassTest,DBTreeListClassTest,PropertyClassTest'` -- 89 tests, 0 failures.

Test changes: `BooleanClassTest.displayEditRadioWrapsTheControlsInAGroupNamedAfterTheProperty` is new and stubs the localization so the assertion pins the group's name to the property's translated pretty name rather than to a fallback. `StaticListClassTest.testDisplayEditRadio` and `testDisplayEditCheckbox` had their expected markup updated with the wrapper.

Note that `xwiki-platform-oldcore` sets `xwiki.revapi.skip=true`, so the green build says nothing about API compatibility. No public or protected signature changed; the only API surface added is one protected method.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
