### PR TITLE
XWIKI-24729: Make livedata's edit mode better integrated in XWiki's UI

### DIFF
--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-fontawesome/src/main/resources/IconThemes/FontAwesome.xml
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-fontawesome/src/main/resources/IconThemes/FontAwesome.xml
@@ -211,8 +211,8 @@ sort-descending = sort-amount-desc
 note = sticky-note
 
 ## Since 18.8.0RC1
-expand = expand
-compress = compress
+maximize = expand
+minimize = compress
 
 ## Silk icons for backward compatibility (see: http://design.xwiki.org/xwiki/bin/view/Proposal/Silk+Mapping).
 accept = check

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-fontawesome/src/main/resources/IconThemes/FontAwesome.xml
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-fontawesome/src/main/resources/IconThemes/FontAwesome.xml
@@ -210,6 +210,10 @@ sort-descending = sort-amount-desc
 ## Since 18.0.0RC1
 note = sticky-note
 
+## Since 18.8.0RC1
+expand = expand
+compress = compress
+
 ## Silk icons for backward compatibility (see: http://design.xwiki.org/xwiki/bin/view/Proposal/Silk+Mapping).
 accept = check
 anchor = anchor

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-ui/src/main/resources/IconThemes/Silk.xml
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-ui/src/main/resources/IconThemes/Silk.xml
@@ -208,6 +208,10 @@ sort-descending = arrow_down
 ## Since 18.0.0RC1
 note = note
 
+## Since 18.8.0RC1
+expand = arrow_out
+compress = arrow_in
+
 ## Silk icons for backward compatibility (see: http://design.xwiki.org/xwiki/bin/view/Proposal/Silk+Mapping).
 accept = accept
 add = add

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-ui/src/main/resources/IconThemes/Silk.xml
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-ui/src/main/resources/IconThemes/Silk.xml
@@ -209,8 +209,8 @@ sort-descending = arrow_down
 note = note
 
 ## Since 18.8.0RC1
-expand = arrow_out
-compress = arrow_in
+maximize = arrow_out
+minimize = arrow_in
 
 ## Silk icons for backward compatibility (see: http://design.xwiki.org/xwiki/bin/view/Proposal/Silk+Mapping).
 accept = accept

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/main/resources/ApplicationResources.properties
@@ -122,6 +122,8 @@ livedata.action.addEntry=Add entry
 livedata.action.columnName.default.hint=Drag or use arrow keys to reorder this property.
 livedata.action.columnName.sortable.hint=Click to sort the entries based on this property. Drag or use arrow keys to reorder.
 livedata.action.editMode=Edit mode
+livedata.action.maximize=Maximize
+livedata.action.minimize=Minimize
 livedata.action.resizeColumn.hint=Drag or use arrow keys to resize. Double click or press escape to reset.
 
 livedata.table.entrySelector.hint=Entry selection

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/LiveDataIT.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/LiveDataIT.java
@@ -895,31 +895,7 @@ class LiveDataIT
         testUtils.loginAsSuperAdmin();
         testUtils.deletePage(testReference, true);
 
-        // testReference is used both as the XClass defining the entries and as the page holding the Live Data macro.
-        String className = testUtils.serializeReference(testReference.getLocalDocumentReference());
-        String newRowLocation = testUtils.serializeReference(testReference.getLocalDocumentReference().getParent());
-
-        // Create the Live Data page.
-        // The "uuid" row naming strategy generates a new page named after a random UUID in the "newRowLocation" space.
-        // "hasEditMode=true" exposes the edit mode toggle in the actions menu.
-        String sourceParameters = String.format(
-            "translationPrefix=&className=%s&hasEditMode=true&newRowNamingStrategy=uuid&newRowLocation=%s",
-            className, newRowLocation);
-        String content = """
-            {{liveData
-              id="test"
-              properties="%s"
-              source="liveTable"
-              sourceParameters="%s"
-            /}}
-            """.formatted(NAME_COLUMN, sourceParameters);
-        testUtils.createPage(testReference, content, "Add entry from layout");
-
-        // Define the XClass on the test page.
-        testUtils.addClassProperty(testReference, NAME_COLUMN, "String");
-
-        DocumentReference initialEntry = new DocumentReference("InitialEntry", testReference.getLastSpaceReference());
-        testUtils.addObject(initialEntry, className, singletonMap(NAME_COLUMN, NAME_LYNDA));
+        createEditableLiveDataPage(testUtils, testReference);
 
         testUtils.createUser("creator", "creator", null);
         testUtils.setRightsOnSpace(testReference.getLastSpaceReference(), null, "XWiki.creator", "edit", true);
@@ -965,6 +941,125 @@ class LiveDataIT
         assertEquals(2, tableLayout.getTotalEntries());
         tableLayout.assertRow(NAME_COLUMN, NAME_LYNDA);
         tableLayout.assertRow(NAME_COLUMN, NAME_ESTHER);
+    }
+
+    @Test
+    @Order(12)
+    void toggleEditMode(TestUtils testUtils, TestReference testReference) throws Exception
+    {
+        testUtils.loginAsSuperAdmin();
+        testUtils.deletePage(testReference, true);
+
+        createEditableLiveDataPage(testUtils, testReference);
+
+        testUtils.gotoPage(testReference);
+        LiveDataElement liveData = new LiveDataElement("test");
+        TableLayoutElement tableLayout = liveData.getTableLayout();
+        tableLayout.waitUntilRowCountEqualsTo(1);
+
+        assertTrue(liveData.hasEditModeAction());
+        assertFalse(liveData.isEditMode());
+
+        // The button stays pressed while the user is in edit mode.
+        liveData.toggleEditMode();
+        tableLayout.waitUntilReady();
+        assertTrue(liveData.isEditMode());
+        assertTrue(tableLayout.hasEditModeActionsColumn());
+
+        liveData.toggleEditMode();
+        tableLayout.waitUntilReady();
+        assertFalse(liveData.isEditMode());
+        assertFalse(tableLayout.hasEditModeActionsColumn());
+    }
+
+    @Test
+    @Order(13)
+    void maximizeLiveData(TestUtils testUtils, TestReference testReference) throws Exception
+    {
+        testUtils.loginAsSuperAdmin();
+        testUtils.deletePage(testReference, true);
+
+        createEditableLiveDataPage(testUtils, testReference);
+
+        testUtils.gotoPage(testReference);
+        LiveDataElement liveData = new LiveDataElement("test");
+        TableLayoutElement tableLayout = liveData.getTableLayout();
+        tableLayout.waitUntilRowCountEqualsTo(1);
+
+        assertFalse(liveData.isMaximized());
+        assertEquals("Maximize", liveData.getMaximizedActionLabel());
+        // Both states use a different icon name, so each of them must be mapped by the icon theme.
+        assertTrue(liveData.hasMaximizedActionIcon());
+
+        // Maximize the Live Data: it is displayed over the rest of the page, and the action now offers to go back to
+        // the normal view.
+        liveData.toggleMaximized();
+        liveData.waitUntilMaximized(true);
+        assertEquals("Minimize", liveData.getMaximizedActionLabel());
+        assertTrue(liveData.hasMaximizedActionIcon());
+        // The entries are still displayed once maximized.
+        tableLayout.assertRow(NAME_COLUMN, NAME_LYNDA);
+
+        // Going back to the normal view from the same action.
+        liveData.toggleMaximized();
+        liveData.waitUntilMaximized(false);
+        assertEquals("Maximize", liveData.getMaximizedActionLabel());
+
+        // Escape exits the maximized view too.
+        liveData.toggleMaximized();
+        liveData.waitUntilMaximized(true);
+        liveData.pressEscape();
+        liveData.waitUntilMaximized(false);
+
+        // Escape does nothing when the Live Data is not maximized.
+        liveData.pressEscape();
+        assertFalse(liveData.isMaximized());
+
+        // Escape is first consumed by the cell editor, so it takes a second one to leave the maximized view.
+        liveData.toggleMaximized();
+        liveData.waitUntilMaximized(true);
+        // The editor is opened from the cell popover, which is only offered outside of edit mode.
+        tableLayout.clickEditCell(NAME_COLUMN, 1);
+        testUtils.getDriver().waitUntilCondition(
+            input -> tableLayout.isCellEditing(NAME_COLUMN, 1, NAME_COLUMN));
+
+        liveData.pressEscape();
+        testUtils.getDriver().waitUntilCondition(
+            input -> !tableLayout.isCellEditing(NAME_COLUMN, 1, NAME_COLUMN));
+        assertTrue(liveData.isMaximized());
+
+        liveData.pressEscape();
+        liveData.waitUntilMaximized(false);
+    }
+
+    /**
+     * Creates a Live Data page on an XClass holding a single entry, with a source supporting the edit mode.
+     */
+    private void createEditableLiveDataPage(TestUtils testUtils, DocumentReference testReference)
+    {
+        // testReference is used both as the XClass defining the entries and as the page holding the Live Data macro.
+        String className = testUtils.serializeReference(testReference.getLocalDocumentReference());
+        String newRowLocation = testUtils.serializeReference(testReference.getLocalDocumentReference().getParent());
+
+        // The "uuid" row naming strategy generates a new page named after a random UUID in the "newRowLocation" space.
+        // "hasEditMode=true" exposes the edit mode button in the top bar.
+        String sourceParameters = String.format(
+            "translationPrefix=&className=%s&hasEditMode=true&newRowNamingStrategy=uuid&newRowLocation=%s",
+            className, newRowLocation);
+        String content = """
+            {{liveData
+              id="test"
+              properties="%s"
+              source="liveTable"
+              sourceParameters="%s"
+            /}}
+            """.formatted(NAME_COLUMN, sourceParameters);
+        testUtils.createPage(testReference, content, "Live Data with an edit mode");
+
+        // Define the XClass on the test page, and add a single entry.
+        testUtils.addClassProperty(testReference, NAME_COLUMN, "String");
+        DocumentReference initialEntry = new DocumentReference("InitialEntry", testReference.getLastSpaceReference());
+        testUtils.addObject(initialEntry, className, singletonMap(NAME_COLUMN, NAME_LYNDA));
     }
 
     private void initLocalization(TestUtils testUtils, DocumentReference testReference) throws Exception

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/LiveDataIT.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/LiveDataIT.java
@@ -945,7 +945,7 @@ class LiveDataIT
 
     @Test
     @Order(12)
-    void toggleEditMode(TestUtils testUtils, TestReference testReference) throws Exception
+    void editModeAndMaximizedView(TestUtils testUtils, TestReference testReference) throws Exception
     {
         testUtils.loginAsSuperAdmin();
         testUtils.deletePage(testReference, true);
@@ -970,21 +970,6 @@ class LiveDataIT
         tableLayout.waitUntilReady();
         assertFalse(liveData.isEditMode());
         assertFalse(tableLayout.hasEditModeActionsColumn());
-    }
-
-    @Test
-    @Order(13)
-    void maximizeLiveData(TestUtils testUtils, TestReference testReference) throws Exception
-    {
-        testUtils.loginAsSuperAdmin();
-        testUtils.deletePage(testReference, true);
-
-        createEditableLiveDataPage(testUtils, testReference);
-
-        testUtils.gotoPage(testReference);
-        LiveDataElement liveData = new LiveDataElement("test");
-        TableLayoutElement tableLayout = liveData.getTableLayout();
-        tableLayout.waitUntilRowCountEqualsTo(1);
 
         assertFalse(liveData.isMaximized());
         assertEquals("Maximize", liveData.getMaximizedActionLabel());
@@ -1020,12 +1005,10 @@ class LiveDataIT
         liveData.waitUntilMaximized(true);
         // The editor is opened from the cell popover, which is only offered outside of edit mode.
         tableLayout.clickEditCell(NAME_COLUMN, 1);
-        testUtils.getDriver().waitUntilCondition(
-            input -> tableLayout.isCellEditing(NAME_COLUMN, 1, NAME_COLUMN));
+        tableLayout.waitUntilCellIsEditing(NAME_COLUMN, 1, NAME_COLUMN, true);
 
         liveData.pressEscape();
-        testUtils.getDriver().waitUntilCondition(
-            input -> !tableLayout.isCellEditing(NAME_COLUMN, 1, NAME_COLUMN));
+        tableLayout.waitUntilCellIsEditing(NAME_COLUMN, 1, NAME_COLUMN, false);
         assertTrue(liveData.isMaximized());
 
         liveData.pressEscape();

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/LiveDataElement.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/LiveDataElement.java
@@ -24,9 +24,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.ui.Select;
 import org.xwiki.test.ui.po.BaseElement;
 
@@ -149,6 +151,92 @@ public class LiveDataElement extends BaseElement
     public void toggleEditMode()
     {
         getRootElement().findElement(By.cssSelector(".livedata-edit-button")).click();
+    }
+
+    /**
+     * Check if edit mode is currently enabled. The edit mode button stays pressed as long as the user is in edit mode.
+     *
+     * @return {@code true} if edit mode is enabled, {@code false} otherwise
+     * @since 18.8.0RC1
+     */
+    public boolean isEditMode()
+    {
+        WebElement editModeButton = getRootElement().findElement(By.cssSelector(".livedata-edit-button"));
+        return Boolean.parseBoolean(editModeButton.getDomAttribute("aria-pressed"))
+            && Arrays.asList(editModeButton.getDomAttribute("class").split("\\s+")).contains("active");
+    }
+
+    /**
+     * Toggle the maximized view from the actions menu. The maximized view displays the Live Data over the rest of the
+     * page.
+     *
+     * @since 18.8.0RC1
+     */
+    public void toggleMaximized()
+    {
+        openDropDownMenu().findElement(By.cssSelector(".livedata-action-maximize")).click();
+    }
+
+    /**
+     * @return the label of the action toggling the maximized view, which describes the view the user switches to
+     *     (e.g., "Maximize" or "Minimize")
+     * @since 18.8.0RC1
+     */
+    public String getMaximizedActionLabel()
+    {
+        WebElement dropdownMenu = openDropDownMenu();
+        String label = dropdownMenu.findElement(By.cssSelector(".livedata-action-maximize")).getText();
+        // Close the dropdown menu back so it doesn't overlap the layout.
+        dropdownMenu.findElement(By.cssSelector(".dropdown-toggle")).click();
+        return label;
+    }
+
+    /**
+     * Check that the icon of the action toggling the maximized view is known by the current icon theme. An icon name
+     * that the theme does not map is displayed as an empty placeholder.
+     *
+     * @return {@code true} if the action displays an actual icon, {@code false} otherwise
+     * @since 18.8.0RC1
+     */
+    public boolean hasMaximizedActionIcon()
+    {
+        WebElement dropdownMenu = openDropDownMenu();
+        boolean resolved = dropdownMenu.findElements(
+            By.cssSelector(".livedata-action-maximize .icon-placeholder")).isEmpty();
+        // Close the dropdown menu back so it doesn't overlap the layout.
+        dropdownMenu.findElement(By.cssSelector(".dropdown-toggle")).click();
+        return resolved;
+    }
+
+    /**
+     * @return {@code true} if the Live Data is displayed over the rest of the page, {@code false} otherwise
+     * @since 18.8.0RC1
+     */
+    public boolean isMaximized()
+    {
+        return getDriver().hasElementWithoutWaiting(getRootElement(),
+            By.cssSelector(".xwiki-livedata.livedata-maximized"));
+    }
+
+    /**
+     * Wait until the Live Data enters or leaves the maximized view.
+     *
+     * @param maximized {@code true} to wait for the maximized view, {@code false} to wait for the normal view
+     * @since 18.8.0RC1
+     */
+    public void waitUntilMaximized(boolean maximized)
+    {
+        getDriver().waitUntilCondition(input -> isMaximized() == maximized);
+    }
+
+    /**
+     * Press the escape key, which exits the maximized view when no other component consumes it.
+     *
+     * @since 18.8.0RC1
+     */
+    public void pressEscape()
+    {
+        new Actions(getDriver().getWrappedDriver()).sendKeys(Keys.ESCAPE).build().perform();
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/LiveDataElement.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/LiveDataElement.java
@@ -155,8 +155,11 @@ public class LiveDataElement extends BaseElement
 
     /**
      * Check if edit mode is currently enabled. The edit mode button stays pressed as long as the user is in edit mode.
+     * Only a Live Data whose source supports the edit mode displays that button, so call {@link #hasEditModeAction()}
+     * first when the source is not known to support it.
      *
      * @return {@code true} if edit mode is enabled, {@code false} otherwise
+     * @throws NoSuchElementException if the Live Data does not offer the edit mode
      * @since 18.8.0RC1
      */
     public boolean isEditMode()
@@ -201,8 +204,9 @@ public class LiveDataElement extends BaseElement
     public boolean hasMaximizedActionIcon()
     {
         WebElement dropdownMenu = openDropDownMenu();
-        boolean resolved = dropdownMenu.findElements(
-            By.cssSelector(".livedata-action-maximize .icon-placeholder")).isEmpty();
+        // The placeholder is expected to be absent, so looking for it must not wait for it to appear.
+        boolean resolved = !getDriver().hasElementWithoutWaiting(dropdownMenu,
+            By.cssSelector(".livedata-action-maximize .icon-placeholder"));
         // Close the dropdown menu back so it doesn't overlap the layout.
         dropdownMenu.findElement(By.cssSelector(".dropdown-toggle")).click();
         return resolved;

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/LiveDataElement.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/LiveDataElement.java
@@ -132,30 +132,23 @@ public class LiveDataElement extends BaseElement
     /**
      * Check if the livedata supports edit mode.
      *
-     * @return {@code true} if the "Edit mode" toggle is available in the dropdown menu, {@code false} otherwise
+     * @return {@code true} if the edit mode button is available in the top bar, {@code false} otherwise
      * @since 18.7.0RC1
      */
     public boolean hasEditModeAction()
     {
-        WebElement dropdownMenu = openDropDownMenu();
-        boolean present = dropdownMenu.findElements(By.cssSelector(".livedata-action-edit-mode"))
+        return getRootElement().findElements(By.cssSelector(".livedata-edit-button"))
             .stream().anyMatch(WebElement::isDisplayed);
-        // Close the dropdown menu back so it doesn't overlap the layout.
-        dropdownMenu.click();
-        return present;
     }
 
     /**
      * Toggle edit mode.
-     * 
+     *
      * @since 18.7.0RC1
      */
     public void toggleEditMode()
     {
-        WebElement dropdownMenu = openDropDownMenu();
-        dropdownMenu.findElement(By.cssSelector(".livedata-action-edit-mode input[type='checkbox']")).click();
-        // Close the dropdown menu back so it doesn't overlap the layout.
-        dropdownMenu.click();
+        getRootElement().findElement(By.cssSelector(".livedata-edit-button")).click();
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/TableLayoutElement.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/TableLayoutElement.java
@@ -969,7 +969,22 @@ public class TableLayoutElement extends BaseElement
     {
         int columnIndex = getColumnIndex(columnLabel);
         WebElement element = getCellsByColumnIndex(columnIndex).get(rowNumber - 1);
-        return !element.findElements(By.cssSelector(String.format("[name$='_%s']", fieldName))).isEmpty();
+        // This is called to observe the editor closing as well as opening, so it must not wait for the editor.
+        return getDriver().hasElementWithoutWaiting(element, By.cssSelector(String.format("[name$='_%s']", fieldName)));
+    }
+
+    /**
+     * Wait until the inline editor of the given XObject property cell is displayed, or until it is closed.
+     *
+     * @param columnLabel the label of the column
+     * @param rowNumber the number of the row (the first line is number 1)
+     * @param fieldName the name of the edited XClass property
+     * @param editing {@code true} to wait for the editor to be displayed, {@code false} to wait for it to be closed
+     * @since 18.8.0RC1
+     */
+    public void waitUntilCellIsEditing(String columnLabel, int rowNumber, String fieldName, boolean editing)
+    {
+        getDriver().waitUntilCondition(input -> isCellEditing(columnLabel, rowNumber, fieldName) == editing);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-api/etc/platform-livedata-api.api.md
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-api/etc/platform-livedata-api.api.md
@@ -72,6 +72,7 @@ export interface Logic {
     getEntryId(entry: Values): string | undefined;
     getPageCount(): number;
     isContentTrusted(): boolean;
+    isMaximized(): boolean;
     onEvent(event: string, callback: (e: Event) => void): void;
     onEventWhere(eventName: string, condition: object | ((p: unknown) => boolean), callback: (e: Event) => void): void;
     registerPanel(panel: Panel): void;
@@ -84,6 +85,7 @@ export interface Logic {
         values: unknown;
     }): Promise<unknown>;
     sort(property: string, level: number, descending?: boolean): Promise<void>;
+    toggleMaximized(): void;
     translationsLoaded(): Promise<boolean>;
     triggerEvent(eventName: string, eventData?: object): void;
     updateEntries(): Promise<void>;

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-api/src/logic.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-api/src/logic.ts
@@ -228,4 +228,18 @@ export interface Logic {
    * @param panel - the panel to add
    */
   registerPanel(panel: Panel): void;
+
+  /**
+   * Indicates whether the view is currently maximized.
+   *
+   * @returns whether the Live Data is currently displayed maximized
+   * @since 18.8.0RC1
+   */
+  isMaximized(): boolean;
+
+  /**
+   * Switches between the maximized view and the normal view.
+   * @since 18.8.0RC1
+   */
+  toggleMaximized(): void;
 }

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataActions.test.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataActions.test.js
@@ -1,0 +1,98 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import LivedataActions from "./LivedataActions.vue";
+import LivedataDropdownMenu from "./LivedataDropdownMenu.vue";
+import LivedataEditButton from "./LivedataEditButton.vue";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import { ref } from "vue";
+
+/**
+ * Vue component initializer for `LivedataActions` components. Calls `mount()` with preconfigured
+ * values.
+ *
+ * @param hasEditMode - whether the source of the Live Data supports the edit mode
+ * @returns a wrapper for `LivedataActions` components
+ */
+function initWrapper({ hasEditMode = false } = {}) {
+  global.XWiki = {
+    contextPath: "",
+  };
+
+  const editModeSupported = ref(hasEditMode);
+  return {
+    editModeSupported,
+    wrapper: mount(LivedataActions, {
+      global: {
+        provide: {
+          logic: {
+            hasEditMode: () => editModeSupported.value,
+          },
+        },
+        mocks: {
+          $t: (key) => key,
+        },
+        stubs: {
+          LivedataDropdownMenu: true,
+          LivedataEditButton: true,
+        },
+      },
+    }),
+  };
+}
+
+describe("LivedataActions.vue", () => {
+  it("Displays the dropdown menu when the source has no edit mode", () => {
+    const { wrapper } = initWrapper();
+
+    expect(wrapper.findComponent(LivedataDropdownMenu).exists()).toBe(true);
+    expect(wrapper.findComponent(LivedataEditButton).exists()).toBe(false);
+  });
+
+  it("Displays the edit button when the source has an edit mode", () => {
+    const { wrapper } = initWrapper({ hasEditMode: true });
+
+    expect(wrapper.findComponent(LivedataEditButton).exists()).toBe(true);
+    expect(wrapper.findComponent(LivedataDropdownMenu).exists()).toBe(true);
+  });
+
+  it("Displays the edit button before the dropdown menu", () => {
+    const { wrapper } = initWrapper({ hasEditMode: true });
+    const actions = wrapper.findAll("li");
+
+    expect(actions).toHaveLength(2);
+    expect(actions.at(0).findComponent(LivedataEditButton).exists()).toBe(true);
+    expect(actions.at(1).findComponent(LivedataDropdownMenu).exists()).toBe(
+      true,
+    );
+  });
+
+  it("Displays the edit button as soon as the source declares an edit mode", async () => {
+    const { wrapper, editModeSupported } = initWrapper();
+
+    expect(wrapper.findComponent(LivedataEditButton).exists()).toBe(false);
+
+    editModeSupported.value = true;
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findComponent(LivedataEditButton).exists()).toBe(true);
+  });
+});

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataActions.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataActions.vue
@@ -19,47 +19,43 @@
 -->
 
 <!--
-  The LivedataTopbar component can be use to create consistent topbars
-  for the different layout implementations.
-  It usually contains the dropdown menu, the refresh button, the global search
-  and the pagination.
-
-  It contains two slots: `left` and `right`, that allows to quickly
-  organize its content to stick to the left or to the right
+  LivedataActions groups the actions of the Live Data at the end of its top bar. They are laid out
+  as a list of buttons sharing a flat look, the same way the skin displays the actions of a page.
 -->
 <template>
-  <div class="livedata-topbar">
-    <div class="livedata-topbar-left">
-      <slot name="left"></slot>
-    </div>
-
-    <div class="livedata-topbar-right">
-      <slot name="right"></slot>
-    </div>
-  </div>
+  <ul class="livedata-actions flat-buttons">
+    <li v-if="logic.hasEditMode()"><LivedataEditButton /></li>
+    <li><LivedataDropdownMenu /></li>
+  </ul>
 </template>
 
 <script>
+import LivedataDropdownMenu from "./LivedataDropdownMenu.vue";
+import LivedataEditButton from "./LivedataEditButton.vue";
+
 export default {
-  name: "LivedataTopbar",
+  name: "LivedataActions",
+
+  components: {
+    LivedataDropdownMenu,
+    LivedataEditButton,
+  },
+
+  inject: ["logic"],
 };
 </script>
 
 <style>
-.livedata-topbar {
+.livedata-actions {
   display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: var(--padding-large-vertical);
-  margin-bottom: var(--padding-large-vertical);
+  gap: var(--button-spacing);
+  list-style: none;
+  margin-bottom: 0;
+  margin-left: var(--grid-gutter-width);
+  padding-left: 0;
 }
 
-.livedata-topbar-left,
-.livedata-topbar-right {
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-  align-items: center;
+.livedata-actions .btn span {
+  vertical-align: middle;
 }
 </style>

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataDropdownMenu.test.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataDropdownMenu.test.js
@@ -48,7 +48,7 @@ function initWrapper() {
             },
           },
           changeLayout: changeLayout,
-          hasEditMode: () => false,
+          isMaximized: () => false,
         },
       },
       mocks: {

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataDropdownMenu.test.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataDropdownMenu.test.js
@@ -28,15 +28,20 @@ import { ref } from "vue";
  * Vue component initializer for `LivedataDropdownMenu` components. Calls `mount()` with
  * preconfigured values.
  *
- * @returns a map containing a wrapper for `LivedataDropdownMenu` components and a mock of
- *   logic.changeLayout
+ * @param maximized - whether the Live Data starts maximized
+ * @returns a map containing a wrapper for `LivedataDropdownMenu` components and mocks of
+ *   logic.changeLayout and logic.toggleMaximized
  */
-function initWrapper() {
+function initWrapper({ maximized = false } = {}) {
   global.XWiki = {
     contextPath: "",
   };
 
   const changeLayout = spy();
+  const isMaximized = ref(maximized);
+  const toggleMaximized = spy(() => {
+    isMaximized.value = !isMaximized.value;
+  });
   const wrapper = mount(LivedataDropdownMenu, {
     global: {
       provide: {
@@ -48,7 +53,8 @@ function initWrapper() {
             },
           },
           changeLayout: changeLayout,
-          isMaximized: () => false,
+          isMaximized: () => isMaximized.value,
+          toggleMaximized: toggleMaximized,
         },
       },
       mocks: {
@@ -59,7 +65,7 @@ function initWrapper() {
       },
     },
   });
-  return { wrapper, changeLayout };
+  return { wrapper, changeLayout, toggleMaximized };
 }
 
 // Since the <li> elements does not have distinguishing attributes, we look for the layout items by
@@ -121,5 +127,30 @@ describe("LivedataDropdownMenu.vue", () => {
     expect(
       wrapper.find('[data-toggle="dropdown"]').attributes("aria-expanded"),
     ).toBe("false");
+  });
+
+  it("Offers to maximize the Live Data when it is not maximized", () => {
+    const { wrapper } = initWrapper();
+    expect(wrapper.find(".livedata-action-maximize").text()).toBe(
+      "livedata.action.maximize",
+    );
+  });
+
+  it("Offers to minimize the Live Data when it is maximized", () => {
+    const { wrapper } = initWrapper({ maximized: true });
+    expect(wrapper.find(".livedata-action-maximize").text()).toBe(
+      "livedata.action.minimize",
+    );
+  });
+
+  it("Clicking on the maximize action switches to the maximized view", async () => {
+    const { wrapper, toggleMaximized } = initWrapper();
+
+    await wrapper.find(".livedata-action-maximize").trigger("click");
+
+    expect(toggleMaximized.callCount).toBe(1);
+    expect(wrapper.find(".livedata-action-maximize").text()).toBe(
+      "livedata.action.minimize",
+    );
   });
 });

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataDropdownMenu.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataDropdownMenu.vue
@@ -60,15 +60,24 @@
               {{ $t("livedata.action.refresh") }}
             </a>
           </li>
-          <!-- Edit mode toggle. -->
-          <li class="livedata-action-edit-mode" v-show="logic.hasEditMode()">
-            <a href="#" @click.stop.prevent="toggleEditMode">
-              <input
-                type="checkbox"
-                :checked="isEditMode"
-                @click.stop="toggleEditMode"
+          <!-- Maximized view, which displays the Live Data on its own, over the rest of the
+          page. -->
+          <li>
+            <a
+              href="#"
+              @click.prevent="logic.toggleMaximized()"
+              class="livedata-action-maximize"
+            >
+              <XWikiIcon
+                :icon-descriptor="{
+                  name: isMaximized ? 'arrow_in' : 'arrow_out',
+                }"
               />
-              {{ $t("livedata.action.editMode") }}
+              {{
+                isMaximized
+                  ? $t("livedata.action.minimize")
+                  : $t("livedata.action.maximize")
+              }}
             </a>
           </li>
         </ul>
@@ -131,20 +140,12 @@ export default {
 
   inject: ["logic"],
 
-  data() {
-    return {
-      isEditMode: false,
-    };
-  },
-
-  async beforeUnmount() {
-    this.logic.disableEditMode();
-    await this.logic.updateEntries();
-  },
-
   computed: {
     data() {
       return this.logic.data;
+    },
+    isMaximized() {
+      return this.logic.isMaximized();
     },
   },
 
@@ -156,20 +157,6 @@ export default {
       if (!this.isCurrentLayout(layoutId)) {
         this.logic.changeLayout(layoutId);
       }
-    },
-    toggleEditMode() {
-      this.isEditMode = !this.isEditMode;
-    },
-  },
-
-  watch: {
-    async isEditMode(value) {
-      if (value) {
-        this.logic.enableEditMode();
-      } else {
-        this.logic.disableEditMode();
-      }
-      await this.logic.updateEntries();
     },
   },
 };
@@ -224,15 +211,6 @@ export default {
 
   li:has(> ul):has(+ li > ul) {
     margin-bottom: calc(0.5lh - 1px);
-  }
-}
-
-#xwikicontent ul li.livedata-action-edit-mode {
-  a {
-    text-decoration: none;
-  }
-  a:hover {
-    text-decoration: underline;
   }
 }
 </style>

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataDropdownMenu.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataDropdownMenu.vue
@@ -70,7 +70,7 @@
             >
               <XWikiIcon
                 :icon-descriptor="{
-                  name: isMaximized ? 'arrow_in' : 'arrow_out',
+                  name: isMaximized ? 'compress' : 'expand',
                 }"
               />
               {{
@@ -164,32 +164,11 @@ export default {
 
 <style>
 .livedata-dropdown-menu {
-  /* Similar to .flat-buttons() */
-  .btn-default {
-    background-color: var(--breadcrumb-bg);
-    background-image: none;
-    border-color: var(--dropdown-divider-bg);
-    box-shadow: none;
-    color: var(--dropdown-link-color);
-    text-shadow: none;
-  }
-
-  .btn-default:hover,
-  .btn-default:active,
-  .btn-default:focus,
-  .open .dropdown-toggle {
-    border-color: hsl(from var(--dropdown-divider-bg) h s calc(l - 0.1));
-  }
-
   /* Style each section of the dropdown */
   ul.dropdown-menu > li > ul {
     list-style: none;
     padding-left: 0;
   }
-}
-
-.livedata-dropdown-menu .btn-default span {
-  vertical-align: middle;
 }
 
 /*

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataDropdownMenu.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataDropdownMenu.vue
@@ -70,7 +70,7 @@
             >
               <XWikiIcon
                 :icon-descriptor="{
-                  name: isMaximized ? 'compress' : 'expand',
+                  name: isMaximized ? 'minimize' : 'maximize',
                 }"
               />
               {{

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataEditButton.test.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataEditButton.test.js
@@ -1,0 +1,126 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import LivedataEditButton from "./LivedataEditButton.vue";
+import { mount } from "@vue/test-utils";
+import flushPromises from "flush-promises";
+import { spy } from "sinon";
+import { describe, expect, it } from "vitest";
+import { ref } from "vue";
+
+/**
+ * Vue component initializer for `LivedataEditButton` components. Calls `mount()` with preconfigured
+ * values.
+ *
+ * @param editMode - whether the Live Data starts in edit mode
+ * @returns a map containing a wrapper for `LivedataEditButton` components and a mock of the logic
+ */
+function initWrapper({ editMode = false } = {}) {
+  global.XWiki = {
+    contextPath: "",
+  };
+
+  const isEditMode = ref(editMode);
+  const logic = {
+    isEditMode: () => isEditMode.value,
+    enableEditMode: spy(() => {
+      isEditMode.value = true;
+    }),
+    disableEditMode: spy(() => {
+      isEditMode.value = false;
+    }),
+    updateEntries: spy(() => Promise.resolve()),
+  };
+
+  const wrapper = mount(LivedataEditButton, {
+    global: {
+      provide: {
+        logic,
+      },
+      mocks: {
+        $t: (key) => key,
+      },
+      stubs: {
+        XWikiIcon: true,
+      },
+    },
+  });
+  return { wrapper, logic };
+}
+
+describe("LivedataEditButton.vue", () => {
+  it("Is labelled and not pressed by default", () => {
+    const { wrapper } = initWrapper();
+    const button = wrapper.find("button");
+
+    expect(button.attributes("title")).toBe("livedata.action.editMode");
+    expect(button.attributes("aria-label")).toBe("livedata.action.editMode");
+    expect(button.attributes("aria-pressed")).toBe("false");
+    expect(button.classes()).not.toContain("active");
+  });
+
+  it("Is pressed when the Live Data is in edit mode", () => {
+    const { wrapper } = initWrapper({ editMode: true });
+    const button = wrapper.find("button");
+
+    expect(button.attributes("aria-pressed")).toBe("true");
+    expect(button.classes()).toContain("active");
+  });
+
+  it("Enables the edit mode on click and refreshes the entries", async () => {
+    const { wrapper, logic } = initWrapper();
+
+    await wrapper.find("button").trigger("click");
+    await flushPromises();
+
+    expect(logic.enableEditMode.callCount).toBe(1);
+    expect(logic.disableEditMode.callCount).toBe(0);
+    expect(logic.updateEntries.callCount).toBe(1);
+
+    const button = wrapper.find("button");
+    expect(button.attributes("aria-pressed")).toBe("true");
+    expect(button.classes()).toContain("active");
+  });
+
+  it("Disables the edit mode on click when it is already enabled", async () => {
+    const { wrapper, logic } = initWrapper({ editMode: true });
+
+    await wrapper.find("button").trigger("click");
+    await flushPromises();
+
+    expect(logic.disableEditMode.callCount).toBe(1);
+    expect(logic.enableEditMode.callCount).toBe(0);
+    expect(logic.updateEntries.callCount).toBe(1);
+
+    const button = wrapper.find("button");
+    expect(button.attributes("aria-pressed")).toBe("false");
+    expect(button.classes()).not.toContain("active");
+  });
+
+  it("Disables the edit mode when unmounted", async () => {
+    const { wrapper, logic } = initWrapper({ editMode: true });
+
+    wrapper.unmount();
+    await flushPromises();
+
+    expect(logic.disableEditMode.callCount).toBe(1);
+    expect(logic.updateEntries.callCount).toBe(1);
+  });
+});

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataEditButton.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataEditButton.vue
@@ -1,0 +1,108 @@
+<!--
+  See the NOTICE file distributed with this work for additional
+  information regarding copyright ownership.
+
+  This is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation; either version 2.1 of
+  the License, or (at your option) any later version.
+
+  This software is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this software; if not, write to the Free
+  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<!--
+  LivedataEditButton is used to toggle edit mode n and off, for the sources that support it.
+  It should be placed in the top bar, next to the dropdown menu.
+-->
+<template>
+  <button
+    v-if="logic.hasEditMode()"
+    type="button"
+    class="btn btn-default livedata-edit-button"
+    :class="{ active: isEditMode }"
+    :title="$t('livedata.action.editMode')"
+    :aria-label="$t('livedata.action.editMode')"
+    :aria-pressed="isEditMode"
+    @click="toggleEditMode"
+  >
+    <XWikiIcon :icon-descriptor="{ name: 'pencil' }" />
+  </button>
+</template>
+
+<script>
+import XWikiIcon from "./utilities/XWikiIcon.vue";
+
+export default {
+  name: "LivedataEditButton",
+
+  components: {
+    XWikiIcon,
+  },
+
+  inject: ["logic"],
+
+  // We disable edit mode on unmount to reset properties to view mode.
+  async beforeUnmount() {
+    this.logic.disableEditMode();
+    await this.logic.updateEntries();
+  },
+
+  computed: {
+    isEditMode() {
+      return this.logic.isEditMode();
+    },
+  },
+
+  methods: {
+    async toggleEditMode() {
+      if (this.logic.isEditMode()) {
+        this.logic.disableEditMode();
+      } else {
+        this.logic.enableEditMode();
+      }
+      // The entries are re-fetched because the edit mode changes the set of displayed properties.
+      await this.logic.updateEntries();
+    },
+  },
+};
+</script>
+
+<style>
+.livedata-edit-button.btn-default {
+  /* The same flat look as the dropdown menu button. */
+  background-color: var(--breadcrumb-bg);
+  background-image: none;
+  border-color: var(--dropdown-divider-bg);
+  box-shadow: none;
+  color: var(--dropdown-link-color);
+  margin-left: 1rem;
+  text-shadow: none;
+}
+
+.livedata-edit-button.btn-default:hover,
+.livedata-edit-button.btn-default:active,
+.livedata-edit-button.btn-default:focus {
+  border-color: hsl(from var(--dropdown-divider-bg) h s calc(l - 0.1));
+}
+
+/*
+ * The edit mode is a state the user stays in, so the button has to look pressed when it's on.
+ */
+.livedata-edit-button.btn-default.active {
+  background-color: var(--btn-primary-bg);
+  border-color: var(--btn-primary-border, var(--btn-primary-bg));
+  color: var(--btn-primary-color);
+}
+
+.livedata-edit-button span {
+  vertical-align: middle;
+}
+</style>

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataEditButton.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/LivedataEditButton.vue
@@ -19,12 +19,11 @@
 -->
 
 <!--
-  LivedataEditButton is used to toggle edit mode n and off, for the sources that support it.
-  It should be placed in the top bar, next to the dropdown menu.
+  LivedataEditButton is used to toggle edit mode on and off, for the sources that support it.
+  It should be placed in the actions area.
 -->
 <template>
   <button
-    v-if="logic.hasEditMode()"
     type="button"
     class="btn btn-default livedata-edit-button"
     :class="{ active: isEditMode }"
@@ -76,33 +75,12 @@ export default {
 </script>
 
 <style>
-.livedata-edit-button.btn-default {
-  /* The same flat look as the dropdown menu button. */
-  background-color: var(--breadcrumb-bg);
-  background-image: none;
-  border-color: var(--dropdown-divider-bg);
-  box-shadow: none;
-  color: var(--dropdown-link-color);
-  margin-left: 1rem;
-  text-shadow: none;
-}
-
-.livedata-edit-button.btn-default:hover,
-.livedata-edit-button.btn-default:active,
-.livedata-edit-button.btn-default:focus {
-  border-color: hsl(from var(--dropdown-divider-bg) h s calc(l - 0.1));
-}
-
 /*
  * The edit mode is a state the user stays in, so the button has to look pressed when it's on.
  */
 .livedata-edit-button.btn-default.active {
   background-color: var(--btn-primary-bg);
-  border-color: var(--btn-primary-border, var(--btn-primary-bg));
+  border-color: var(--btn-primary-bg);
   color: var(--btn-primary-color);
-}
-
-.livedata-edit-button span {
-  vertical-align: middle;
 }
 </style>

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/XWikiLivedata.test.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/XWikiLivedata.test.js
@@ -68,16 +68,20 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  // The tests mounting in the document leave their elements behind otherwise.
+  document.body.innerHTML = "";
 });
 
 /**
  * Vue component initializer for `XWikiLivedata` components. Calls `mount()` with preconfigured
  * values.
  *
+ * @param attachTo - an optional element to mount the component into, needed by the tests
+ *   looking at the elements surrounding the Live Data
  * @returns a map containing a wrapper for `XWikiLivedata` components and the logic instance it
  *   created
  */
-function initWrapper() {
+function initWrapper(attachTo) {
   global.XWiki = {
     contextPath: "",
   };
@@ -111,6 +115,7 @@ function initWrapper() {
   });
 
   const wrapper = mount(XWikiLivedata, {
+    attachTo,
     props: {
       liveDataSource: {},
       data: JSON.stringify(data),
@@ -143,6 +148,17 @@ function initWrapper() {
 async function pressKey(key) {
   document.dispatchEvent(new KeyboardEvent("keydown", { key }));
   await nextTick();
+}
+
+/**
+ * Mounts a Live Data in the document, next to an element standing for the rest of the page.
+ *
+ * @returns the result of `initWrapper()`, plus the element displayed next to the Live Data
+ */
+function initWrapperWithSibling() {
+  const sibling = document.createElement("div");
+  document.body.appendChild(sibling);
+  return { sibling, ...initWrapper(document.body) };
 }
 
 describe("XWikiLivedata.vue", () => {
@@ -217,6 +233,48 @@ describe("XWikiLivedata.vue", () => {
     await pressKey("Escape");
 
     expect(logic.isMaximized()).toBe(true);
+  });
+
+  it("Makes the rest of the page inert while maximized", async () => {
+    const { sibling, getLogic } = initWrapperWithSibling();
+    await flushPromises();
+
+    expect(sibling.hasAttribute("inert")).toBe(false);
+
+    getLogic().toggleMaximized();
+    await nextTick();
+    expect(sibling.hasAttribute("inert")).toBe(true);
+
+    getLogic().toggleMaximized();
+    await nextTick();
+    expect(sibling.hasAttribute("inert")).toBe(false);
+  });
+
+  it("Leaves the rest of the page inert as it found it", async () => {
+    const { sibling, getLogic } = initWrapperWithSibling();
+    sibling.setAttribute("inert", "");
+    await flushPromises();
+
+    getLogic().toggleMaximized();
+    await nextTick();
+    getLogic().toggleMaximized();
+    await nextTick();
+
+    // The element was inert before the Live Data was maximized, so it stays inert.
+    expect(sibling.hasAttribute("inert")).toBe(true);
+  });
+
+  it("Restores the rest of the page when unmounted while maximized", async () => {
+    const { wrapper, sibling, getLogic } = initWrapperWithSibling();
+    await flushPromises();
+
+    getLogic().toggleMaximized();
+    await nextTick();
+    expect(sibling.hasAttribute("inert")).toBe(true);
+
+    wrapper.unmount();
+
+    expect(sibling.hasAttribute("inert")).toBe(false);
   });
 
   it("Escape only exits the maximized Live Data when several are displayed", async () => {

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/XWikiLivedata.test.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/XWikiLivedata.test.js
@@ -1,0 +1,238 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import XWikiLivedata from "./XWikiLivedata.vue";
+import { mount } from "@vue/test-utils";
+import flushPromises from "flush-promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+
+// The logic resolves its translations through vue-i18n, which requires an active Vue application.
+// The maximized view does not depend on the translations, so a pass-through is enough.
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key) => key }),
+}));
+
+const MAXIMIZED_CLASS = "livedata-maximized";
+
+// The escape key is listened to on the document, because the focus can be on any element of the
+// maximized Live Data. We count those listeners to check that they are only registered while
+// maximized.
+let keydownListeners;
+
+/**
+ * @returns the number of keydown listeners currently registered on the document
+ */
+function countKeydownListeners() {
+  return keydownListeners;
+}
+
+beforeEach(() => {
+  keydownListeners = 0;
+  const addEventListener = document.addEventListener.bind(document);
+  const removeEventListener = document.removeEventListener.bind(document);
+  vi.spyOn(document, "addEventListener").mockImplementation(
+    (type, ...parameters) => {
+      if (type === "keydown") {
+        keydownListeners++;
+      }
+      addEventListener(type, ...parameters);
+    },
+  );
+  vi.spyOn(document, "removeEventListener").mockImplementation(
+    (type, ...parameters) => {
+      if (type === "keydown") {
+        keydownListeners--;
+      }
+      removeEventListener(type, ...parameters);
+    },
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/**
+ * Vue component initializer for `XWikiLivedata` components. Calls `mount()` with preconfigured
+ * values.
+ *
+ * @returns a map containing a wrapper for `XWikiLivedata` components and the logic instance it
+ *   created
+ */
+function initWrapper() {
+  global.XWiki = {
+    contextPath: "",
+  };
+
+  const data = {
+    id: 0,
+    query: {
+      source: { id: "liveTable" },
+      properties: [],
+    },
+    meta: {
+      defaultLayout: "table",
+      layouts: [{ id: "table" }],
+      propertyDescriptors: [],
+      propertyTypes: [],
+      selection: { enabled: false },
+    },
+    // A non-empty list of entries prevents the component from fetching them on mount.
+    data: { count: 1, entries: [{}] },
+  };
+
+  let logic;
+  // The component registers the logic on the parent of its root element through jQuery. We reuse
+  // that registration to access the logic instance, the same way the public API does.
+  const jQuery = () => ({
+    parent: () => ({
+      data: (key, value) => {
+        logic = value;
+      },
+    }),
+  });
+
+  const wrapper = mount(XWikiLivedata, {
+    props: {
+      liveDataSource: {},
+      data: JSON.stringify(data),
+      contentTrusted: true,
+      locale: "en",
+      i18n: {},
+      resolveTranslations: async () => ({}),
+    },
+    global: {
+      provide: {
+        jQuery,
+      },
+      stubs: {
+        LivedataAdvancedPanels: true,
+        LivedataFootnotes: true,
+        LivedataLayout: true,
+        LivedataPersistentConfiguration: true,
+      },
+    },
+  });
+
+  return { wrapper, getLogic: () => logic };
+}
+
+/**
+ * Presses a key on the document, where the maximized view listens for the escape key.
+ *
+ * @param key - the key to press
+ */
+async function pressKey(key) {
+  document.dispatchEvent(new KeyboardEvent("keydown", { key }));
+  await nextTick();
+}
+
+describe("XWikiLivedata.vue", () => {
+  it("Is not maximized by default", async () => {
+    const { wrapper } = initWrapper();
+    await flushPromises();
+
+    expect(wrapper.classes()).not.toContain(MAXIMIZED_CLASS);
+  });
+
+  it("Covers the page once maximized", async () => {
+    const { wrapper, getLogic } = initWrapper();
+    await flushPromises();
+
+    getLogic().toggleMaximized();
+    await nextTick();
+
+    expect(wrapper.classes()).toContain(MAXIMIZED_CLASS);
+  });
+
+  it("Escape exits the maximized view", async () => {
+    const { wrapper, getLogic } = initWrapper();
+    await flushPromises();
+
+    getLogic().toggleMaximized();
+    await nextTick();
+
+    await pressKey("Escape");
+
+    expect(getLogic().isMaximized()).toBe(false);
+    expect(wrapper.classes()).not.toContain(MAXIMIZED_CLASS);
+  });
+
+  it("Keys other than escape don't exit the maximized view", async () => {
+    const { wrapper, getLogic } = initWrapper();
+    await flushPromises();
+
+    getLogic().toggleMaximized();
+    await nextTick();
+
+    await pressKey("Enter");
+
+    expect(wrapper.classes()).toContain(MAXIMIZED_CLASS);
+  });
+
+  it("Only listens to the document while maximized", async () => {
+    const { getLogic } = initWrapper();
+    await flushPromises();
+
+    expect(countKeydownListeners()).toBe(0);
+
+    getLogic().toggleMaximized();
+    await nextTick();
+    expect(countKeydownListeners()).toBe(1);
+
+    getLogic().toggleMaximized();
+    await nextTick();
+    expect(countKeydownListeners()).toBe(0);
+  });
+
+  it("Stops listening to escape once unmounted", async () => {
+    const { wrapper, getLogic } = initWrapper();
+    await flushPromises();
+
+    const logic = getLogic();
+    logic.toggleMaximized();
+    await nextTick();
+
+    wrapper.unmount();
+    expect(countKeydownListeners()).toBe(0);
+
+    await pressKey("Escape");
+
+    expect(logic.isMaximized()).toBe(true);
+  });
+
+  it("Escape only exits the maximized Live Data when several are displayed", async () => {
+    const first = initWrapper();
+    const second = initWrapper();
+    await flushPromises();
+
+    second.getLogic().toggleMaximized();
+    await nextTick();
+    // Only the maximized Live Data listens to the document.
+    expect(countKeydownListeners()).toBe(1);
+
+    await pressKey("Escape");
+
+    expect(second.getLogic().isMaximized()).toBe(false);
+    expect(first.getLogic().isMaximized()).toBe(false);
+    expect(first.wrapper.classes()).not.toContain(MAXIMIZED_CLASS);
+  });
+});

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/XWikiLivedata.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/XWikiLivedata.vue
@@ -193,7 +193,7 @@ onMounted(async () => {
   position: fixed;
   inset: 0;
   /*
-   * We use the same z-index az the gallery application, which maximizes the same way.
+   * We use the same z-index as the gallery application, which maximizes the same way.
    */
   z-index: 1001;
   overflow: auto;

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/XWikiLivedata.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/XWikiLivedata.vue
@@ -38,6 +38,7 @@ import {
   inject,
   nextTick,
   onMounted,
+  onUnmounted,
   provide,
   ref,
   useTemplateRef,
@@ -74,6 +75,17 @@ const translationsLoaded = ref(false);
 
 const dataId = computed(() => logic.data?.id);
 const layoutId = computed(() => logic.currentLayoutId?.value);
+const maximized = computed(() => logic.isMaximized());
+
+function onKeydown(event: KeyboardEvent) {
+  // Escape should allow to exit maximized mode.
+  if (event.key === "Escape" && logic.isMaximized()) {
+    logic.toggleMaximized();
+  }
+}
+
+onMounted(() => document.addEventListener("keydown", onKeydown));
+onUnmounted(() => document.removeEventListener("keydown", onKeydown));
 
 // eslint-disable-next-line max-statements
 onMounted(async () => {
@@ -144,7 +156,11 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="xwiki-livedata" ref="rootElement">
+  <div
+    class="xwiki-livedata"
+    :class="{ 'livedata-maximized': maximized }"
+    ref="rootElement"
+  >
     <!-- Import the Livedata advanced configuration panels -->
     <LivedataAdvancedPanels />
 
@@ -161,3 +177,14 @@ onMounted(async () => {
     <div v-if="!layoutLoaded" class="loading"></div>
   </div>
 </template>
+
+<style>
+.xwiki-livedata.livedata-maximized {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  overflow: auto;
+  padding: 0 var(--padding-large-horizontal, 1rem);
+  background-color: var(--body-bg, #fff);
+}
+</style>

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/XWikiLivedata.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/XWikiLivedata.vue
@@ -42,6 +42,7 @@ import {
   provide,
   ref,
   useTemplateRef,
+  watch,
 } from "vue";
 import type { LiveDataSource, Logic } from "@xwiki/platform-livedata-api";
 import type { Query, Translations } from "@xwiki/platform-localization-api";
@@ -77,15 +78,24 @@ const dataId = computed(() => logic.data?.id);
 const layoutId = computed(() => logic.currentLayoutId?.value);
 const maximized = computed(() => logic.isMaximized());
 
-function onKeydown(event: KeyboardEvent) {
-  // Escape should allow to exit maximized mode.
-  if (event.key === "Escape" && logic.isMaximized()) {
+// Escape should allow to exit maximized mode,
+// unless it's already handled by another component (e.g., editor).
+function onEscape(event: KeyboardEvent) {
+  if (event.key === "Escape" && maximized.value) {
     logic.toggleMaximized();
   }
 }
 
-onMounted(() => document.addEventListener("keydown", onKeydown));
-onUnmounted(() => document.removeEventListener("keydown", onKeydown));
+// We only set the escape listener when we're actually in maximized mode.
+watch(maximized, (isMaximized) => {
+  if (isMaximized) {
+    document.addEventListener("keydown", onEscape);
+  } else {
+    document.removeEventListener("keydown", onEscape);
+  }
+});
+
+onUnmounted(() => document.removeEventListener("keydown", onEscape));
 
 // eslint-disable-next-line max-statements
 onMounted(async () => {
@@ -182,9 +192,12 @@ onMounted(async () => {
 .xwiki-livedata.livedata-maximized {
   position: fixed;
   inset: 0;
-  z-index: 1000;
+  /*
+   * We use the same z-index az the gallery application, which maximizes the same way.
+   */
+  z-index: 1001;
   overflow: auto;
-  padding: 0 var(--padding-large-horizontal, 1rem);
-  background-color: var(--body-bg, #fff);
+  padding: 0 var(--grid-gutter-width);
+  background-color: var(--body-bg);
 }
 </style>

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/XWikiLivedata.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/XWikiLivedata.vue
@@ -86,8 +86,38 @@ function onEscape(event: KeyboardEvent) {
   }
 }
 
+// The elements we made inert, so that only those are restored afterwards. An element already
+// inert before the Live Data was maximized must stay inert once the normal view is back.
+let inertElements: Element[] = [];
+
+// The maximized view is painted over the page, so the content it hides must not stay reachable
+// with the keyboard nor exposed to assistive technologies. Everything becomes inert except the
+// ancestors of the Live Data, which are the only path leading to it.
+function setPageInert(inert: boolean) {
+  if (inert) {
+    for (
+      let node = element.value as Element | null;
+      node && node !== document.body && node.parentElement;
+      node = node.parentElement
+    ) {
+      for (const sibling of Array.from(node.parentElement.children)) {
+        if (sibling !== node && !sibling.hasAttribute("inert")) {
+          sibling.setAttribute("inert", "");
+          inertElements.push(sibling);
+        }
+      }
+    }
+  } else {
+    for (const inertElement of inertElements) {
+      inertElement.removeAttribute("inert");
+    }
+    inertElements = [];
+  }
+}
+
 // We only set the escape listener when we're actually in maximized mode.
 watch(maximized, (isMaximized) => {
+  setPageInert(isMaximized);
   if (isMaximized) {
     document.addEventListener("keydown", onEscape);
   } else {
@@ -95,7 +125,12 @@ watch(maximized, (isMaximized) => {
   }
 });
 
-onUnmounted(() => document.removeEventListener("keydown", onEscape));
+// Unmounting while maximized removes the view without toggling it back, so the rest of the page
+// must be restored here too.
+onUnmounted(() => {
+  document.removeEventListener("keydown", onEscape);
+  setPageInert(false);
+});
 
 // eslint-disable-next-line max-statements
 onMounted(async () => {

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/displayers/BaseDisplayer.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/displayers/BaseDisplayer.vue
@@ -87,7 +87,7 @@
 
       <!-- The slot containing the displayer Editor widget -->
       <div
-        @keydown.esc.capture="cancelEdit"
+        @keydown.esc.capture.stop="cancelEdit"
         @focusin="editorFocused = true"
         v-if="!isView && !isLoading"
         ref="editBlock"

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/cards/LayoutCards.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/cards/LayoutCards.vue
@@ -39,8 +39,7 @@
       <template #right>
         <LivedataPagination side="right" />
         <LivedataEntrySelectorAll v-if="isSelectionEnabled" />
-        <LivedataEditButton />
-        <LivedataDropdownMenu />
+        <LivedataActions />
       </template>
     </LivedataTopbar>
 
@@ -82,9 +81,8 @@
 <script>
 import LayoutCardsCard from "./LayoutCardsCard.vue";
 import LayoutCardsNewCard from "./LayoutCardsNewCard.vue";
+import LivedataActions from "../../LivedataActions.vue";
 import LivedataBottombar from "../../LivedataBottombar.vue";
-import LivedataDropdownMenu from "../../LivedataDropdownMenu.vue";
-import LivedataEditButton from "../../LivedataEditButton.vue";
 import LivedataEntrySelectorAll from "../../LivedataEntrySelectorAll.vue";
 import LivedataEntrySelectorInfoBar from "../../LivedataEntrySelectorInfoBar.vue";
 import LivedataPagination from "../../LivedataPagination.vue";
@@ -95,10 +93,9 @@ export default {
   name: "layout-cards",
 
   components: {
+    LivedataActions,
     LivedataBottombar,
     LivedataTopbar,
-    LivedataDropdownMenu,
-    LivedataEditButton,
     LivedataEntrySelectorAll,
     LivedataPagination,
     LivedataEntrySelectorInfoBar,

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/cards/LayoutCards.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/cards/LayoutCards.vue
@@ -39,6 +39,7 @@
       <template #right>
         <LivedataPagination side="right" />
         <LivedataEntrySelectorAll v-if="isSelectionEnabled" />
+        <LivedataEditButton />
         <LivedataDropdownMenu />
       </template>
     </LivedataTopbar>
@@ -83,6 +84,7 @@ import LayoutCardsCard from "./LayoutCardsCard.vue";
 import LayoutCardsNewCard from "./LayoutCardsNewCard.vue";
 import LivedataBottombar from "../../LivedataBottombar.vue";
 import LivedataDropdownMenu from "../../LivedataDropdownMenu.vue";
+import LivedataEditButton from "../../LivedataEditButton.vue";
 import LivedataEntrySelectorAll from "../../LivedataEntrySelectorAll.vue";
 import LivedataEntrySelectorInfoBar from "../../LivedataEntrySelectorInfoBar.vue";
 import LivedataPagination from "../../LivedataPagination.vue";
@@ -96,6 +98,7 @@ export default {
     LivedataBottombar,
     LivedataTopbar,
     LivedataDropdownMenu,
+    LivedataEditButton,
     LivedataEntrySelectorAll,
     LivedataPagination,
     LivedataEntrySelectorInfoBar,

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/table/LayoutTable.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/table/LayoutTable.vue
@@ -41,6 +41,7 @@
       </template>
       <template #right>
         <LivedataPagination side="right" />
+        <LivedataEditButton />
         <LivedataDropdownMenu />
       </template>
     </LivedataTopbar>
@@ -105,6 +106,7 @@ import LayoutTableNewRow from "./LayoutTableNewRow.vue";
 import LayoutTableRow from "./LayoutTableRow.vue";
 import LivedataBottombar from "../../LivedataBottombar.vue";
 import LivedataDropdownMenu from "../../LivedataDropdownMenu.vue";
+import LivedataEditButton from "../../LivedataEditButton.vue";
 import LivedataEntrySelectorInfoBar from "../../LivedataEntrySelectorInfoBar.vue";
 import LivedataPagination from "../../LivedataPagination.vue";
 import LivedataTopbar from "../../LivedataTopbar.vue";
@@ -117,6 +119,7 @@ export default {
     LivedataBottombar,
     LivedataTopbar,
     LivedataDropdownMenu,
+    LivedataEditButton,
     LivedataPagination,
     LivedataEntrySelectorInfoBar,
     LayoutTableHeaderNames,

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/table/LayoutTable.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/table/LayoutTable.vue
@@ -41,8 +41,7 @@
       </template>
       <template #right>
         <LivedataPagination side="right" />
-        <LivedataEditButton />
-        <LivedataDropdownMenu />
+        <LivedataActions />
       </template>
     </LivedataTopbar>
 
@@ -104,9 +103,8 @@ import LayoutTableHeaderFilters from "./LayoutTableHeaderFilters.vue";
 import LayoutTableHeaderNames from "./LayoutTableHeaderNames.vue";
 import LayoutTableNewRow from "./LayoutTableNewRow.vue";
 import LayoutTableRow from "./LayoutTableRow.vue";
+import LivedataActions from "../../LivedataActions.vue";
 import LivedataBottombar from "../../LivedataBottombar.vue";
-import LivedataDropdownMenu from "../../LivedataDropdownMenu.vue";
-import LivedataEditButton from "../../LivedataEditButton.vue";
 import LivedataEntrySelectorInfoBar from "../../LivedataEntrySelectorInfoBar.vue";
 import LivedataPagination from "../../LivedataPagination.vue";
 import LivedataTopbar from "../../LivedataTopbar.vue";
@@ -116,10 +114,9 @@ export default {
   name: "layout-table",
 
   components: {
+    LivedataActions,
     LivedataBottombar,
     LivedataTopbar,
-    LivedataDropdownMenu,
-    LivedataEditButton,
     LivedataPagination,
     LivedataEntrySelectorInfoBar,
     LayoutTableHeaderNames,

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/table/LayoutTableHeaderNames.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/table/LayoutTableHeaderNames.vue
@@ -101,7 +101,7 @@
           @keydown.left="keyboardResizeColumn($event, -10)"
           @keydown.right="keyboardResizeColumn($event, 10)"
           @dblclick="resetColumnSize"
-          @keydown.esc="resetColumnSize"
+          @keydown.esc.stop="resetColumnSize"
         ></button>
       </th>
     </template>

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/services/LiveDataLogic.test.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/services/LiveDataLogic.test.ts
@@ -1,0 +1,119 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import { LiveDataLogic } from "./LiveDataLogic";
+import { describe, expect, it, vi } from "vitest";
+import { computed } from "vue";
+import type { LiveDataSource } from "@xwiki/platform-livedata-api";
+
+// The logic resolves its translations through vue-i18n, which requires an active Vue application.
+// The state tested here does not depend on the translations, so a pass-through is enough.
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+/**
+ * @param sourceParameters - the parameters to set on the source of the query
+ * @returns a logic instance operating on a minimal Live Data configuration
+ */
+function initLogic(sourceParameters: Record<string, string> = {}) {
+  const data = {
+    id: 0,
+    query: {
+      source: { id: "liveTable", ...sourceParameters },
+    },
+    meta: {
+      defaultLayout: "table",
+      layouts: [{ id: "table" }, { id: "cards" }],
+    },
+    data: { count: 0, entries: [] },
+  };
+  return new LiveDataLogic(
+    {} as LiveDataSource,
+    JSON.stringify(data),
+    true,
+    async () => ({}),
+  );
+}
+
+describe("LiveDataLogic.ts", () => {
+  describe("maximized state", () => {
+    it("Is not maximized by default", () => {
+      expect(initLogic().isMaximized()).toBe(false);
+    });
+
+    it("Switches back and forth between maximized and normal", () => {
+      const logic = initLogic();
+
+      logic.toggleMaximized();
+      expect(logic.isMaximized()).toBe(true);
+
+      logic.toggleMaximized();
+      expect(logic.isMaximized()).toBe(false);
+    });
+
+    it("Exposes the maximized state reactively", () => {
+      const logic = initLogic();
+      const maximized = computed(() => logic.isMaximized());
+
+      expect(maximized.value).toBe(false);
+
+      logic.toggleMaximized();
+
+      expect(maximized.value).toBe(true);
+    });
+  });
+
+  describe("edit mode", () => {
+    it("Has no edit mode when the source does not declare one", () => {
+      expect(initLogic().hasEditMode()).toBe(false);
+      expect(initLogic({ hasEditMode: "false" }).hasEditMode()).toBe(false);
+    });
+
+    it("Has an edit mode when the source declares one", () => {
+      expect(initLogic({ hasEditMode: "true" }).hasEditMode()).toBe(true);
+    });
+
+    it("Is not in edit mode by default", () => {
+      expect(initLogic({ hasEditMode: "true" }).isEditMode()).toBe(false);
+    });
+
+    it("Enables and disables the edit mode", () => {
+      const logic = initLogic({ hasEditMode: "true" });
+
+      logic.enableEditMode();
+      expect(logic.isEditMode()).toBe(true);
+
+      logic.disableEditMode();
+      expect(logic.isEditMode()).toBe(false);
+    });
+
+    it("Exposes the edit mode state reactively", () => {
+      const logic = initLogic({ hasEditMode: "true" });
+      const editMode = computed(() => logic.isEditMode());
+
+      expect(editMode.value).toBe(false);
+
+      logic.enableEditMode();
+
+      expect(editMode.value).toBe(true);
+    });
+  });
+});

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/services/LiveDataLogic.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/services/LiveDataLogic.ts
@@ -67,6 +67,8 @@ export class LiveDataLogic implements Logic {
 
   private editMode: Ref<boolean> = ref(false);
 
+  private maximized: Ref<boolean> = ref(false);
+
   constructor(
     private readonly liveDataSource: LiveDataSource,
     data: string,
@@ -1550,6 +1552,20 @@ export class LiveDataLogic implements Logic {
 
   hasEditMode(): boolean {
     return this.data.query.source.hasEditMode === "true";
+  }
+
+  /**
+   * @returns whether the Live Data should be maximized, covering the rest of the page
+   */
+  isMaximized(): boolean {
+    return this.maximized.value;
+  }
+
+  /**
+   * Switches between the maximized view and the normal one
+   */
+  toggleMaximized(): void {
+    this.maximized.value = !this.maximized.value;
   }
 
   // eslint-disable-next-line max-statements

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/services/i18nResolver.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/services/i18nResolver.ts
@@ -58,6 +58,8 @@ export async function i18nResolver(
       "action.columnName.sortable.hint",
       "action.columnName.default.hint",
       "action.editMode",
+      "action.maximize",
+      "action.minimize",
       "action.resizeColumn.hint",
       "table.entrySelector.hint",
       "panel.heading.actions.collapse.hint",

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/icons/default.iconset
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/icons/default.iconset
@@ -165,6 +165,10 @@ sort-descending = arrow_down
 ## Since 18.0.0RC1
 note = note
 
+## Since 18.8.0RC1
+maximize = arrow_out
+minimize = arrow_in
+
 ## Silk icons for backward compatibility (see: http://design.xwiki.org/xwiki/bin/view/Proposal/Silk+Mapping).
 accept = accept
 add = add


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-24729
Forum proposal: https://forum.xwiki.org/t/live-datas-edit-mode-ui-integration/18822/

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
This PR moves the edit mode toggle to a more accessible spot (left of the dropdown menu button) and also adds a maximized mode that can be toggles from the dropdown menu.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->
N/A

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
View mode with edit mode button:
<img width="1920" height="1080" alt="localhost_8080_xwiki_bin_view_Sandbox_TestPage1(Full Screen)" src="https://github.com/user-attachments/assets/e8689bfa-fe59-4101-8462-f1f53db217ff" />
Edit mode button toggled and dropdown menu opened:
<img width="1920" height="1080" alt="localhost_8080_xwiki_bin_view_Sandbox_TestPage1(Full Screen) (2)" src="https://github.com/user-attachments/assets/1be7b4a5-f134-4d06-8398-4c75281ec33d" />
Maximized mode toggled:
<img width="1920" height="1080" alt="localhost_8080_xwiki_bin_view_Sandbox_TestPage1(Full Screen) (3)" src="https://github.com/user-attachments/assets/65feb8c9-4b5b-4db9-a794-a026a570dd82" />

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Ran the existing test suite.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: N/A