### PR TITLE
[Misc] Fix three SonarQube javabugs:S2259 null dereferences in oldcore

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -1386,7 +1386,9 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
             getProgress().startStep(getDocumentReference(), "document.progress.render.translatedcontent",
                 "Get translated content");
 
-            XWikiContext xcontext = getXWikiContext();
+            // There's nothing to display without a context: the translated content, the rendering cache and
+            // the display itself below are all resolved through it.
+            XWikiContext xcontext = Objects.requireNonNull(getXWikiContext());
 
             XWikiDocument tdoc = translate ? getTranslatedDocument(xcontext) : this;
             String translatedContent = tdoc.getContent();
@@ -9004,6 +9006,10 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         // Restore the Execution Context. This will also restore the previous Velocity and Script Context.
         Execution execution = Utils.getComponent(Execution.class);
         execution.popContext();
+
+        // The Execution Context is popped first so that backupContext()'s push is undone whatever happens next.
+        // Everything restored below is written to the XWiki Context, which backupContext() also requires.
+        Objects.requireNonNull(context);
 
         // Restore the current document on the XWiki Context.
         context.setDoc((XWikiDocument) backup.get("doc"));

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseCollection.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseCollection.java
@@ -943,16 +943,24 @@ public abstract class BaseCollection<R extends EntityReference> extends BaseElem
             oldPropertyValue = getPropertyDisplayValue(oldProperty, pclass, oldCollection, propertyName, context);
         } else {
             // Cannot get property definition, so use the plain value
-            newPropertyValue = newProperty.toText();
+            newPropertyValue = (newProperty == null) ? "" : newProperty.toText();
             oldPropertyValue = oldProperty.toText();
         }
         difflist.add(new ObjectDiff(getXClassReference(), getNumber(), "", ObjectDiff.ACTION_PROPERTYCHANGED,
             propertyName, propertyType, oldPropertyValue, newPropertyValue, isSensitive));
     }
 
+    /**
+     * @return the value of the property as it would be displayed in the interface, or the empty string when the
+     *         property is not set in the collection, matching how addOrChangePropertyDiff() compares the two sides
+     */
     private String getPropertyDisplayValue(BaseProperty property, PropertyClass pclass, BaseCollection collection,
         String propertyName, XWikiContext context)
     {
+        if (property == null) {
+            return "";
+        }
+
         return (property.getValue() instanceof String) ? property.toText()
             : pclass.displayView(propertyName, collection, context);
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mock;
 import org.mockito.stubbing.Answer;
 import org.xwiki.context.Execution;
+import org.xwiki.context.ExecutionContext;
 import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
@@ -82,6 +83,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -981,6 +983,22 @@ class XWikiDocumentTest
 
         assertSame(oldVelocityContext, execution.getContext().getProperty("velocityContext"));
         assertSame(oldVelocityContext, this.oldcore.getXWikiContext().get("vcontext"));
+    }
+
+    @Test
+    void restoreContextWithoutXWikiContext() throws Exception
+    {
+        Execution execution = this.oldcore.getMocker().getInstance(Execution.class);
+        ExecutionContext initialContext = execution.getContext();
+
+        Map<String, Object> backup = new HashMap<>();
+        XWikiDocument.backupContext(backup, this.oldcore.getXWikiContext());
+        assertNotSame(initialContext, execution.getContext());
+
+        // Everything restored on the XWiki Context needs one, so a missing context is reported rather than failing
+        // further down. The Execution Context that backupContext() pushed is popped all the same.
+        assertThrows(NullPointerException.class, () -> XWikiDocument.restoreContext(backup, null));
+        assertSame(initialContext, execution.getContext());
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/BaseCollectionTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/BaseCollectionTest.java
@@ -19,21 +19,39 @@
  */
 package com.xpn.xwiki.objects;
 
+import java.util.List;
+
 import org.dom4j.Element;
 import org.junit.jupiter.api.Test;
+import org.xwiki.model.reference.EntityReference;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.objects.classes.BaseClass;
+import com.xpn.xwiki.objects.classes.PropertyClass;
+import com.xpn.xwiki.test.MockitoOldcore;
+import com.xpn.xwiki.test.junit5.mockito.InjectMockitoOldcore;
+import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
+import com.xpn.xwiki.test.reference.ReferenceComponentList;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for the {@link BaseCollection} class.
  *
  * @version $Id$
  */
+@ReferenceComponentList
+@OldcoreTest
 class BaseCollectionTest
 {
+    private static final String FIELD = "myField";
+
+    @InjectMockitoOldcore
+    private MockitoOldcore oldcore;
+
     @Test
     void getXClassWithNullReference()
     {
@@ -47,5 +65,82 @@ class BaseCollectionTest
         };
 
         assertNull(collection.getXClass(new XWikiContext()));
+    }
+
+    @Test
+    void getDiffWhenNewPropertyIsNull()
+    {
+        PropertyClass propertyClass = mock(PropertyClass.class);
+        when(propertyClass.getClassType()).thenReturn("StringClass");
+        BaseClass xclass = mock(BaseClass.class);
+        when(xclass.getField(FIELD)).thenReturn(propertyClass);
+
+        BaseProperty oldProperty = mock(BaseProperty.class);
+        when(oldProperty.getValue()).thenReturn("oldValue");
+        when(oldProperty.toText()).thenReturn("oldValue");
+
+        // addField() stores the property as given, so a null one leaves the field name in the collection
+        // without a value.
+        BaseCollection<EntityReference> newCollection = createCollection(xclass);
+        newCollection.addField(FIELD, null);
+        BaseCollection<EntityReference> oldCollection = createCollection(xclass);
+        oldCollection.addField(FIELD, oldProperty);
+
+        ObjectDiff diff = getChangedPropertyDiff(newCollection.getDiff(oldCollection, this.oldcore.getXWikiContext()));
+
+        assertEquals(FIELD, diff.getPropName());
+        assertEquals("StringClass", diff.getPropType());
+        assertEquals("oldValue", diff.getPrevValue());
+        assertEquals("", diff.getNewValue());
+    }
+
+    @Test
+    void getDiffWhenNewPropertyIsNullAndNoPropertyClass()
+    {
+        BaseProperty oldProperty = mock(BaseProperty.class);
+        when(oldProperty.toText()).thenReturn("oldValue");
+
+        // Without a property class the diff falls back on the plain values, where a missing property is empty too.
+        BaseCollection<EntityReference> newCollection = createCollection(null);
+        newCollection.addField(FIELD, null);
+        BaseCollection<EntityReference> oldCollection = createCollection(null);
+        oldCollection.addField(FIELD, oldProperty);
+
+        ObjectDiff diff = getChangedPropertyDiff(newCollection.getDiff(oldCollection, this.oldcore.getXWikiContext()));
+
+        assertEquals(FIELD, diff.getPropName());
+        assertEquals("", diff.getPropType());
+        assertEquals("oldValue", diff.getPrevValue());
+        assertEquals("", diff.getNewValue());
+    }
+
+    /**
+     * @param xclass the class to return from {@link BaseCollection#getXClass(XWikiContext)}, so that the test needs
+     *            no wiki to resolve it
+     * @return a collection using {@link BaseCollection}'s own {@code getDiff()}, which both {@link BaseObject} and
+     *         {@link BaseClass} override
+     */
+    private BaseCollection<EntityReference> createCollection(BaseClass xclass)
+    {
+        return new BaseCollection<>()
+        {
+            @Override
+            public Element toXML(BaseClass bclass)
+            {
+                return null;
+            }
+
+            @Override
+            public BaseClass getXClass(XWikiContext context)
+            {
+                return xclass;
+            }
+        };
+    }
+
+    private ObjectDiff getChangedPropertyDiff(List<ObjectDiff> diffs)
+    {
+        return diffs.stream().filter(diff -> ObjectDiff.ACTION_PROPERTYCHANGED.equals(diff.getAction())).findFirst()
+            .orElseThrow();
     }
 }


### PR DESCRIPTION
# Jira URL

None — this is a `[Misc]` SonarQube fix.

> These are the three findings currently taking **master's quality gate to red**: `New Reliability
> Rating` is `C` (threshold `A`), and they are the *only* reliability issues inside the new-code
> period. Every other gate condition is green.

# Changes

## Description

Fixes the three open [`javabugs:S2259`](https://rules.sonarsource.com/java/RSPEC-2259/) issues
("Fix this access that will throw a NullPointerException when executed") in `xwiki-platform-oldcore`:

* [`BaseCollection.java:956`](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&open=AaBjuSrjCbny7Q3KyAEn&issues=AaBjuSrjCbny7Q3KyAEn)
* [`XWikiDocument.java:6935`](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&open=AaBjuS3SCbny7Q3KyAEq&issues=AaBjuS3SCbny7Q3KyAEq)
* [`XWikiDocument.java:9009`](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&open=AaBjuS3SCbny7Q3KyAEs&issues=AaBjuS3SCbny7Q3KyAEs)

### 1. `BaseCollection#getPropertyDisplayValue()` — a real NPE, reachable from public API

`addOrChangePropertyDiff()` reaches `addPropertyChangedDiff()` with a null `newProperty` by its own
branch condition, which spells the case out:

```java
} else if (!oldProperty.toText().equals(((newProperty == null) ? "" : newProperty.toText()))) {
    addPropertyChangedDiff(propertyName, oldProperty, newProperty, oldCollection, pclass, context, difflist);
}
```

`addPropertyChangedDiff()` then dereferences it on **both** branches — `getPropertyDisplayValue()`
does `property.getValue()`, and the fallback does `newProperty.toText()`. The state is reachable
through published API: `BaseCollection#addField(String, PropertyInterface)` stores the property as
given, so `addField(name, null)` leaves the field name in the collection without a value.

The fix reports the missing property as an empty value — exactly how the caller's own comparison
above already treats it — so a property whose value disappeared is reported as a change to `""`.

### 2. `XWikiDocument#display()` — dereferencing a `@Nullable` result

`getXWikiContext()` is annotated `@Nullable` (in de737018e98, which fixed the same rule elsewhere in
this file), and `display()` passed its result straight into `getTranslatedDocument(XWikiContext)`,
which does `context.getWiki()`. The provider genuinely returns `null` when there is no XWiki context
on the current thread. `display()` cannot do anything without one — the translated content, the
rendering cache lookup and the cache store all read from it — so it now requires it up front, the
same treatment `backupContext()` received in that earlier commit.

### 3. `XWikiDocument#restoreContext()` — dereferencing a context that may be missing

Its callers read the context back out of the Execution Context and hand over whatever they find, for
instance:

```java
private XWikiContext getContext()
{
    Execution execution = Utils.getComponent(Execution.class);
    ExecutionContext econtext = execution.getContext();
    return econtext != null ? (XWikiContext) econtext.getProperty("xwikicontext") : null;
}
```

`restoreContext()` then does `context.setDoc(...)`. It now requires the context, mirroring the
requirement `backupContext()` already makes — but **after** `execution.popContext()`, so that
`backupContext()`'s push is undone whatever happens next. Putting the check first would have leaked
the pushed Execution Context, which the old code did not.

## Clarifications

* **Why `Objects.requireNonNull` in `XWikiDocument` and an empty value in `BaseCollection`.** The two
  `XWikiDocument` sites cannot carry on without a context, so failing immediately and diagnosably is
  the only sane outcome (and is what already happened, one dereference later). `BaseCollection`, by
  contrast, has a meaningful answer for a missing property — the empty value its own caller already
  substitutes.
* **`BaseCollection#getDiff()` is only reachable from outside the repo.** Both in-repo subclasses,
  `BaseObject` and `BaseClass`, override `getDiff()` without delegating to `super`. `BaseCollection`
  is published, extensible API, so the defect is real for extensions, and the new tests exercise it
  through a local subclass.
* **No behaviour change on any path that worked before.** All three sites previously threw an NPE
  under exactly the conditions now handled; nothing that returned normally does anything different.
* **The 10 `java:S1117` findings on this PR's SonarCloud check are not from this PR.** They sit on
  the `XWikiDocument document = createDocumentToApply();` lines added by 8a30d50d3ea (XWIKI-24792) at
  14:35 today, i.e. *after* master's last analysis at 11:28. A PR analysis reports every issue in a
  file the PR touches, so they surface here first; they will appear on master's next analysis whether
  or not this PR merges. My diff to that file is 18 pure insertions (two imports plus the new test)
  and does not touch those lines. They are MAINTAINABILITY findings and leave the PR's
  `New Maintainability Rating` at `A`.
* **Coverage not bumped.** `xwiki-platform-oldcore` achieves an instruction ratio of 0.4308 against a
  pinned 0.40. That 3-point gap is pre-existing — three small tests move 164k instructions by
  ~0.0001 — so raising the module's floor belongs to its own change rather than this fix.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

```
mvn clean install -B -ntp -Plegacy,quality -fae \
  -pl xwiki-platform-core/xwiki-platform-oldcore,\
xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore
```

`BUILD SUCCESS` — `oldcore` **1209 tests** green (1206 on master plus the three added here) and
`legacy-oldcore` **48** green, with Checkstyle, Revapi and the JaCoCo check all passing under
`-Pquality`.

Regression tests added:

* `BaseCollectionTest#getDiffWhenNewPropertyIsNull` — reproduces the reported issue. Without the fix:
  `NullPointerException: Cannot invoke "com.xpn.xwiki.objects.BaseProperty.getValue()" because
  "property" is null`.
* `BaseCollectionTest#getDiffWhenNewPropertyIsNullAndNoPropertyClass` — covers the fallback branch.
  Without the fix: `... because "newProperty" is null`.
* `XWikiDocumentTest#restoreContextWithoutXWikiContext` — passes with and without the change (the old
  code also threw, one line later); it is there to pin the ordering contract, so that a future
  refactor moving the check before `popContext()` fails instead of silently leaking the pushed
  Execution Context.

`javabugs:*` findings are computed server-side and never appear in a local build, so the PR-level
SonarCloud analysis is what proves the three issues gone. It is green:

| Condition | On master | On this PR |
|---|---|---|
| **New Reliability Rating** | **C** ❌ | **A** ✅ |
| Quality gate | **ERROR** | **OK** |

with no `javabugs:S2259` finding left on any of the three sites.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
