### PR TITLE
[stable-18.4.x] XWIKI-24800: The WYSIWYG editor sometimes doesn't join the realtime collaboration session

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-realtime/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-realtime/plugin.js
@@ -267,10 +267,34 @@
             await editor._realtime.editor?._onAbort();
             onAfterLeaveCollaboration(editor);
           };
-          return editor._realtime.connect();
+          // We can't join the realtime session before knowing the editing mode (we join only in WYSIWYG mode).
+          return whenEditingModeIsSet(editor).then(() => editor._realtime.connect());
         }, resolve, reject), reject);
       });
     }
+  }
+
+  /**
+   * The editing mode is loaded after the editor plugins are initialized, so the editor mode is not set yet when this
+   * plugin is initialized. Waiting for it is required because otherwise we can't tell whether the user is editing in
+   * WYSIWYG mode, where the realtime collaboration is supported, or in Source mode, where it isn't, and thus we would
+   * silently skip joining the realtime session.
+   *
+   * @param {CKEDITOR.editor} editor the editor whose editing mode we're waiting for
+   * @returns {Promise} a promise that resolves as soon as the editing mode is set, or when the editor is destroyed
+   *   (because in this case there's no editing mode to wait for anymore)
+   */
+  function whenEditingModeIsSet(editor) {
+    if (editor.mode) {
+      return Promise.resolve();
+    }
+    return new Promise(resolve => {
+      const listeners = [editor.once('mode', onEditingModeSet), editor.once('destroy', onEditingModeSet)];
+      function onEditingModeSet() {
+        listeners.forEach(listener => listener.removeListener());
+        resolve();
+      }
+    });
   }
 
   function onAfterJoinCollaboration(editor) {


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24800

Backport of #6301 (merged on `master` as fbf84d5b477) to `stable-18.4.x`.

# Changes

## Description

Clean `git cherry-pick -x` of the master commit — **no adaptation was needed**, and the result
reproduces the original commit's stat exactly (1 file changed, 25 insertions, 1 deletion).

* Wait for the CKEditor editing mode to be set before deciding whether the realtime collaboration
  session can be joined.

`CKEDITOR.plugins.add('xwiki-realtime').init()` runs at `pluginsLoaded`, but `editor.mode` is only
assigned much later, from within `CKEDITOR.editor.prototype.setMode()`, once the mode creator
(i.e. the WYSIWYG iframe) has finished loading. The `if (editor.mode !== 'wysiwyg') return true;`
guard on the initial join is meant to detect the Source mode, but it also matches "the editing mode
is not set yet", so whenever `Loader.bootstrap()` won the race the editor **silently gave up on
joining the realtime session** — no exception, no notification, and no later Source -> WYSIWYG switch
for the mode change handlers to recover from.

## Clarifications

* `stable-18.4.x` is affected: the guard was added by XWIKI-23985 (f582505f865), first released in
  18.1.0, and is present in this branch at
  `xwiki-realtime/plugin.js:252`.
* `stable-17.10.x` and `stable-16.10.x` predate f582505f865 and are **not** affected, so they need no
  backport.
* No pom, `@since` or Java-level adaptation applies — the change is a single JavaScript file and this
  branch targets the same Java version as master (21).

# Screenshots & Video

See #6301 — the CI failure artifacts (screenshot and VNC recording of master build 1361) are attached
to XWIKI-24287.

# Executed Tests

Module build on this branch, all checks on (Checkstyle, license, Revapi, Spoon):

```bash
mvn clean install -B -ntp -Plegacy \
  -pl xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins
# BUILD SUCCESS
```

The full realtime Docker IT suite was run on the master version of this change (#6301):
`RealtimeWYSIWYGEditorIT` 28/28 and `RealtimeWikiEditorIT` 2/2, on containerised Tomcat 11 +
PostgreSQL + Firefox. The functional runs for this branch are left to CI.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: none — this *is* the backport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
