### PR TITLE
XWIKI-24798: LiveData's state is not persisted in the URL when the macro call enforces a filter

### DIFF
--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-xwiki/src/XWikiLiveDataSource.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-xwiki/src/XWikiLiveDataSource.ts
@@ -57,13 +57,12 @@ export class XWikiLiveDataSource implements LiveDataSource {
       }
       parameters["filters." + filter.property] = filter.constraints
         .filter((constraint) => constraint.value !== undefined)
-        .map((constraint) => {
-          if (constraint.operator === undefined) {
-            constraint.operator = "";
-          }
-          return constraint;
-        })
-        .map((constraint) => constraint.operator + ":" + constraint.value);
+        // The operator can be missing, in which case the backend applies the default one. The constraints themselves
+        // are left untouched: they are part of the Live Data query, which is also encoded to persist the Live Data
+        // state, and that encoding only accepts a known operator.
+        .map(
+          (constraint) => (constraint.operator || "") + ":" + constraint.value,
+        );
     });
     // Add sort.
     parameters.sort = liveDataQuery.sort.map((sort) => sort.property);

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-xwiki/src/liveDataSource.test.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-xwiki/src/liveDataSource.test.ts
@@ -23,6 +23,7 @@ import { XWikiLiveDataSource } from "./XWikiLiveDataSource";
 import $ from "jquery";
 import { stub } from "sinon";
 import { describe, expect, it } from "vitest";
+import type { QueryConstraint } from "@xwiki/platform-livedata-api";
 
 const getJSONStub = stub($, "getJSON");
 // @ts-expect-error leftover from initial javascript implementation
@@ -57,6 +58,30 @@ describe("liveDataSource.js", () => {
       });
 
       expect(res).toEqual({ count: 0, entries: [] });
+    });
+
+    it("sends the constraints without operator with an empty operator, without modifying them", async () => {
+      global.XWiki = {};
+
+      const liveDataSource = new XWikiLiveDataSource($);
+      const constraint = { value: "help" } as unknown as QueryConstraint;
+
+      await liveDataSource.getEntries({
+        source: { id: "test" },
+        properties: ["doc.location"],
+        offset: 0,
+        limit: 15,
+        filters: [{ property: "doc.location", constraints: [constraint] }],
+        sort: [],
+        descending: [],
+      });
+
+      expect(getJSONStub.lastCall.args[1]).toContain(
+        "filters.doc.location=%3Ahelp",
+      );
+      // The constraint is part of the Live Data query, which is also encoded to persist the Live Data state, and that
+      // encoding only accepts a known operator.
+      expect(constraint).toEqual({ value: "help" });
     });
   });
 });


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24798

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

*

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-18.4.x
  * stable-17.10.x