### PR TITLE
XWIKI-24808: The Live Data is not always rendered in the PDF export

### DIFF
--- a/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-test/xwiki-platform-export-pdf-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-test/xwiki-platform-export-pdf-test-docker/pom.xml
@@ -74,6 +74,20 @@
       <version>${project.version}</version>
       <scope>runtime</scope>
     </dependency>
+    <!-- Provides the Live Data macro used to test how the Live Data is exported to PDF. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-livedata-macro</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <!-- Provides the Live Data source used by the page that tests the PDF export of the Live Data. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-livedata-livetable</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
     <!--Test only dependencies. -->
     <dependency>
       <groupId>org.xwiki.platform</groupId>
@@ -84,6 +98,13 @@
     <dependency>
       <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-export-pdf-test-pageobjects</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Used to drive the Live Data before exporting it to PDF. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-livedata-test-pageobjects</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-test/xwiki-platform-export-pdf-test-docker/src/test/it/org/xwiki/export/pdf/test/ui/PDFExportIT.java
+++ b/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-test/xwiki-platform-export-pdf-test-docker/src/test/it/org/xwiki/export/pdf/test/ui/PDFExportIT.java
@@ -44,7 +44,10 @@ import org.xwiki.export.pdf.test.po.PDFExportOptionsModal;
 import org.xwiki.export.pdf.test.po.PDFImage;
 import org.xwiki.export.pdf.test.po.PDFTemplateEditPage;
 import org.xwiki.flamingo.skin.test.po.ExportTreeModal;
+import org.xwiki.livedata.test.po.LiveDataElement;
+import org.xwiki.livedata.test.po.TableLayoutElement;
 import org.xwiki.model.EntityType;
+import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.LocalDocumentReference;
 import org.xwiki.officeimporter.test.po.OfficeServerAdministrationSectionPage;
@@ -771,7 +774,7 @@ class PDFExportIT
         // Change the state of the Live Table in order to verify that the PDF export preserves it.
         LiveTableElement liveTable = new LiveTableElement("docs");
         liveTable.sortDescending("Date");
-        liveTable.filterColumn("xwiki-livetable-docs-filter-2", "live");
+        liveTable.filterColumn("xwiki-livetable-docs-filter-2", "livetable");
 
         PDFExportOptionsModal exportOptions = PDFExportOptionsModal.open(viewPage);
 
@@ -784,7 +787,7 @@ class PDFExportIT
             assertTrue(content.contains("""
                 Results 1 - 2 out of 2 per page of 15
                 Page Location Date Last Author Actions
-                live
+                livetable
                 """), "Unexpected content: " + content);
             // Verify the results and the order.
             // Depending on the screen width the text from the live table cells might be wrapped on multiple lines,
@@ -1736,6 +1739,70 @@ class PDFExportIT
             // Make sure we're actually testing a table of contents that is split between print pages.
             assertTrue(tocPageCount > 1, "The table of contents is not split between print pages.");
             assertEquals(expectedAnchors, actualAnchors);
+        }
+    }
+
+    @Test
+    @Order(37)
+    void liveData(TestUtils setup, TestReference testReference) throws Exception
+    {
+        // The page name is used both as the page title and as the value of the Location filter below, so that the live
+        // data lists only the pages created by this test.
+        String pageName = testReference.getLastSpaceReference().getName();
+        setup.createPage(testReference, """
+            {{liveData
+              id="docs"
+              properties="doc.title,doc.location,doc.date,doc.author"
+              source="liveTable"
+              sourceParameters="translationPrefix=platform.index."
+              pageSizes="1,15,25"
+            /}}""", pageName);
+        // Create a child page after the parent because we want to verify that the PDF export preserves the live data
+        // state (we sort by last modification date and show a single entry per page, so only the child page should be
+        // exported).
+        DocumentReference childReference = new DocumentReference("Child", testReference.getLastSpaceReference());
+        setup.createPage(childReference, "", "Child");
+
+        ViewPage viewPage = setup.gotoPage(testReference);
+
+        // Change the state of the live data in order to verify that the PDF export preserves it.
+        LiveDataElement liveData = new LiveDataElement("docs");
+        TableLayoutElement tableLayout = liveData.getTableLayout();
+        tableLayout.waitUntilReady();
+        // Keep only the pages from the space used by this test.
+        tableLayout.filterColumn("Location", pageName);
+        tableLayout.waitUntilRowCountEqualsTo(2);
+        // Sort by date, descending, so that the child page comes first. The first click sorts ascending, replacing the
+        // default sort (by title, ascending), while the second click reverses the order.
+        tableLayout.sortBy("Date");
+        tableLayout.sortBy("Date");
+        // Show a single entry per page.
+        liveData.setPagination(1);
+        tableLayout.waitUntilRowCountEqualsTo(1);
+        assertEquals("Child", tableLayout.getCell("Title", 1).getText());
+
+        PDFExportOptionsModal exportOptions = PDFExportOptionsModal.open(viewPage);
+
+        try (PDFDocument pdf = export(exportOptions)) {
+            // We should have 2 pages: cover page and content page.
+            assertEquals(2, pdf.getNumberOfPages());
+
+            String content = pdf.getTextFromPage(1);
+            // Depending on the screen width the text from the live data cells might be wrapped on multiple lines,
+            // which translates to new lines in the PDF text as well. For this reason we need to do the lookup ignoring
+            // line endings. Moreover, we normally get a space character between the text from two adjacent cells, but
+            // even this is not always consistent, so we need to ignore spaces also.
+            String contentWithoutWhitespace = content.replaceAll("\\s+", "");
+            // Verify the column headers.
+            assertTrue(contentWithoutWhitespace.contains("TitleLocationDateLastAuthor"),
+                "Unexpected content: " + content);
+            // Verify that the entries were actually fetched (2 pages match the filter) and that the page size was
+            // preserved (a single entry is displayed).
+            assertTrue(contentWithoutWhitespace.contains("Entries1-1outof2"), "Unexpected content: " + content);
+            // The displayed entry should be the child page, because we sorted by date descending.
+            String childLocation = setup.serializeLocalReference(childReference).replace(".", "");
+            assertTrue(contentWithoutWhitespace.contains(/* Title */ "Child" + /* Location */ childLocation),
+                "Unexpected content: " + content);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/node/src/main.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/node/src/main.js
@@ -18,27 +18,30 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-require(["jquery"], ($) => {
+// The Live Data user interface is loaded with dynamic imports, which the page ready detection is not able to see: it
+// watches the XMLHttpRequest and fetch calls, and the script elements added to the page head, while the modules are
+// fetched by the module loader of the web browser. The entries are fetched asynchronously as well. We thus have to
+// delay the page ready ourselves until the Live Data is displayed, otherwise the page can be marked as ready too
+// early (e.g. the PDF export would print an empty Live Data).
+require(["jquery", "xwiki-page-ready"], ($, pageReady) => {
   $.fn.liveData = function(config) {
     return this.each(function() {
       if (!$(this).data("liveData")) {
         const instanceConfig = $.extend($(this).data("config"), config);
-        import("./services/init.js").then(
-          ({init}) => {
-             $(this).attr("data-config", JSON.stringify(instanceConfig));
-            init(this, $);
-          });
+        pageReady.delayPageReady(import("./services/init.js").then(({init}) => {
+          $(this).attr("data-config", JSON.stringify(instanceConfig));
+          return init(this, $);
+        }), "livedata:display");
       }
     });
   };
 
   const init = function(event, data) {
-    import("@xwiki/platform-livedata-ui").then(({populateStore}) => {
+    pageReady.delayPageReady(import("@xwiki/platform-livedata-ui").then(({populateStore}) => {
       populateStore()
       const container = $((data && data.elements) || document);
       container.find(".liveData").liveData();
-    });
-
+    }), "livedata:load");
   };
   $(document).on("xwiki:dom:updated", init);
   $(init);

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/node/src/services/init.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/node/src/services/init.js
@@ -33,6 +33,8 @@ import { resolver } from "xwiki-platform-localization-webjar";
  * If the data does not exist yet, create it from the element
  * @param {HTMLElement} element The HTML Element corresponding to the Livedata component
  * @param $ a jquery instance
+ * @returns {Promise} a promise that resolves with the Livedata API once the Livedata is fully displayed, or that
+ *   rejects with the error that prevented the Livedata from being displayed
  */
 function init(element, $) {
 
@@ -60,6 +62,20 @@ function init(element, $) {
 
   const buildTranslations = initTranslationsBuilder(resolver);
 
+  // The live data is displayed asynchronously: the layout and the displayers are loaded with dynamic imports and the
+  // entries are fetched from the live data source. Listen for the event that marks the end of this process, before
+  // mounting the application, so that the caller can know when the live data is fully displayed. The event is
+  // triggered whatever the outcome, with the error that prevented the display, if any.
+  const displayed = new Promise((resolve, reject) => {
+    element.addEventListener("xwiki:livedata:instanceReady", ({detail}) => {
+      if (detail.error) {
+        reject(detail.error);
+      } else {
+        resolve(detail.livedata);
+      }
+    }, {once: true});
+  });
+
   createApp(XWikiLivedata, {
     data,
     liveDataSource: new XWikiLiveDataSource($),
@@ -75,6 +91,8 @@ function init(element, $) {
     .use(i18n)
     .use(Vue3TouchEvents)
     .mount(element)
+
+  return displayed;
 }
 
 export { init };

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/XWikiLivedata.test.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/XWikiLivedata.test.js
@@ -1,0 +1,167 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+import XWikiLivedata from "./XWikiLivedata.vue";
+import { LiveDataLogic } from "./services/LiveDataLogic";
+import { shallowMount } from "@vue/test-utils";
+import flushPromises from "flush-promises";
+import jQuery from "jquery";
+import _ from "lodash-es";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+vi.mock("./services/LiveDataLogic", () => ({
+  LiveDataLogic: vi.fn(),
+}));
+
+/**
+ * @param overrides - the properties overriding the default mock logic
+ * @returns a mock Live Data logic, recording the registered event listeners so that the tests can fire the events
+ */
+function mockLogic(overrides) {
+  const listeners = {};
+  return _.merge(
+    {
+      listeners,
+      setElement: vi.fn(),
+      onEvent: vi.fn((event, callback) => {
+        (listeners[event] ??= []).push(callback);
+      }),
+      triggerEvent: vi.fn(),
+      translationsLoaded: vi.fn().mockResolvedValue(true),
+      registerPanel: vi.fn(),
+      updateEntries: vi.fn().mockResolvedValue(undefined),
+      t: (key) => key,
+      firstEntriesLoading: ref(true),
+      currentLayoutId: ref("table"),
+      data: {
+        id: "my-live-data-id",
+        // The entries are fetched on mount when there are none.
+        data: { entries: [] },
+      },
+    },
+    overrides,
+  );
+}
+
+/**
+ * Mount a shallow XWikiLivedata component and let it initialize as far as it can.
+ *
+ * @param logic - the mock logic the component is expected to create
+ * @returns the initialized shallow wrapper
+ */
+async function mount(logic) {
+  // The component creates its own logic, which we replace with the mock the test drives.
+  LiveDataLogic.mockImplementation(
+    class {
+      constructor() {
+        return logic;
+      }
+    },
+  );
+  const wrapper = shallowMount(XWikiLivedata, {
+    props: {
+      liveDataSource: {},
+      data: "{}",
+      contentTrusted: false,
+      locale: "en",
+      i18n: {},
+      resolveTranslations: vi.fn(),
+    },
+    global: {
+      provide: { jQuery },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+/**
+ * Fire the layoutLoaded event on the given mock logic, the way LivedataLayout does.
+ *
+ * @param logic - the mock logic to fire the event on
+ * @param detail - the event data, holding the error when no layout could be loaded
+ */
+async function fireLayoutLoaded(logic, detail = {}) {
+  const event = new CustomEvent("xwiki:livedata:layoutLoaded", { detail });
+  logic.listeners.layoutLoaded.forEach((callback) => callback(event));
+  await flushPromises();
+}
+
+/**
+ * @param logic - the mock logic to check
+ * @returns the instanceReady event data, or undefined if the event was not triggered yet
+ */
+function instanceReadyData(logic) {
+  return logic.triggerEvent.mock.calls.find(
+    ([event]) => event === "instanceReady",
+  )?.[1];
+}
+
+describe("XWikiLivedata.vue", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("Triggers instanceReady once the layout is displayed", async () => {
+    const logic = mockLogic();
+    const wrapper = await mount(logic);
+
+    // The live data is not displayed until its layout is loaded.
+    expect(instanceReadyData(logic)).toBeUndefined();
+    expect(wrapper.find(".loading").exists()).toBe(true);
+
+    await fireLayoutLoaded(logic);
+
+    expect(instanceReadyData(logic)).toStrictEqual({ error: undefined });
+    expect(wrapper.find(".loading").exists()).toBe(false);
+  });
+
+  it("Triggers instanceReady with the error when no layout can be displayed", async () => {
+    const logic = mockLogic();
+    const wrapper = await mount(logic);
+    const error = new Error("Unknown layout [table]");
+
+    await fireLayoutLoaded(logic, { error });
+
+    expect(instanceReadyData(logic)).toStrictEqual({ error });
+    // There's nothing to display in place of the loader, so it keeps running.
+    expect(wrapper.find(".loading").exists()).toBe(true);
+  });
+
+  it("Waits for the entries to be fetched before triggering instanceReady", async () => {
+    let fetchEntries;
+    const logic = mockLogic({
+      updateEntries: vi.fn(
+        () => new Promise((resolve) => (fetchEntries = resolve)),
+      ),
+    });
+    await mount(logic);
+    await fireLayoutLoaded(logic);
+
+    // The layout is displayed but the entries are still being fetched.
+    expect(logic.updateEntries).toHaveBeenCalled();
+    expect(instanceReadyData(logic)).toBeUndefined();
+
+    fetchEntries();
+    await flushPromises();
+
+    expect(instanceReadyData(logic)).toStrictEqual({ error: undefined });
+  });
+});

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/XWikiLivedata.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/XWikiLivedata.vue
@@ -81,65 +81,98 @@ onMounted(async () => {
   logic.setElement(elementValue);
   // Register the logic on the parent of the root element to make its API accessible publicly.
   jQuery(elementValue).parent().data("liveData", logic);
-  // Waits for the layout to be (lazily) loaded before hiding the loader.
-  logic.onEvent("layoutLoaded", () => {
-    layoutLoaded.value = true;
+  // Waits for the layout to be (lazily) loaded before hiding the loader. The promise is rejected when no layout
+  // can be loaded at all, so that we never wait for one indefinitely.
+  const layoutReady = new Promise<void>((resolve, reject) => {
+    logic.onEvent("layoutLoaded", (event) => {
+      const { error } = (event as CustomEvent).detail;
+      if (error) {
+        reject(error);
+      } else {
+        // Hide the loader and show the footnotes only when a layout was actually loaded. When none could be
+        // loaded the loader keeps running: there is nothing to display in its place yet, and it is also what
+        // tells the functional tests that the live data is not usable.
+        // TODO: XWIKI-24835: The Live Data displays an endless loading animation instead of an error when no
+        // layout can be loaded
+        layoutLoaded.value = true;
+        resolve();
+      }
+    });
   });
+  // We await this promise only at the end, after the translations and the entries, so we register the rejection
+  // handler right away to keep the failure from being reported as unhandled meanwhile.
+  layoutReady.catch(() => {});
 
+  let error: unknown;
   try {
-    await logic.translationsLoaded();
-  } finally {
-    translationsLoaded.value = true;
-  }
-
-  logic.registerPanel({
-    id: "propertiesPanel",
-    title: logic.t("livedata.panel.properties.title"),
-    name: logic.t("livedata.dropdownMenu.panels.properties"),
-    icon: "list-bullets",
-    component: "LivedataAdvancedPanelProperties",
-    order: 1000,
-  });
-  logic.registerPanel({
-    id: "sortPanel",
-    title: logic.t("livedata.panel.sort.title"),
-    name: logic.t("livedata.dropdownMenu.panels.sort"),
-    icon: "table_sort",
-    component: "LivedataAdvancedPanelSort",
-    order: 2000,
-  });
-  logic.registerPanel({
-    id: "filterPanel",
-    title: logic.t("livedata.panel.filter.title"),
-    name: logic.t("livedata.dropdownMenu.panels.filter"),
-    icon: "filter",
-    component: "LivedataAdvancedPanelFilter",
-    order: 3000,
-  });
-
-  // Fetch the data if we don't have any. This call must be made just after the main Vue
-  // component is initialized as  LivedataPersistentConfiguration must be mounted for the
-  // persisted filters to be loaded and applied when fetching  the entries. We use a dedicated
-  // field (firstEntriesLoading) for the first load as the fetch start/end events can be
-  // triggered  before the loader components is loaded (and in this case the loader is never
-  // hidden even once the entries are displayed).
-  if (!logic.data.data.entries.length) {
     try {
-      await logic.updateEntries();
+      await logic.translationsLoaded();
     } finally {
-      // Mark the loader as finished, even if it fails as the loader should stop and a message be
-      // displayed to the user in this case.
+      translationsLoaded.value = true;
+    }
+
+    logic.registerPanel({
+      id: "propertiesPanel",
+      title: logic.t("livedata.panel.properties.title"),
+      name: logic.t("livedata.dropdownMenu.panels.properties"),
+      icon: "list-bullets",
+      component: "LivedataAdvancedPanelProperties",
+      order: 1000,
+    });
+    logic.registerPanel({
+      id: "sortPanel",
+      title: logic.t("livedata.panel.sort.title"),
+      name: logic.t("livedata.dropdownMenu.panels.sort"),
+      icon: "table_sort",
+      component: "LivedataAdvancedPanelSort",
+      order: 2000,
+    });
+    logic.registerPanel({
+      id: "filterPanel",
+      title: logic.t("livedata.panel.filter.title"),
+      name: logic.t("livedata.dropdownMenu.panels.filter"),
+      icon: "filter",
+      component: "LivedataAdvancedPanelFilter",
+      order: 3000,
+    });
+
+    // Fetch the data if we don't have any. This call must be made just after the main Vue
+    // component is initialized as  LivedataPersistentConfiguration must be mounted for the
+    // persisted filters to be loaded and applied when fetching  the entries. We use a dedicated
+    // field (firstEntriesLoading) for the first load as the fetch start/end events can be
+    // triggered  before the loader components is loaded (and in this case the loader is never
+    // hidden even once the entries are displayed).
+    if (!logic.data.data.entries.length) {
+      try {
+        await logic.updateEntries();
+      } finally {
+        // Mark the loader as finished, even if it fails as the loader should stop and a message be
+        // displayed to the user in this case.
+        logic.firstEntriesLoading.value = false;
+      }
+    } else {
       logic.firstEntriesLoading.value = false;
     }
-  } else {
-    logic.firstEntriesLoading.value = false;
-  }
 
-  // Trigger the "instanceCreated" event on the next tick to ensure that the constructor has
-  // returned, and thus all references to the logic instance have been initialized.
-  nextTick(() => {
-    logic.triggerEvent("instanceCreated", {});
-  });
+    // Trigger the "instanceCreated" event on the next tick to ensure that the constructor has
+    // returned, and thus all references to the logic instance have been initialized.
+    nextTick(() => {
+      logic.triggerEvent("instanceCreated", {});
+    });
+
+    // The layout is loaded in parallel with the entries so we have to wait for it too, and for
+    // the tick that renders it, before the live data can be considered fully displayed.
+    await layoutReady;
+    await nextTick();
+  } catch (e) {
+    error = e;
+  } finally {
+    // Notify that the live data is fully loaded and displayed, or that it failed, because there are
+    // listeners that can't wait indefinitely, such as the page ready detection used by the PDF
+    // export. The "error" event data tells the two cases apart: it is undefined on success, and the
+    // live data instance is always available as the "livedata" event data.
+    logic.triggerEvent("instanceReady", { error });
+  }
 });
 </script>
 

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/LivedataLayout.test.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/LivedataLayout.test.js
@@ -19,42 +19,140 @@
  */
 import LivedataLayout from "./LivedataLayout.vue";
 import { shallowMount } from "@vue/test-utils";
-import { describe, expect, it } from "vitest";
+import { componentStore } from "@xwiki/platform-livedata-componentstore";
+import flushPromises from "flush-promises";
+import _ from "lodash-es";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@xwiki/platform-livedata-componentstore", () => ({
+  componentStore: { load: vi.fn() },
+}));
+
+const layoutComponent = { name: "LayoutTable", template: "<div></div>" };
+
+/**
+ * @param overrides - the properties overriding the default mock logic
+ * @returns a mock Live Data logic
+ */
+function mockLogic(overrides) {
+  return _.merge(
+    {
+      data: {
+        id: "my-layout-id",
+        meta: {},
+      },
+      triggerEvent: vi.fn(),
+      changeLayout: vi.fn(),
+      getLayoutDescriptor: vi.fn(),
+    },
+    overrides,
+  );
+}
 
 /**
  * Initialize a shallow LivedataLayout component.
  *
- * @param description - the optional description of the Live Data
+ * @param logic - the mock logic to provide to the component
+ * @param props - the props to pass to the component
  * @returns the initialized shallow wrapper
  */
-function initWrapper(description) {
+function initWrapper(logic = mockLogic(), props = {}) {
   return shallowMount(LivedataLayout, {
+    props,
     global: {
-      provide: {
-        logic: {
-          data: {
-            id: "my-layout-id",
-            meta: {
-              description,
-            },
-          },
-        },
-      },
+      provide: { logic },
     },
   });
 }
 
 describe("LivedataLayout.vue", () => {
+  beforeEach(() => {
+    // The component logs the layouts it fails to load, which we don't want in the test output.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    // By default the requested layout is loaded successfully.
+    componentStore.load.mockReset().mockResolvedValue(layoutComponent);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("Without a description", () => {
     const wrapper = initWrapper();
     expect(wrapper.find(".livedata-layout-description").exists()).toBe(false);
   });
 
   it("With a description", () => {
-    const description = "A description";
-    const wrapper = initWrapper(description);
+    const wrapper = initWrapper(
+      mockLogic({ data: { meta: { description: "A description" } } }),
+    );
     expect(wrapper.find(".livedata-layout-description").text()).toBe(
       "A description",
     );
+  });
+
+  it("Triggers layoutLoaded with the loaded layout component", async () => {
+    const logic = mockLogic();
+    initWrapper(logic, { layoutId: "table" });
+    await flushPromises();
+
+    expect(componentStore.load).toHaveBeenCalledWith("layout", "table");
+    expect(logic.triggerEvent).toHaveBeenCalledWith("layoutLoaded", {
+      layoutId: "table",
+      previousLayoutId: undefined,
+      component: layoutComponent,
+    });
+    expect(logic.changeLayout).not.toHaveBeenCalled();
+  });
+
+  it("Falls back on the default layout when the requested one can't be loaded", async () => {
+    componentStore.load.mockRejectedValue(new Error("Failed to load"));
+    const logic = mockLogic({
+      data: { meta: { defaultLayout: "table" } },
+      getLayoutDescriptor: vi.fn().mockReturnValue({ id: "table" }),
+    });
+    initWrapper(logic, { layoutId: "cards" });
+    await flushPromises();
+
+    expect(logic.changeLayout).toHaveBeenCalledWith("table");
+    // The default layout is going to be loaded, so we're not done yet.
+    expect(logic.triggerEvent).not.toHaveBeenCalled();
+  });
+
+  it("Triggers layoutLoaded with the error when the default layout is the one that failed", async () => {
+    const error = new Error("Failed to load");
+    componentStore.load.mockRejectedValue(error);
+    const logic = mockLogic({
+      data: { meta: { defaultLayout: "table" } },
+      getLayoutDescriptor: vi.fn().mockReturnValue({ id: "table" }),
+    });
+    initWrapper(logic, { layoutId: "table" });
+    await flushPromises();
+
+    expect(logic.changeLayout).not.toHaveBeenCalled();
+    expect(logic.triggerEvent).toHaveBeenCalledWith("layoutLoaded", {
+      layoutId: "table",
+      previousLayoutId: undefined,
+      error,
+    });
+  });
+
+  it("Triggers layoutLoaded with the error when the default layout is not declared", async () => {
+    const error = new Error("Failed to load");
+    componentStore.load.mockRejectedValue(error);
+    const logic = mockLogic({
+      data: { meta: { defaultLayout: "table" } },
+      getLayoutDescriptor: vi.fn().mockReturnValue(undefined),
+    });
+    initWrapper(logic, { layoutId: "cards" });
+    await flushPromises();
+
+    expect(logic.changeLayout).not.toHaveBeenCalled();
+    expect(logic.triggerEvent).toHaveBeenCalledWith("layoutLoaded", {
+      layoutId: "cards",
+      previousLayoutId: undefined,
+      error,
+    });
   });
 });

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/LivedataLayout.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/LivedataLayout.vue
@@ -101,7 +101,11 @@ export default {
 
   // On mounted and when the `layoutId` prop change,
   // try to load the layout corresponding to the layoutId
-  // or the default one as fallback
+  // or the default one as fallback.
+  //
+  // Either way the "layoutLoaded" event is triggered on the logic, with {layoutId, previousLayoutId} plus:
+  // * "component", the loaded layout component, when a layout could be displayed
+  // * "error", the error that prevented it, when no layout could be displayed at all
   watch: {
     layoutId: {
       immediate: true,
@@ -118,15 +122,25 @@ export default {
             });
           })
           .catch((err) => {
-            // If the layout was not the default one, try to load default layout
-            if (
+            const defaultLayout = this.data.meta.defaultLayout;
+            // Fall back on the default layout, unless it's the one that just failed or it isn't declared, in which
+            // case changing the layout would be a no-op.
+            const canFallBack =
               this.layoutId &&
-              this.layoutId !== this.data.meta.defaultLayout
-            ) {
+              this.layoutId !== defaultLayout &&
+              this.logic.getLayoutDescriptor(defaultLayout);
+            if (canFallBack) {
               console.warn(err);
-              this.logic.changeLayout(this.data.meta.defaultLayout);
+              this.logic.changeLayout(defaultLayout);
             } else {
               console.error(err);
+              // There's no layout left to try, so report the failure to the listeners waiting for a layout,
+              // instead of making them wait indefinitely.
+              this.logic.triggerEvent("layoutLoaded", {
+                layoutId,
+                previousLayoutId,
+                error: err,
+              });
             }
           });
       },

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/services/LiveDataLogic.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/services/LiveDataLogic.ts
@@ -428,12 +428,14 @@ export class LiveDataLogic implements Logic {
     return (
       this.fetchEntries()
         // eslint-disable-next-line promise/always-return
-        .then((data) => {
+        .then(async (data) => {
           // We need to keep drafts to insert them back in the entries.
           const drafts = this.data.data.entries.filter((entry) => entry._new);
           data.entries.push(...drafts);
 
           this.data.data = data;
+          // Remove the outdated footnotes, they will be recomputed by the new entries.
+          this.footnotes.reset();
           // Before triggering 'entriesUpdated', we wait for the next tick to be sure to have the DOM updated
           // first.
           // It turns out this is not enough when components are resolved asynchronously.
@@ -450,12 +452,9 @@ export class LiveDataLogic implements Logic {
                 (this.getDisplayerDescriptor(it!.id) as { id: string }).id,
               ),
             );
-          // eslint-disable-next-line promise/catch-or-return,promise/always-return,promise/no-nesting
-          Promise.all(preloadDisplayer).then(() => {
-            nextTick(() => this.triggerEvent("entriesUpdated", {}));
-          });
-          // Remove the outdated footnotes, they will be recomputed by the new entries.
-          this.footnotes.reset();
+          await Promise.all(preloadDisplayer);
+          await nextTick();
+          this.triggerEvent("entriesUpdated", {});
         })
         .catch((err) => {
           // Prevent undesired notifications of the end user for non business related errors (for


### PR DESCRIPTION
## Jira URL

https://jira.xwiki.org/browse/XWIKI-24808

## Changes

### Description

The Live Data user interface is loaded with dynamic imports and its entries are fetched
asynchronously, neither of which the page ready detection can see (it watches `XMLHttpRequest` /
`fetch` calls and the script elements added to the page head, while the modules are fetched by the
browser's own module loader). As a result the page could be marked as ready before the Live Data was
displayed, and the PDF export would print an empty Live Data.

* Delay the page ready detection until the Live Data is fully displayed.
* Trigger a new `instanceReady` event, on the Live Data logic, once the layout is loaded and the
  entries are displayed (or as soon as we know that neither is coming), and return a promise settled
  by this event from the Live Data initialization, so that the page ready detection has something to
  wait for. The event data holds the error that prevented the display, if any, so that listeners can
  tell success from failure, and the returned promise is rejected with it.
* Trigger the existing `layoutLoaded` event also when no layout can be loaded at all (the requested
  one failed and there's no usable default layout to fall back on), with the error in the event data,
  so that the listeners waiting for a layout don't wait indefinitely.
* Wait for the displayers to be preloaded and for the DOM to be updated before triggering
  `entriesUpdated`, by awaiting the preload promise and the next tick inside the entries update
  chain, instead of leaving them in a detached promise chain.
* Add component tests for the new `instanceReady` and `layoutLoaded` behavior, covering both the
  success and the failure paths.
* Add a functional test that checks the PDF export of the Live Data macro, verifying that the
  entries are fetched and that the sort, filter and page size set by the user are preserved.
* Fix the Live Table PDF export test, whose Location filter value also matched the new Live Data
  test page.

### Clarifications

* `instanceReady` is triggered whatever the outcome, because the page ready detection must never be
  blocked by a Live Data that failed to load — but the listeners still need to know whether the Live
  Data is usable, which is why the error is part of the event data. The instance itself is always
  there (`triggerEvent` merges `livedata: this` into every `detail`), so the absence of `error` is
  what means success.
* Reporting the layout failure through `layoutLoaded` rather than through a separate negative event
  keeps the API positive and has a welcome side effect: `layoutLoaded` is also the "loading finished"
  signal of `LayoutLoader`, whose progress bar used to be left running forever when a layout change
  failed.
* The layout is loaded in parallel with the entries, so both have to be awaited before the Live Data
  can be considered fully displayed; the extra `nextTick()` covers the render of the layout.
* `layoutReady` gets a no-op rejection handler as soon as it is created, because it is only awaited
  at the end of the mount: without it, a layout failure would be reported as an unhandled rejection
  while we are still waiting for the translations and the entries.
* When no layout can be displayed at all the loader keeps running: there is nothing to display in
  its place yet, and it is also what tells the functional-test page objects that the Live Data is not
  usable. There's a `TODO` in the code for replacing it with a proper error message, which is its own
  change.

## Screenshots & Video

<!-- TODO: attach the before/after PDF export of a page containing a Live Data macro to
     https://jira.xwiki.org/browse/XWIKI-24808 and reference the attachment URLs here. -->

## Executed Tests

```
pnpm -C xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui test
pnpm -C xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui lint
mvn -B -ntp clean install -f xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker
mvn -B -ntp clean install -f xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-test/xwiki-platform-export-pdf-test-docker
```

The new `LivedataLayout` (6 tests) and `XWikiLivedata` (3 tests) component tests pass, along with the
module's lint and `api-extractor` (no public API change). Both functional suites pass against the
locally installed modules: Live Data 13/13 and PDF export 37/37, the latter including the new
`PDFExportIT#liveData`.

Note: `BaseDisplayer.test.js > "Renders a viewable entry with an empty content"` fails on `master`
too, independently of this change, so `xwiki-platform-node` currently needs `-DskipTests`.

## Expected merging strategy

- [x] Prefers squash
- No backports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
