### PR TITLE
XWIKI-24806: TextAreaImageUploadIT is flickering and its missing edit-mode cleanup fails the rest of AllIT

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/CKEditor.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/CKEditor.java
@@ -170,4 +170,18 @@ public class CKEditor extends BaseElement
             }
         }
     }
+
+    /**
+     * Marks every CKEditor instance on the current page as clean, so that leaving the page doesn't ask the user to
+     * confirm that they want to discard their changes. Meant to be called when cleaning up after a test that may have
+     * been interrupted in the middle of an edit: the confirmation dialog would otherwise block the next navigation,
+     * including the navigation done by the tests that come after in the same browser session.
+     *
+     * @since 18.8.0RC1
+     */
+    public static void discardUnsavedChanges()
+    {
+        getUtil().getDriver()
+            .executeScript("Object.values(window.CKEDITOR?.instances ?? {}).forEach(editor => editor.resetDirty());");
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-test/xwiki-platform-edit-test-docker/src/test/it/org/xwiki/edit/test/ui/TextAreaImageUploadIT.java
+++ b/xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-test/xwiki-platform-edit-test-docker/src/test/it/org/xwiki/edit/test/ui/TextAreaImageUploadIT.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.edit.test.ui;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -88,6 +89,23 @@ class TextAreaImageUploadIT
         // Velocity script.
         testUtils.setGlobalRights("", "XWiki." + USER_NAME, "script", true);
         testUtils.createUserAndLogin(USER_NAME, "pa$$word", "editor", "Wysiwyg");
+    }
+
+    @AfterEach
+    void discardUnsavedChanges(TestUtils testUtils)
+    {
+        // A test failing in the middle of an edit leaves the page with unsaved changes, so the next navigation shows
+        // the leave confirmation. All the tests of AllIT share a single browser session, so that dialog blocks every
+        // test that comes after, in this class and in the other nested ones. Discarding the changes here keeps a
+        // failure contained to the test that caused it.
+
+        // The comment, the annotation and the in-place property are edited on a view page, where there is no edit
+        // mode to leave: the leave confirmation comes from the CKEditor instances themselves being dirty.
+        CKEditor.discardUnsavedChanges();
+
+        // The object editor asks for confirmation based on its own form state, which only leaving the edit mode
+        // resets. Done after the editors are marked clean, so that leaving doesn't trigger the dialog itself.
+        testUtils.maybeLeaveEditMode();
     }
 
     /**


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24806

# Changes

## Description

* Discard the unsaved changes after each test of `TextAreaImageUploadIT`, so that a test failing in the middle of an edit no longer leaves the page with an armed `beforeunload` handler.
* Add `CKEditor#discardUnsavedChanges()` to the CKEditor page objects, marking every editor instance on the current page as clean.

## Clarifications

`AllIT` runs all its `@Nested` ITs in a single shared browser session, with `NestedTextAreaImageUploadIT` first. `TextAreaImageUploadIT` had no `@AfterEach`, so when one of its tests failed mid-edit the leave confirmation stayed armed and the next navigation died with `UnhandledAlertException: Unexpected beforeunload dialog detected` (`InvalidArgumentException: Unexpected dialog type beforeunload` on Chrome). Every remaining nested IT then failed in its setup, so a single flickering test produced six failures — see the two builds of 2026-09-03 linked from the issue, one of which also spent 422 s hung on a single `driver.get()`.

The cleanup needs two steps because two different mechanisms ask for confirmation:

* the comment, the annotation and the in-place property are edited on a **view** page, where `TestUtils#maybeLeaveEditMode()` is a no-op (`window.XWiki.editor` is empty). There the confirmation comes from the CKEditor `xwiki-save` plugin, whose `beforeunload` handler tests `editor.checkDirty()` — hence the new `CKEditor#discardUnsavedChanges()`, which calls `resetDirty()` on every instance;
* the **object editor** asks based on its own form state (`dataeditors.js` sets `window.onbeforeunload` from `unsavedChanges`), which only leaving the edit mode resets — hence the `maybeLeaveEditMode()` call, done after the editors are marked clean so that leaving doesn't trigger the dialog itself.

This only contains the damage. The underlying flicker — `ckeditor.getToolBar().insertImage()` occasionally not opening the image dialog within the 10 s wait, seen on master, stable-17.10.x and stable-18.4.x — is still open on XWIKI-24806.

# Screenshots & Video

N/A — test-only change, no UI change.

# Executed Tests

* `mvn clean verify -B -ntp -pl xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-test/xwiki-platform-edit-test-docker -Pdocker,integration-tests -Dit.test=AllIT` — 17 tests, 0 failures, 0 errors.
* `mvn clean install -B -ntp -Plegacy,quality,docker,integration-tests -pl xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects` — 0 Checkstyle violations, Revapi clean.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * stable-18.4.x
  * stable-17.10.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)

