### PR TITLE
XWIKI-24807: AdministrationSectionPage#clickSave() doesn't wait for the page reload, causing flickering StaleElementReferenceException in administration UI tests

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/AdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/AdministrationSectionPage.java
@@ -145,12 +145,18 @@ public class AdministrationSectionPage extends ViewPage
             saveButton = getDriver().findElement(By.xpath("//input[@type='submit'][@name='action_saveandcontinue']"));
         } else {
             saveButton = getDriver().findElement(By.xpath("//input[@type='submit'][@name='formactionsac']"));
+            // The button triggers a full page reload. Mark the current page so that we can be sure the reload has
+            // actually happened before continuing, otherwise the caller can race the navigation and interact with
+            // an element from the page being unloaded, causing a StaleElementReferenceException.
+            getDriver().addPageNotYetReloadedMarker();
         }
         saveButton.click();
 
         if (wait) {
             // Wait until the page is really saved.
             waitForNotificationSuccessMessage("Saved");
+        } else if (!this.asyncSave) {
+            getDriver().waitUntilPageIsReloaded();
         }
     }
 


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24807

# Changes

## Description

* `AdministrationSectionPage#clickSave(boolean)` now waits for the full-page reload triggered by a
  non-async administration section's save button (using the existing
  `addPageNotYetReloadedMarker()`/`waitUntilPageIsReloaded()` idiom) instead of returning right after
  the click.

## Clarifications

* Root cause: `XWikiWebDriver#findElement(By)` resolves the element then calls `scrollTo()`
  (a separate `executeScript()` call). If the save's full-page reload tears down the DOM in the
  window between those two calls, the element reference goes stale and the *next* page-object call
  throws `StaleElementReferenceException`. This affects every non-async administration section, not
  just Presentation, since they all share this `clickSave()` code path.
* Confirmed via Jenkins + Develocity that this is a genuine, recurring race (not a one-off infra
  fluke): the same failure, at the same line, recurs in isolation across independent builds with
  different Chrome/JDK combinations. See XWIKI-24807 for the full analysis.

# Screenshots & Video

N/A — no UI change, this only affects test synchronization.

# Executed Tests

* `mvn clean install -B -ntp -Plegacy -pl xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects` — green (Checkstyle, license, Spoon all pass).
* Re-ran the whole `PresentationIT` docker IT class with `showPageAttachmentsTab` repeated 10 times,
  against Tomcat 11/jdk25 + PostgreSQL + Chrome (matching the failing CI job): 15/15 executions
  passed, `BUILD SUCCESS`.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * stable-18.4.x (PR opened separately)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
