### PR TITLE
XCOMMONS-3772: Don't run javac lint checks on generated sources

### DIFF
--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-jpql-parser/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-jpql-parser/pom.xml
@@ -35,7 +35,7 @@
     <xwiki.jacoco.instructionRatio>0.13</xwiki.jacoco.instructionRatio>
     <!-- Name to display by the Extension Manager -->
     <xwiki.extension.name>JPQL Query Parser</xwiki.extension.name>
-    </properties>
+  </properties>
   <dependencies>
     <!-- Test Dependencies -->
     <dependency>
@@ -55,6 +55,41 @@
             <goals>
               <goal>generate</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <!-- Compile the SableCC-generated sources in their own execution, with the javac lint checks turned off
+               since we don't control the generated code (it uses raw collection types, for instance). The generated
+               sources don't reference the hand-written ones, so they can be compiled first, which lets the
+               hand-written sources below stay fully checked. -->
+          <execution>
+            <id>compile-generated-sources</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <compileSourceRoots>
+                <compileSourceRoot>${project.build.directory}/generated-sources/sablecc</compileSourceRoot>
+              </compileSourceRoots>
+              <compilerArgs>
+                <arg>-Xlint:none</arg>
+                <arg>-parameters</arg>
+              </compilerArgs>
+            </configuration>
+          </execution>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <!-- Only the hand-written sources: the generated ones are compiled by the execution above. -->
+              <compileSourceRoots>
+                <compileSourceRoot>${project.build.sourceDirectory}</compileSourceRoot>
+              </compileSourceRoots>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
## Jira URL

https://jira.xwiki.org/browse/XCOMMONS-3772

## Changes

### Description

The build reports 120 javac lint warnings on machine-generated sources across the 3 repos, and none of them can be
fixed since we don't control the generators. This PR is the xwiki-platform part, and it is the biggest single
chunk: the 100 `rawtypes` warnings raised by the SableCC-generated parser and AST nodes in
`xwiki-platform-query-jpql-parser` (98 in `Parser.java`, 2 in `Node.java`).

The generated sources are compiled in their own `maven-compiler-plugin` execution with `-Xlint:none`, and the
default execution is restricted to `src/main/java`, so the hand-written sources keep `-Xlint:all`.

### Clarifications

Why these cannot be fixed in the code: SableCC predates generics and is unmaintained upstream, and there is no
generator option or grammar-level hook to change what it emits. It generates code such as:

```java
ArrayList list = new ArrayList();
protected String toString(List list)
```

Why a separate execution rather than a module-level `-Xlint:-rawtypes`: `-Xlint` is a per-javac-invocation option
and not a per-source-path one, so switching `rawtypes` off "for the module" would also stop checking the module's
hand-written `JPQLParser.java`. This is also consistent with what the module already does for Checkstyle, where the
4 generated packages are excluded by path rather than the whole module being skipped.

Unlike wikimodel in the companion PR, the generated sources here do not reference the hand-written ones at all, so
they can simply be compiled first and no `-sourcepath` is needed.

Also fixes the indentation of the closing `</properties>` tag, which was off by 2.

Needs https://github.com/xwiki/xwiki-commons/pull/1957 merged first, since it relies on the new parent POM. CI on
this branch will be red until then.

Forum proposal (agreement still pending, hence draft):
https://forum.xwiki.org/t/stop-running-javac-lint-checks-on-generated-code/18828

## Screenshots & Video

N/A — no visible result, this is a build configuration change.

## Executed Tests

```
mvn clean install -B -ntp -Ddevelocity.cache.local.enabled=false -Ddevelocity.cache.remote.enabled=false
```

in `xwiki-platform-query-jpql-parser`. `BUILD SUCCESS`, 3 tests pass, and compared with the same build on `master`:

* The 2 executions split the sources as intended: 279 generated files then 1 hand-written one.
* Warnings in the module: 100 -> 0.
* Output is unchanged: 281 class files, covering both the generated and the hand-written packages.
* The hand-written source is still fully checked. Verified directly rather than assumed: adding
  `private java.util.List rawtypesCanary = new java.util.ArrayList();` to `JPQLParser.java` was still reported as
  2 `rawtypes` warnings, while the 279 generated files stayed silent. The canary was then reverted.
* A rebuild without `clean` is a no-op ("Nothing to compile") for both executions.

## Expected merging strategy

Prefers squash: Yes. No backport needed.

---
Generated with Claude Code
