### PR TITLE
XWIKI-22830: CreateWiki: Next step button remains disabled if one fills the wiki identifier before the pretty name

### DIFF
--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/it/org/xwiki/wiki/test/ui/AllIT.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/it/org/xwiki/wiki/test/ui/AllIT.java
@@ -44,4 +44,9 @@ public class AllIT
     class NestedSubWikiIT extends SubWikiIT
     {
     }
+
+    @Nested
+    class NestedCreateWikiIT extends CreateWikiIT
+    {
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/it/org/xwiki/wiki/test/ui/CreateWikiIT.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/it/org/xwiki/wiki/test/ui/CreateWikiIT.java
@@ -1,0 +1,84 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.wiki.test.ui;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.xwiki.test.docker.junit5.UITest;
+import org.xwiki.test.ui.TestUtils;
+import org.xwiki.wiki.test.po.CreateWikiPage;
+import org.xwiki.wiki.test.po.WikiIndexPage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Tests the validation of the first step of the wiki creation wizard.
+ *
+ * @version $Id$
+ * @since 18.8.0RC1
+ */
+@UITest
+class CreateWikiIT
+{
+    private static final String WIKI_PRETTY_NAME = "My new wiki";
+
+    private static final String WIKI_ID = "mynewwiki";
+
+    private static final String MAIN_WIKI_ID = "xwiki";
+
+    @Test
+    @Order(1)
+    void validateFirstStepWhateverTheFieldOrder(TestUtils setup)
+    {
+        setup.loginAsSuperAdmin();
+        CreateWikiPage createWikiPage = WikiIndexPage.gotoPage().createWiki();
+
+        // The wizard cannot be continued as long as the form is empty, and no error is reported before the user
+        // has filled anything. The button is disabled by the form script, so wait for it rather than asserting.
+        createWikiPage.waitUntilNextStepIsDisabled();
+        assertEquals("", createWikiPage.getPrettyNameValidationMessage());
+
+        // Fill the identifier before the pretty name. Setting the identifier by hand stops it from being computed
+        // from the pretty name, so this is the order that used to leave the button disabled forever.
+        createWikiPage.setWikiName(WIKI_ID);
+        assertFalse(createWikiPage.isNextStepEnabled());
+        createWikiPage.setPrettyName(WIKI_PRETTY_NAME);
+        createWikiPage.waitUntilNextStepIsEnabled();
+
+        // Emptying either field disables the button again, and filling it back enables it without touching the
+        // other one.
+        createWikiPage.clearPrettyName();
+        createWikiPage.waitUntilNextStepIsDisabled();
+        assertEquals("Pretty name must not be empty", createWikiPage.getPrettyNameValidationMessage());
+        createWikiPage.setPrettyName(WIKI_PRETTY_NAME);
+        createWikiPage.waitUntilNextStepIsEnabled();
+
+        // An identifier that is already taken keeps the button disabled.
+        createWikiPage.setWikiName(MAIN_WIKI_ID);
+        createWikiPage.waitForWikiNameValidationMessage("This identifier is already used");
+        assertFalse(createWikiPage.isNextStepEnabled());
+
+        // So does an empty identifier.
+        createWikiPage.clearWikiName();
+        createWikiPage.waitForWikiNameValidationMessage("Identifier can't be empty");
+        assertFalse(createWikiPage.isNextStepEnabled());
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-pageobjects/src/main/java/org/xwiki/wiki/test/po/CreateWikiPage.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-pageobjects/src/main/java/org/xwiki/wiki/test/po/CreateWikiPage.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
@@ -50,6 +51,95 @@ public class CreateWikiPage extends ExtendedViewPage
     {
         prettyNameField.clear();
         prettyNameField.sendKeys(prettyName);
+    }
+
+    /**
+     * @param wikiName the wiki identifier to type in the identifier field, which stops the identifier from being
+     *     computed from the pretty name
+     * @since 18.8.0RC1
+     */
+    public void setWikiName(String wikiName)
+    {
+        this.wikiNameField.clear();
+        this.wikiNameField.sendKeys(wikiName);
+    }
+
+    /**
+     * Empty the wiki pretty name field.
+     *
+     * @since 18.8.0RC1
+     */
+    public void clearPrettyName()
+    {
+        clearField(this.prettyNameField);
+    }
+
+    /**
+     * Empty the wiki identifier field.
+     *
+     * @since 18.8.0RC1
+     */
+    public void clearWikiName()
+    {
+        clearField(this.wikiNameField);
+    }
+
+    /**
+     * @return {@code true} if the button leading to the next step of the wizard is enabled
+     * @since 18.8.0RC1
+     */
+    public boolean isNextStepEnabled()
+    {
+        return this.nextStepButton.isEnabled();
+    }
+
+    /**
+     * Wait until the button leading to the next step of the wizard is enabled. The identifier is validated on the
+     * server, so the button can stay disabled for a while after the form has been filled.
+     *
+     * @since 18.8.0RC1
+     */
+    public void waitUntilNextStepIsEnabled()
+    {
+        getDriver().waitUntilElementIsEnabled(this.nextStepButton);
+    }
+
+    /**
+     * Wait until the button leading to the next step of the wizard is disabled.
+     *
+     * @since 18.8.0RC1
+     */
+    public void waitUntilNextStepIsDisabled()
+    {
+        getDriver().waitUntilElementIsDisabled(this.nextStepButton);
+    }
+
+    /**
+     * Wait until the identifier field reports the given validation message.
+     *
+     * @param message the expected validation message
+     * @since 18.8.0RC1
+     */
+    public void waitForWikiNameValidationMessage(String message)
+    {
+        getDriver().waitUntilElementHasTextContent(By.id("wikinamevalidation"), message);
+    }
+
+    /**
+     * @return the validation message currently displayed for the pretty name field
+     * @since 18.8.0RC1
+     */
+    public String getPrettyNameValidationMessage()
+    {
+        return getDriver().findElement(By.id("wikiprettynamevalidation")).getText();
+    }
+
+    private void clearField(WebElement field)
+    {
+        field.clear();
+        // clear() only fires a change event, so also send a keystroke to make sure the validation runs whatever the
+        // browser does with an already empty field.
+        field.sendKeys(Keys.BACK_SPACE);
     }
 
     public String getName()

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/main/resources/WikiManager/CreateWiki.xml
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/main/resources/WikiManager/CreateWiki.xml
@@ -821,17 +821,30 @@ $xwiki.getURL('XWiki.XWikiPreferences', 'admin', "editor=globaladmin&amp;section
     <property>
       <code>(function(){
 
-  var isWikiNameSet = false;
-  var isAliasSet = false;
-  var lastWikiName;
+  let isWikiNameSet = false;
+  let isAliasSet = false;
+
+  // Validation state of each field that gates the "Next" button. A field is valid, invalid, or being validated on
+  // the server, in which case it is loading. The button is enabled only when every field is valid, so that no
+  // ordering of the user input and of the server answers can enable it for an incomplete or invalid form.
+  const VALID = 'valid';
+  const INVALID = 'invalid';
+  const LOADING = 'loading';
+  const fieldStates = {'prettyname': INVALID, 'wikiname': INVALID};
+
+  // The wiki name availability is checked on the server. The check is delayed so that it does not run on each
+  // keystroke, and its answer is applied only when it answers the last check that was requested.
+  const WIKI_NAME_VALIDATION_DELAY = 500;
+  let wikiNameValidationTimeout;
+  let wikiNameValidationRequest;
+  let wikiNameValidationCounter = 0;
 
   ## Error messages
   #set ($MSG_ERROR_WIKIALREADYEXISTS = "$services.localization.render('platform.wiki.create.error.wikiname.wikialreadyexists')")
   #set ($MSG_ERROR_DATABASEALREADYEXISTS = "$services.localization.render('platform.wiki.create.error.wikiname.databasealreadyexists')")
-  #set ($MSG_ERROR_WIKINAMEALREADYUSED = "$services.localization.render('platform.wiki.create.error.wikiname.wikialreadyexists')")
   #set ($MSG_ERROR_WIKINAMEEMPTY = "$services.localization.render('platform.wiki.create.error.wikiname.empty')")
+  #set ($MSG_ERROR_WIKINAMENOTCHECKED = "$services.localization.render('platform.wiki.create.error.wikiname.notchecked')")
   #set ($MSG_ERROR_WIKIPRETTYNAMEEMPTY = "$services.localization.render('platform.wiki.create.prettyname.empty')")
-  #set ($MSG_INFO_WIKINAMEVALID = "$services.localization.render('workspacemanager.wikiname.info.valid')")
   #set ($ISWIKINAMEAVAILABLE = $xwiki.getURL($services.model.createDocumentReference("", "WikiManager", "IsWikiOrDatabaseOrAvailableService")))
 
   /**
@@ -844,22 +857,24 @@ $xwiki.getURL('XWiki.XWikiPreferences', 'admin', "editor=globaladmin&amp;section
       initStepUsers();
     }
   }
-  
+
   function initStepType() {
-    var prettyName = $('prettyname');
+    const prettyName = $('prettyname');
     prettyName.observe('change', prettyNameChanged);
     prettyName.observe('keyup', prettyNameChanged);
-    var wikiName   = $('wikiname');
+    const wikiName = $('wikiname');
     wikiName.observe('change', wikiNameChanged);
     wikiName.observe('keyup', wikiNameChanged);
-    var alias      = $('wikialias');
+    const alias = $('wikialias');
     if (alias) {
       alias.observe('change', aliasChanged);
       alias.observe('keyup', aliasChanged);
     }
-    if(prettyName.value.blank() || wikiName.value.blank()){
-      $('wizard-next').disabled = true;
-    }
+    // The fields can already hold a value, for instance when the form is re-displayed with the values of a
+    // previous attempt, so validate them right away. The "this field is empty" errors are not displayed at this
+    // point because the user has not filled the form yet.
+    validatePrettyName(false);
+    validateWikiName(false);
   }
 
   function initStepUsers() {
@@ -870,30 +885,61 @@ $xwiki.getURL('XWiki.XWikiPreferences', 'admin', "editor=globaladmin&amp;section
   }
 
   /**
+   * Record the validation state of a field and refresh the "Next" button.
+   */
+  function setFieldState(fieldId, state) {
+    fieldStates[fieldId] = state;
+    updateNextButtonState();
+  }
+
+  /**
+   * Enable the "Next" button only when every validated field is valid.
+   */
+  function updateNextButtonState() {
+    $('wizard-next').disabled = !Object.values(fieldStates).every(function (state) {
+      return state === VALID;
+    });
+  }
+
+  /**
    * Pretty name changed
    */
   function prettyNameChanged(event){
-    var prettyName = $('prettyname');
-    if(prettyName.value.blank()){
-      $('wikiprettynamevalidation').innerHTML = "$MSG_ERROR_WIKIPRETTYNAMEEMPTY";
-      prettyName.addClassName('xErrorField');
-    }else{
-      $('wikiprettynamevalidation').innerHTML = '';
-      prettyName.removeClassName('xErrorField');
+    const prettyName = $('prettyname');
+    validatePrettyName(true);
+    if (!prettyName.value.blank()) {
+      const generatedName = prettyName.value.replace(/[^a-zA-Z0-9]/g,'_').toLowerCase();
       // If the user has manually changed the wikiname, we don't generate it automatically anymore
-      if(!isWikiNameSet){
-        var wikiName = $('wikiname');
-        wikiName.value = prettyName.value.replace(/[^a-zA-Z0-9]/g,'_').toLowerCase();
-        validateWikiName();
+      if (!isWikiNameSet) {
+        $('wikiname').value = generatedName;
+        validateWikiName(true);
       }
-      if(!isAliasSet){
-        var wikiAlias = $('wikialias');
+      if (!isAliasSet) {
+        const wikiAlias = $('wikialias');
         if (wikiAlias) {
-          var alias = filterWikiName(prettyName.value.replace(/[^a-zA-Z0-9]/g,'_').toLowerCase());
-          alias += getAliasSuffix();
-          wikiAlias.value = alias;
+          wikiAlias.value = filterWikiName(generatedName) + getAliasSuffix();
         }
       }
+    }
+  }
+  /**
+   * Validate the wiki pretty name, which is only required to be non empty
+   */
+  function validatePrettyName(showEmptyError) {
+    const prettyName = $('prettyname');
+    if (prettyName.value.blank()) {
+      if (showEmptyError) {
+        $('wikiprettynamevalidation').innerHTML = "$MSG_ERROR_WIKIPRETTYNAMEEMPTY";
+        prettyName.addClassName('xErrorField');
+      } else {
+        $('wikiprettynamevalidation').innerHTML = '';
+        prettyName.removeClassName('xErrorField');
+      }
+      setFieldState('prettyname', INVALID);
+    } else {
+      $('wikiprettynamevalidation').innerHTML = '';
+      prettyName.removeClassName('xErrorField');
+      setFieldState('prettyname', VALID);
     }
   }
   /**
@@ -901,7 +947,7 @@ $xwiki.getURL('XWiki.XWikiPreferences', 'admin', "editor=globaladmin&amp;section
    */
   function wikiNameChanged(event){
     isWikiNameSet = true;
-    validateWikiName();
+    validateWikiName(true);
   }
   /**
    * Alias changed
@@ -910,61 +956,88 @@ $xwiki.getURL('XWiki.XWikiPreferences', 'admin', "editor=globaladmin&amp;section
     isAliasSet = true;
   }
   /**
-   * Validate the wiki name
+   * Validate the wiki name. The field stays in the loading state, which keeps the "Next" button disabled, until
+   * the server has answered whether the name is available.
    */
-  function validateWikiName(){
-    var wikiNameElement = $('wikiname');
-    var wikiname = wikiNameElement.value;
-    var filteredWikiName = filterWikiName(wikiname);
-    if (wikiname != filteredWikiName) {
-      wikiNameElement.value = filteredWikiName;
-      wikiname = filteredWikiName;
+  function validateWikiName(showEmptyError) {
+    const wikiNameElement = $('wikiname');
+    const wikiname = filterWikiName(wikiNameElement.value);
+    if (wikiNameElement.value !== wikiname) {
+      wikiNameElement.value = wikiname;
     }
-    if (lastWikiName == wikiname){
+    // Cancel the availability check that is scheduled or running for the previous value. Incrementing the counter
+    // is what makes its answer obsolete, aborting the request only saves a useless round trip.
+    clearTimeout(wikiNameValidationTimeout);
+    if (wikiNameValidationRequest) {
+      wikiNameValidationRequest.transport.abort();
+      wikiNameValidationRequest = undefined;
+    }
+    wikiNameValidationCounter++;
+    if (wikiname.blank()) {
+      if (showEmptyError) {
+        $('wikinamevalidation').innerHTML = "$MSG_ERROR_WIKINAMEEMPTY";
+        wikiNameElement.addClassName('xErrorField');
+      } else {
+        $('wikinamevalidation').innerHTML = '';
+        wikiNameElement.removeClassName('xErrorField');
+      }
+      setFieldState('wikiname', INVALID);
+    } else {
+      setFieldState('wikiname', LOADING);
+      const validationId = wikiNameValidationCounter;
+      wikiNameValidationTimeout = setTimeout(function () {
+        checkWikiNameAvailability(wikiname, validationId);
+      }, WIKI_NAME_VALIDATION_DELAY);
+    }
+  }
+  /**
+   * Ask the server whether the given wiki name is available
+   */
+  function checkWikiNameAvailability(wikiname, validationId) {
+    let url = "$ISWIKINAMEAVAILABLE" + "?xpage=plain&amp;outputSyntax=plain&amp;ajax=1";
+    url += "&amp;wikiname=" + encodeURIComponent(wikiname);
+    url += "&amp;form_token=$!{services.csrf.getToken()}";
+    wikiNameValidationRequest = new Ajax.Request(url, {
+      method: 'get',
+      onSuccess: function (transport) {
+        applyWikiNameValidationResult(validationId, transport.responseText.strip());
+      },
+      onFailure: function () {
+        applyWikiNameValidationResult(validationId, 'error');
+      }
+    });
+  }
+  /**
+   * Report the result of an availability check, unless the wiki name changed while the check was running
+   */
+  function applyWikiNameValidationResult(validationId, result) {
+    if (validationId !== wikiNameValidationCounter) {
+      // The wiki name changed while this check was running, so its result does not describe the current value.
       return;
     }
-    lastWikiName = wikiname;
-    if (wikiname &amp;&amp; !wikiname.blank()) {
-      var surl = "$ISWIKINAMEAVAILABLE" + "?xpage=plain&amp;outputSyntax=plain&amp;ajax=1&amp;wikiname=" + escape(wikiname);
-      surl += "&amp;form_token=$!{services.csrf.getToken()}";
-      new Ajax.Request(surl, {
-        method: 'get',
-        onSuccess: function(transport) {
-          if (transport.responseText == "true") {
-            $('wikinamevalidation').innerHTML = "";
-            wikiNameElement.removeClassName('xErrorField');
-              if (!$('prettyname').value.blank()) {
-                $('wizard-next').disabled = false;
-              }
-          }
-          else if (transport.responseText == "database"){
-            $('wikinamevalidation').innerHTML = "$MSG_ERROR_DATABASEALREADYEXISTS";
-            wikiNameElement.addClassName('xErrorField');
-            $('wizard-next').disabled = true;
-          }
-          else if (transport.responseText == "wiki"){
-            $('wikinamevalidation').innerHTML = "$MSG_ERROR_WIKIALREADYEXISTS";
-            wikiNameElement.addClassName('xErrorField');
-            $('wizard-next').disabled = true;
-          }
-          else{
-            $('wikinamevalidation').innerHTML = "$MSG_ERROR_WIKINAMEALREADYUSED";
-            wikiNameElement.addClassName('xErrorField');
-            $('wizard-next').disabled = true;
-          }
-        }
-      });
-    }
-    else{
-      $('wikinamevalidation').innerHTML = "$MSG_ERROR_WIKINAMEEMPTY";
-      $('wizard-next').disabled = true;
+    wikiNameValidationRequest = undefined;
+    const wikiNameElement = $('wikiname');
+    if (result === 'true') {
+      $('wikinamevalidation').innerHTML = '';
+      wikiNameElement.removeClassName('xErrorField');
+      setFieldState('wikiname', VALID);
+    } else {
+      if (result === 'database') {
+        $('wikinamevalidation').innerHTML = "$MSG_ERROR_DATABASEALREADYEXISTS";
+      } else if (result === 'wiki') {
+        $('wikinamevalidation').innerHTML = "$MSG_ERROR_WIKIALREADYEXISTS";
+      } else {
+        $('wikinamevalidation').innerHTML = "$MSG_ERROR_WIKINAMENOTCHECKED";
+      }
+      wikiNameElement.addClassName('xErrorField');
+      setFieldState('wikiname', INVALID);
     }
   }
   /**
    * Filter wiki name
    */
   function filterWikiName(wikiName){
-    var result = noaccent(wikiName);
+    let result = noaccent(wikiName);
 
     // The server-side code strips '_' chars from the database name.
     result = result.replace(/[_]/g, "");
@@ -985,12 +1058,12 @@ $xwiki.getURL('XWiki.XWikiPreferences', 'admin', "editor=globaladmin&amp;section
     return result;
   }
   function getAliasSuffix() {
-    var suffix = "${services.wiki.aliasSuffix}";
+    let suffix = "${services.wiki.aliasSuffix}";
     if (suffix != "") {
       suffix = "." + suffix;
     } else {
       // try to compute the suffix from the request URL
-      var hostname = window.location.hostname;
+      const hostname = window.location.hostname;
       if (hostname != "localhost" &amp;&amp; !hostname.match(/[0-9]{1,3}(?:\.[0-9]{1,3}){3}/g)) {
         suffix = hostname.substr(hostname.indexOf("."));
       }
@@ -999,7 +1072,7 @@ $xwiki.getURL('XWiki.XWikiPreferences', 'admin', "editor=globaladmin&amp;section
 }
 
   function userScopeChanged(){
-    var value = $$('input:checked[type=radio][name=userScope]')[0].value
+    const value = $$('input:checked[type=radio][name=userScope]')[0].value
     if (value=='local_only') {
       // Disable membership type radio button
       $$('input[type=radio][name=membershipType]').each(function (item){

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/main/resources/WikiManager/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/main/resources/WikiManager/Translations.xml
@@ -89,6 +89,7 @@ platform.wiki.create.error=Wiki \"{0}\" creation failed: {1}.
 platform.wiki.create.error.wikiname.databasealreadyexists=A database with this identifier already exists
 platform.wiki.create.error.wikiname.wikialreadyexists=This identifier is already used
 platform.wiki.create.error.wikiname.empty=Identifier can't be empty
+platform.wiki.create.error.wikiname.notchecked=The availability of this identifier could not be checked. Please check your connection and try again
 
 ## Common errors and messages
 platform.wiki.error.wikidoesnotexist=Wiki [{0}] does not exist


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22830

Replaces https://github.com/xwiki/xwiki-platform/pull/3852.

# Changes

## Description

* Gave the wiki pretty name and the wiki identifier each their own validation function and their own state, `valid`, `invalid` or `loading`, in the first `XWiki.JavaScriptExtension` object of `WikiManager.CreateWiki`.
* Derived the state of the "Next" button in a single function that enables it only when every field is `valid`, and removed every other assignment to `wizard-next.disabled`.
* Disabled the "Next" button again when a required field is emptied.
* Debounced the identifier availability check, cancelled the pending one when the identifier changes, and ignored the answer of a check the user has moved past.
* Kept the identifier field `loading`, and the button disabled, until the answer of the last check arrives.
* Reported a failed availability check, with a new translation key.
* Added the identifier and "Next" button accessors the test needs to the `CreateWikiPage` page object.
* Added `CreateWikiIT` to the module's `AllIT` suite.

## Clarifications

### Why the button state can no longer disagree with the form

Each field records its own validation state and the button is derived from those states in a single place, so no ordering of the user input and of the server answers can leave the two disagreeing. The reported case is one instance of it: the `lastWikiName` short circuit used to return from `validateWikiName` before reaching the code that enabled the button, and no per-field code enables the button any more. The asynchronous cases follow from the same derivation -- a late "available" answer only writes the identifier state, a pretty name typed during a check finds the identifier `loading`, and the answer of a check the user has moved past is dropped on the id comparison.

### Why the failed check is reported

Without it, an identifier left `loading` by a lost request would keep the button disabled with nothing on screen explaining why.

# Screenshots & Video

<img width="2120" height="2293" alt="comparison-trimmed" src="https://github.com/user-attachments/assets/cd44d090-9239-4d54-82ae-1897053f7d83" />

# Executed Tests

* Added the functional test `CreateWikiIT#validateFirstStepWhateverTheFieldOrder`, which fills the identifier before the pretty name, empties either field, and sets an identifier that is already taken and then an empty one.
* `mvn verify -B -ntp -Plegacy,docker,integration-tests -pl xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker -Dit.test='AllIT$NestedCreateWikiIT'` -> Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
* `mvn clean install -B -ntp -Plegacy,quality,integration-tests,docker -DskipITs -pl <wiki-ui-mainwiki>,<wiki-test-pageobjects>,<wiki-test-docker>` -> 3 modules SUCCESS, 0 Checkstyle violations, `xar:verify` ok on `CreateWiki.xml` and `Translations.xml`
* Drove the state machine outside a browser, over the script extracted from `CreateWiki.xml`, for the cases a functional test cannot time reliably: a late "available" answer arriving after the pretty name was emptied, a pretty name typed while an invalid identifier is being checked, an out-of-order answer from an abandoned check, several keystrokes collapsing into a single check, and a failed check -> 19 checks passing on this branch, the reported bug case among them failing on master
* Compared the wizard before and after the fix on a local instance, filling the identifier before the pretty name and emptying the pretty name of a complete form (screenshot above).

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: none.
