### PR TITLE
XWIKI-24828: npm packages are published with the latest dist-tag even when released from a maintenance branch

### DIFF
--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/package.json
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/package.json
@@ -11,7 +11,7 @@
     "deploy": "node scripts/deploy.js",
     "lint": "npmPkgJsonLint \"./*/**\" && nx run-many -t lint --parallel=2 -p \"xwiki-platform-core/xwiki-platform-node/src/main/node/*/**\"",
     "publint": "pnpm --filter \"./**\" -r exec publint --pack pnpm --strict ",
-    "test:unit": "nx run-many -t test --parallel=2 -p \"xwiki-platform-core/xwiki-platform-node/src/main/node/*/**\""
+    "test:unit": "vitest --run && nx run-many -t test --parallel=2 -p \"xwiki-platform-core/xwiki-platform-node/src/main/node/*/**\""
   },
   "devDependencies": {
     "@microsoft/api-extractor": "catalog:",

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/scripts/deploy.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/scripts/deploy.js
@@ -23,6 +23,8 @@
 import fs from 'fs';
 import {execSync} from 'child_process';
 import path from 'path';
+import {computePublishTag, LATEST_TAG, planLatestMoves} from './lib/tags.js';
+import {addDistTag, distTagArguments, readDistTags, resolveNpmBinary} from './lib/registry.js';
 
 // Allow skipping the npm publication process. This is useful the case where the maven
 // release failed after the npm publication process passed successfully as we want to
@@ -31,10 +33,16 @@ if (process.env.SKIP_NPM_PUBLICATION === "true") {
   process.exit(0);
 }
 
+// Print the publication commands instead of running them, to review what a release would do. The
+// registry is still read, so that the printed plan is the one that would really be applied.
+const dryRun = process.env.DEPLOY_DRY_RUN === "true";
+
 /**
  * Script to conditionally publish npm packages based on version type (SNAPSHOT vs release)
  * Step 1: Updates all package.json files with the same timestamp
  * Step 2: Uses pnpm -r publish to publish all packages
+ * Step 3: For a release, moves the "latest" dist-tag to the published version, but only for the
+ *         packages where it points to an older version
  * Usage: node publish-package.js <snapshot-registry> <release-registry> [base-directory]
  */
 
@@ -80,12 +88,14 @@ function findPackageJsonFiles(dir, fileList = []) {
  * @param {string} packageJsonPath - Path to package.json
  * @param {Object} packageJson - Parsed package.json content
  * @param {string} timestamp - Timestamp to replace SNAPSHOT with
- * @returns {Object} - {success, originalVersion, newVersion, packageName, isSnapshot}
+ * @returns {Object} - {success, originalVersion, newVersion, packageName, isSnapshot, isPrivate}
  */
 function updatePackageVersion(packageJsonPath, packageJson, timestamp) {
   const originalVersion = packageJson.version;
   const packageName = packageJson.name;
   const isSnapshot = originalVersion.includes('SNAPSHOT');
+  // A private package is never sent to a registry by "pnpm publish".
+  const isPrivate = packageJson.private === true;
 
   if (isSnapshot) {
     // Replace SNAPSHOT with timestamp
@@ -94,12 +104,12 @@ function updatePackageVersion(packageJsonPath, packageJson, timestamp) {
 
     try {
       fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
-      return { success: true, originalVersion, newVersion, packageName, isSnapshot: true };
+      return { success: true, originalVersion, newVersion, packageName, isSnapshot: true, isPrivate };
     } catch (error) {
       return { success: false };
     }
   } else {
-    return { success: true, originalVersion, newVersion: originalVersion, packageName, isSnapshot: false };
+    return { success: true, originalVersion, newVersion: originalVersion, packageName, isSnapshot: false, isPrivate };
   }
 }
 
@@ -119,6 +129,96 @@ function restoreVersions(updates) {
       }
     }
   });
+}
+
+/**
+ * Move the "latest" dist-tag of the published packages to the published version, for the packages
+ * where it points to an older version, or where it does not exist yet.
+ *
+ * "latest" is what "npm install <package>" resolves to, so it must always point to the newest
+ * released version. Since releases are not published in version order (a maintenance branch is
+ * released after a newer branch, and a release candidate is published before the final version),
+ * the dist-tag the publication writes is never "latest", and this decides afterwards whether
+ * "latest" can move to it.
+ *
+ * The packages are already published when this runs, so a failure here never fails the build: it
+ * is reported with the commands needed to fix it, and any later release fixes it on its own.
+ *
+ * @param {{name: string}[]} packages the published packages
+ * @param {string} version the published version
+ * @returns {Promise<void>} resolved once every dist-tag has been dealt with
+ */
+async function moveLatestForward(packages, version) {
+  const npmBinary = resolveNpmBinary();
+  const names = packages.map(({name}) => name);
+
+  console.log(`Reading the "${LATEST_TAG}" dist-tag of ${names.length} package(s) from ${releaseRegistry}`);
+  const {distTags, failures} = await readDistTags(names, {registry: releaseRegistry, npmBinary});
+
+  // A package whose dist-tags could not be read is left alone: not knowing where "latest" points
+  // is not the same as it not existing, and moving it blindly could make it go backwards.
+  const failedNames = new Set(failures.map(({name}) => name));
+  const readPackages = packages.filter(({name}) => !failedNames.has(name));
+
+  const {moves, undecidable} = planLatestMoves({packages: readPackages, distTags, version});
+  const unchanged = readPackages.length - moves.length - undecidable.length;
+  console.log(`"${LATEST_TAG}" moves to ${version} for ${moves.length} package(s), ` +
+    `${unchanged} package(s) already point to ${version} or to a newer version`);
+
+  const writeFailures = [];
+  for (const move of moves) {
+    const target = {...move, tag: LATEST_TAG, registry: releaseRegistry};
+
+    if (dryRun) {
+      console.log(`[dry run] ${npmBinary} ${distTagArguments(target).join(' ')}`);
+      continue;
+    }
+
+    try {
+      await addDistTag({...target, npmBinary});
+      console.log(`Set "${LATEST_TAG}" of ${move.name} to ${move.version}`);
+    } catch (error) {
+      writeFailures.push({...target, message: error.message});
+    }
+  }
+
+  reportDistTagProblems({failures, undecidable, writeFailures, npmBinary, version});
+}
+
+/**
+ * Report, as a single block, every package whose "latest" dist-tag could not be dealt with, with
+ * the command to run to fix it.
+ *
+ * @param {{failures: Object[], undecidable: Object[], writeFailures: Object[], npmBinary: string,
+ *   version: string}} problems the read failures, the packages whose current "latest" could not be
+ *   compared, the write failures, the npm executable and the published version
+ */
+function reportDistTagProblems({failures, undecidable, writeFailures, npmBinary, version}) {
+  if (failures.length === 0 && undecidable.length === 0 && writeFailures.length === 0) {
+    return;
+  }
+
+  console.error('');
+  console.error('========================================================================');
+  console.error(`The "${LATEST_TAG}" dist-tag could not be updated for ` +
+    `${failures.length + undecidable.length + writeFailures.length} package(s).`);
+  console.error(`The packages themselves are published: only "${LATEST_TAG}" is left untouched, ` +
+    'which means it may still point to an older version.');
+  console.error('');
+
+  failures.forEach(({name, message}) =>
+    console.error(`Failed to read the dist-tags of ${name}: ${message}`));
+  undecidable.forEach(({name, currentLatest, reason}) =>
+    console.error(`Cannot compare ${name}@${currentLatest} with ${version}: ${reason}`));
+  writeFailures.forEach(({name, message}) =>
+    console.error(`Failed to set the dist-tag of ${name}: ${message}`));
+
+  console.error('');
+  console.error('Run the following command(s) once the cause is fixed:');
+  [...failures, ...undecidable, ...writeFailures].forEach(({name}) => console.error(
+    `  ${npmBinary} ${distTagArguments({name, version, tag: LATEST_TAG, registry: releaseRegistry}).join(' ')}`));
+  console.error('========================================================================');
+  console.error('');
 }
 
 // Main execution
@@ -172,17 +272,40 @@ if (failedUpdates.length > 0) {
   process.exit(1);
 }
 
+// The packages "pnpm publish" sends to the registry.
+const publishedPackages = updates
+  .filter(({isPrivate, packageName}) => !isPrivate && packageName)
+  .map(({packageName, newVersion, originalVersion}) => ({
+    name: packageName,
+    version: newVersion,
+    originalVersion,
+  }));
+
+const publishedVersions = [...new Set(publishedPackages.map(({version}) => version))];
+const declaredVersions = [...new Set(publishedPackages.map(({originalVersion}) => originalVersion))];
+if (publishedVersions.length !== 1 || declaredVersions.length !== 1) {
+  console.error(`Expected a single version to publish but found: ${declaredVersions.join(', ')}`);
+  process.exit(1);
+}
+const publishedVersion = publishedVersions[0];
+// The dist-tag is computed from the version declared in the package.json files rather than from the
+// published one, because a SNAPSHOT version has already been replaced by a timestamp at this point.
+const publishTag = computePublishTag(declaredVersions[0]);
+
 try {
-  if (isSnapshotMode) {
-    execSync(
-      `pnpm -r publish --registry ${snapshotRegistry} --tag snapshot --no-git-checks`,
-      { stdio: 'inherit', cwd: baseDirectory }
-    );
+  const registry = isSnapshotMode ? snapshotRegistry : releaseRegistry;
+  const access = isSnapshotMode ? '' : ' --access public';
+  const command = `pnpm -r publish --registry ${registry}${access} --tag ${publishTag} --no-git-checks`;
+
+  if (dryRun) {
+    console.log(`[dry run] ${command}`);
   } else {
-    execSync(
-      `pnpm -r publish --registry ${releaseRegistry} --access public --no-git-checks`,
-      { stdio: 'inherit', cwd: baseDirectory }
-    );
+    execSync(command, { stdio: 'inherit', cwd: baseDirectory });
+  }
+
+  if (!isSnapshotMode) {
+    // Step 3: a release publishes under its own dist-tag, so "latest" is moved separately.
+    await moveLatestForward(publishedPackages, publishedVersion);
   }
 } catch (error) {
   console.error('Error during publication', error.message);
@@ -193,4 +316,3 @@ try {
     restoreVersions(updates);
   }
 }
-

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/scripts/lib/registry.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/scripts/lib/registry.js
@@ -1,0 +1,159 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import {execFile} from 'child_process';
+import {promisify} from 'util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * The npm executable installed next to the node executable by the frontend-maven-plugin, so that
+ * the npm version used here is the one the build controls rather than whichever one happens to
+ * come first on the PATH.
+ *
+ * @returns {string} the path to the npm executable, or "npm" when there is none next to node
+ */
+export function resolveNpmBinary() {
+  const sibling = path.join(path.dirname(process.execPath), 'npm');
+
+  return fs.existsSync(sibling) ? sibling : 'npm';
+}
+
+/**
+ * Run the given tasks with a bounded number of them in flight at any time.
+ *
+ * @param {any[]} items the task inputs
+ * @param {number} concurrency the maximum number of tasks running in parallel
+ * @param {function(any): Promise<any>} task the task to run for each input
+ * @returns {Promise<any[]>} the task results, in the order of the inputs
+ */
+export async function mapWithConcurrency(items, concurrency, task) {
+  const results = new Array(items.length);
+  let next = 0;
+
+  const worker = async () => {
+    while (next < items.length) {
+      const current = next++;
+      results[current] = await task(items[current]);
+    }
+  };
+
+  await Promise.all(Array.from({length: Math.min(concurrency, items.length)}, worker));
+
+  return results;
+}
+
+/**
+ * Extract the npm error code from a failed npm invocation. With --json, npm reports the error as
+ * JSON on its standard output, but it also keeps a human readable form on the standard error.
+ *
+ * @param {Error} error the error thrown by the runner
+ * @returns {string|undefined} the npm error code, when there is one
+ */
+function npmErrorCode(error) {
+  try {
+    const parsed = JSON.parse(error.stdout);
+    if (parsed?.error?.code) {
+      return parsed.error.code;
+    }
+  } catch {
+    // Not JSON, fall back to the standard error below.
+  }
+
+  return /\b(E\d{3})\b/.exec(error.stderr ?? '')?.[1];
+}
+
+/**
+ * Read the dist-tags of the given packages from a registry.
+ *
+ * @param {string[]} names the package names
+ * @param {{registry: string, npmBinary?: string, runner?: function, concurrency?: number}} options
+ *   the registry to read from, and the injectable npm executable, runner and concurrency
+ * @returns {Promise<{distTags: Object<string, Object<string, string>|null>,
+ *   failures: {name: string, message: string}[]}>} the dist-tags of each package (null when the
+ *   registry does not know the package) and the packages whose dist-tags could not be read
+ */
+export async function readDistTags(names, options) {
+  const {registry, npmBinary = resolveNpmBinary(), runner = execFileAsync, concurrency = 8} = options;
+  const distTags = {};
+  const failures = [];
+
+  await mapWithConcurrency(names, concurrency, async name => {
+    const args = ['view', name, 'dist-tags', '--json', '--registry', registry];
+
+    try {
+      const {stdout} = await runner(npmBinary, args);
+      // A package that exists but has no dist-tag at all prints nothing.
+      distTags[name] = stdout.trim() === '' ? {} : JSON.parse(stdout);
+    } catch (error) {
+      if (npmErrorCode(error) === 'E404') {
+        // The package has never been published: there is no "latest" to preserve.
+        distTags[name] = null;
+      } else {
+        failures.push({name, message: error.message});
+      }
+    }
+  });
+
+  return {distTags, failures};
+}
+
+/**
+ * Point a dist-tag of a package to a version.
+ *
+ * @param {{name: string, version: string, tag: string, registry: string, npmBinary?: string,
+ *   runner?: function, attempts?: number, delays?: number[], sleep?: function}} options the
+ *   dist-tag to write and the injectable npm executable, runner, retry policy and sleep function
+ * @returns {Promise<void>} resolved once the dist-tag is written
+ * @throws {Error} when every attempt failed
+ */
+export async function addDistTag(options) {
+  const {
+    name, version, tag, registry,
+    npmBinary = resolveNpmBinary(),
+    runner = execFileAsync,
+    attempts = 3,
+    delays = [1000, 4000],
+    sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds)),
+  } = options;
+
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await runner(npmBinary, distTagArguments({name, version, tag, registry}));
+      return;
+    } catch (error) {
+      if (attempt >= attempts) {
+        throw error;
+      }
+      await sleep(delays[Math.min(attempt - 1, delays.length - 1)]);
+    }
+  }
+}
+
+/**
+ * @param {{name: string, version: string, tag: string, registry: string}} target the dist-tag to
+ *   write
+ * @returns {string[]} the npm arguments writing that dist-tag
+ */
+export function distTagArguments({name, version, tag, registry}) {
+  return ['dist-tag', 'add', `${name}@${version}`, tag, '--registry', registry];
+}

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/scripts/lib/registry.spec.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/scripts/lib/registry.spec.js
@@ -1,0 +1,180 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import {describe, expect, it, vi} from 'vitest';
+import {addDistTag, distTagArguments, mapWithConcurrency, readDistTags} from './registry.js';
+
+/**
+ * @param {Object} stdout the dist-tags each package name answers with
+ * @returns {function} a runner behaving like "npm view <name> dist-tags --json"
+ */
+function viewRunner(stdout) {
+  return vi.fn(async (npmBinary, args) => ({stdout: stdout[args[1]]}));
+}
+
+/**
+ * @param {string} code the npm error code to fail with
+ * @returns {Error} the error the npm CLI produces for that code
+ */
+function npmError(code) {
+  const error = new Error(`Command failed with ${code}`);
+  error.stdout = JSON.stringify({error: {code, summary: 'not found'}});
+  error.stderr = `npm error code ${code}`;
+
+  return error;
+}
+
+describe('readDistTags', () => {
+  it('reads the dist-tags of each package from the given registry', async () => {
+    const runner = viewRunner({a: '{"latest":"18.4.5","rc":"18.8.0-rc-1"}', b: '{"latest":"18.7.0"}'});
+
+    const result = await readDistTags(['a', 'b'], {registry: 'https://registry', npmBinary: 'npm', runner});
+
+    expect(result).toEqual({
+      distTags: {a: {latest: '18.4.5', rc: '18.8.0-rc-1'}, b: {latest: '18.7.0'}},
+      failures: [],
+    });
+    expect(runner).toHaveBeenCalledWith('npm',
+      ['view', 'a', 'dist-tags', '--json', '--registry', 'https://registry']);
+  });
+
+  it('reports a package unknown to the registry as having no dist-tag', async () => {
+    const runner = vi.fn(async () => {
+      throw npmError('E404');
+    });
+
+    const result = await readDistTags(['new'], {registry: 'https://registry', npmBinary: 'npm', runner});
+
+    expect(result).toEqual({distTags: {new: null}, failures: []});
+  });
+
+  it('detects the npm error code from the standard error too', async () => {
+    const runner = vi.fn(async () => {
+      const error = new Error('failed');
+      error.stdout = 'not json';
+      error.stderr = 'npm error code E404\nnpm error 404 Not Found';
+      throw error;
+    });
+
+    const result = await readDistTags(['new'], {registry: 'https://registry', npmBinary: 'npm', runner});
+
+    expect(result.distTags).toEqual({new: null});
+  });
+
+  it('reports any other failure instead of assuming there is no dist-tag', async () => {
+    const runner = vi.fn(async (npmBinary, args) => {
+      if (args[1] === 'broken') {
+        throw npmError('E500');
+      }
+      return {stdout: '{"latest":"18.4.5"}'};
+    });
+
+    const result = await readDistTags(['fine', 'broken'], {
+      registry: 'https://registry',
+      npmBinary: 'npm',
+      runner,
+    });
+
+    expect(result.distTags).toEqual({fine: {latest: '18.4.5'}});
+    expect(result.failures).toEqual([{name: 'broken', message: 'Command failed with E500'}]);
+  });
+
+  it('treats a package published without any dist-tag as having none', async () => {
+    const runner = viewRunner({empty: '\n'});
+
+    const result = await readDistTags(['empty'], {registry: 'https://registry', npmBinary: 'npm', runner});
+
+    expect(result.distTags).toEqual({empty: {}});
+  });
+});
+
+describe('addDistTag', () => {
+  const target = {name: '@xwiki/platform-api', version: '18.7.0', tag: 'latest', registry: 'https://registry'};
+
+  it('points the dist-tag to the version', async () => {
+    const runner = vi.fn(async () => ({stdout: ''}));
+
+    await addDistTag({...target, npmBinary: 'npm', runner});
+
+    expect(runner).toHaveBeenCalledExactlyOnceWith('npm',
+      ['dist-tag', 'add', '@xwiki/platform-api@18.7.0', 'latest', '--registry', 'https://registry']);
+  });
+
+  it('retries a failing write', async () => {
+    const runner = vi.fn()
+      .mockRejectedValueOnce(new Error('ETIMEDOUT'))
+      .mockResolvedValueOnce({stdout: ''});
+    const sleep = vi.fn();
+
+    await addDistTag({...target, npmBinary: 'npm', runner, sleep});
+
+    expect(runner).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledExactlyOnceWith(1000);
+  });
+
+  it('gives up after the last attempt and surfaces the error', async () => {
+    const runner = vi.fn().mockRejectedValue(new Error('ETIMEDOUT'));
+    const sleep = vi.fn();
+
+    await expect(addDistTag({...target, npmBinary: 'npm', runner, sleep})).rejects.toThrow('ETIMEDOUT');
+    expect(runner).toHaveBeenCalledTimes(3);
+    expect(sleep.mock.calls).toEqual([[1000], [4000]]);
+  });
+});
+
+describe('distTagArguments', () => {
+  it('builds a command that can be copied into a terminal to repair a dist-tag', () => {
+    expect(distTagArguments({
+      name: '@xwiki/platform-api',
+      version: '18.7.0',
+      tag: 'latest',
+      registry: 'https://registry.npmjs.org',
+    }).join(' ')).toBe(
+      'dist-tag add @xwiki/platform-api@18.7.0 latest --registry https://registry.npmjs.org');
+  });
+});
+
+describe('mapWithConcurrency', () => {
+  it('runs every task and keeps the order of the inputs', async () => {
+    const result = await mapWithConcurrency([1, 2, 3, 4, 5], 2, async item => item * 2);
+
+    expect(result).toEqual([2, 4, 6, 8, 10]);
+  });
+
+  it('never runs more tasks in parallel than allowed', async () => {
+    let running = 0;
+    let peak = 0;
+
+    await mapWithConcurrency([1, 2, 3, 4, 5, 6], 2, async () => {
+      peak = Math.max(peak, ++running);
+      await Promise.resolve();
+      running--;
+    });
+
+    expect(peak).toBe(2);
+  });
+
+  it('does nothing when there is nothing to do', async () => {
+    const task = vi.fn();
+
+    expect(await mapWithConcurrency([], 8, task)).toEqual([]);
+    expect(task).not.toHaveBeenCalled();
+  });
+});

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/scripts/lib/tags.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/scripts/lib/tags.js
@@ -1,0 +1,106 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import {compareVersions, isSnapshot, parseVersion} from './version.js';
+
+export const SNAPSHOT_TAG = 'snapshot';
+
+export const RELEASE_CANDIDATE_TAG = 'rc';
+
+export const LATEST_TAG = 'latest';
+
+/**
+ * The npm dist-tag a publication writes to. It is never "latest": npm always writes the tag passed
+ * to the publish command, so publishing a maintenance branch under "latest" would make it point to
+ * an older version than the one already published. "latest" is instead moved afterwards, and only
+ * forward, by planLatestMoves().
+ *
+ * @param {string} version the version being published
+ * @returns {string} the dist-tag to publish under
+ */
+export function computePublishTag(version) {
+  if (isSnapshot(version)) {
+    return SNAPSHOT_TAG;
+  }
+
+  const {major, minor, rc} = parseVersion(version);
+  if (rc !== null) {
+    return RELEASE_CANDIDATE_TAG;
+  }
+
+  // Named after the git branch the version is released from, so that a maintenance line stays
+  // installable explicitly, e.g. "npm install @xwiki/platform-api@stable-18.4.x".
+  return `stable-${major}.${minor}.x`;
+}
+
+/**
+ * Decide the "latest" dist-tag of a single package.
+ *
+ * @param {string|null} currentLatest the version "latest" currently points to, null when the
+ *   package has no "latest" tag yet (it has never been published, or was only ever published under
+ *   another tag)
+ * @param {string} version the version being published
+ * @returns {boolean} true when "latest" must be moved to the published version
+ * @throws {Error} when either version cannot be parsed, leaving the decision undecidable
+ */
+export function shouldMoveLatest(currentLatest, version) {
+  // Without a "latest" tag "npm install <package>" fails, so bootstrap it whatever the version is.
+  if (currentLatest === null || currentLatest === undefined) {
+    return true;
+  }
+
+  // A release candidate never becomes the default version users install.
+  if (parseVersion(version).rc !== null) {
+    return false;
+  }
+
+  return compareVersions(version, currentLatest) > 0;
+}
+
+/**
+ * Compute the "latest" dist-tag updates to apply after a publication, from the state of the
+ * registry.
+ *
+ * @param {{packages: {name: string}[], distTags: Object<string, Object<string, string>|null>,
+ *   version: string}} state the published packages, the dist-tags each of them currently has on
+ *   the registry (null when the package is unknown to the registry), and the published version
+ * @returns {{moves: {name: string, version: string}[], undecidable: {name: string,
+ *   currentLatest: string, reason: string}[]}} the packages whose "latest" must be moved, and the
+ *   ones whose current "latest" could not be compared
+ */
+export function planLatestMoves({packages, distTags, version}) {
+  const moves = [];
+  const undecidable = [];
+
+  for (const {name} of packages) {
+    const tags = distTags[name];
+    const currentLatest = tags ? tags[LATEST_TAG] ?? null : null;
+
+    try {
+      if (shouldMoveLatest(currentLatest, version)) {
+        moves.push({name, version});
+      }
+    } catch (error) {
+      undecidable.push({name, currentLatest, reason: error.message});
+    }
+  }
+
+  return {moves, undecidable};
+}

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/scripts/lib/tags.spec.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/scripts/lib/tags.spec.js
@@ -1,0 +1,120 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import {describe, expect, it} from 'vitest';
+import {computePublishTag, LATEST_TAG, planLatestMoves, shouldMoveLatest} from './tags.js';
+
+describe('computePublishTag', () => {
+  it.each([
+    ['18.8.0-SNAPSHOT', 'snapshot'],
+    ['18.7.0-rc-1', 'rc'],
+    ['18.7.0-rc-2', 'rc'],
+    ['18.4.5', 'stable-18.4.x'],
+    ['18.10.0', 'stable-18.10.x'],
+    ['19.0.0', 'stable-19.0.x'],
+  ])('publishes %s under the "%s" dist-tag', (version, tag) => {
+    expect(computePublishTag(version)).toBe(tag);
+  });
+
+  it('never publishes under "latest", which is moved separately', () => {
+    expect(computePublishTag('18.4.5')).not.toBe(LATEST_TAG);
+  });
+
+  it.each(['18.8.0-SNAPSHOT', '18.7.0-rc-1', '18.4.5'])(
+    'computes a tag name npm accepts for %s', version => {
+      // npm rejects a dist-tag name that is a valid SemVer range, e.g. "18.4" or "v18.4".
+      expect(computePublishTag(version)).toMatch(/^[a-z][a-z-]*(-\d+\.\d+\.x)?$/);
+    });
+});
+
+describe('shouldMoveLatest', () => {
+  it('moves "latest" forward', () => {
+    expect(shouldMoveLatest('18.4.4', '18.4.5')).toBe(true);
+    expect(shouldMoveLatest('18.7.0-rc-1', '18.7.0')).toBe(true);
+  });
+
+  it('never moves "latest" backwards', () => {
+    expect(shouldMoveLatest('18.7.0', '18.4.5')).toBe(false);
+  });
+
+  it('does nothing when "latest" already points to the published version', () => {
+    expect(shouldMoveLatest('18.4.5', '18.4.5')).toBe(false);
+  });
+
+  it('never points "latest" to a release candidate of an existing package', () => {
+    expect(shouldMoveLatest('18.4.5', '18.8.0-rc-1')).toBe(false);
+  });
+
+  it.each([null, undefined])('bootstraps a package that has no "latest" yet (%s)', currentLatest => {
+    // Without a "latest" tag "npm install <package>" fails, even for a release candidate.
+    expect(shouldMoveLatest(currentLatest, '18.4.5')).toBe(true);
+    expect(shouldMoveLatest(currentLatest, '18.8.0-rc-1')).toBe(true);
+  });
+
+  it('refuses to decide when a version cannot be parsed', () => {
+    expect(() => shouldMoveLatest('18.4.5-1757312345', '18.4.6')).toThrow('Unsupported version format');
+  });
+});
+
+describe('planLatestMoves', () => {
+  const packages = [{name: 'older'}, {name: 'equal'}, {name: 'newer'}, {name: 'unknown'}];
+  const distTags = {
+    older: {latest: '18.4.4'},
+    equal: {latest: '18.4.5'},
+    newer: {latest: '18.7.0'},
+    unknown: null,
+  };
+
+  it('only moves the packages whose "latest" is older or missing', () => {
+    expect(planLatestMoves({packages, distTags, version: '18.4.5'})).toEqual({
+      moves: [{name: 'older', version: '18.4.5'}, {name: 'unknown', version: '18.4.5'}],
+      undecidable: [],
+    });
+  });
+
+  it('moves nothing but the unknown package for a release candidate', () => {
+    expect(planLatestMoves({packages, distTags, version: '18.8.0-rc-1'})).toEqual({
+      moves: [{name: 'unknown', version: '18.8.0-rc-1'}],
+      undecidable: [],
+    });
+  });
+
+  it('treats a package published without any dist-tag as needing "latest"', () => {
+    expect(planLatestMoves({packages: [{name: 'tagless'}], distTags: {tagless: {}}, version: '18.4.5'}))
+      .toEqual({moves: [{name: 'tagless', version: '18.4.5'}], undecidable: []});
+  });
+
+  it('reports the packages whose current "latest" cannot be compared, and moves the others', () => {
+    const withUnparseable = {...distTags, weird: {latest: 'not-a-version'}};
+
+    expect(planLatestMoves({
+      packages: [...packages, {name: 'weird'}],
+      distTags: withUnparseable,
+      version: '18.4.5',
+    })).toEqual({
+      moves: [{name: 'older', version: '18.4.5'}, {name: 'unknown', version: '18.4.5'}],
+      undecidable: [{
+        name: 'weird',
+        currentLatest: 'not-a-version',
+        reason: 'Unsupported version format: [not-a-version]',
+      }],
+    });
+  });
+});

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/scripts/lib/version.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/scripts/lib/version.js
@@ -1,0 +1,93 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+/**
+ * The version format used by every XWiki release: Major.Minor.Bugfix, optionally followed by a
+ * release candidate number. Anything else is rejected rather than guessed at, so that an
+ * unexpected version can never be mis-ordered silently.
+ */
+const RELEASE_VERSION_PATTERN = /^(\d+)\.(\d+)\.(\d+)(?:-rc-(\d+))?$/;
+
+/**
+ * @param {string} version a version string
+ * @returns {boolean} true when the version is a development (SNAPSHOT) version
+ */
+export function isSnapshot(version) {
+  return version.includes('SNAPSHOT');
+}
+
+/**
+ * @param {string} version a released version, e.g. "18.4.5" or "18.7.0-rc-1"
+ * @returns {{major: number, minor: number, bugfix: number, rc: number|null}} its parts
+ * @throws {Error} when the version does not follow the XWiki release version format
+ */
+export function parseVersion(version) {
+  const parts = RELEASE_VERSION_PATTERN.exec(version);
+  if (!parts) {
+    throw new Error(`Unsupported version format: [${version}]`);
+  }
+
+  return {
+    major: Number(parts[1]),
+    minor: Number(parts[2]),
+    bugfix: Number(parts[3]),
+    rc: parts[4] === undefined ? null : Number(parts[4]),
+  };
+}
+
+/**
+ * @param {string} version a released version
+ * @returns {boolean} true when the version is a release candidate
+ */
+export function isPrerelease(version) {
+  return parseVersion(version).rc !== null;
+}
+
+/**
+ * Order two released versions. A final version is greater than any of its release candidates.
+ *
+ * @param {string} left a released version
+ * @param {string} right a released version
+ * @returns {number} a negative number when left is older than right, 0 when they are equal, a
+ *   positive number when left is newer than right
+ */
+export function compareVersions(left, right) {
+  const a = parseVersion(left);
+  const b = parseVersion(right);
+
+  for (const part of ['major', 'minor', 'bugfix']) {
+    if (a[part] !== b[part]) {
+      return a[part] - b[part];
+    }
+  }
+
+  if (a.rc === b.rc) {
+    return 0;
+  }
+  // A final version has no rc number and is newer than any release candidate of the same version.
+  if (a.rc === null) {
+    return 1;
+  }
+  if (b.rc === null) {
+    return -1;
+  }
+
+  return a.rc - b.rc;
+}

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/scripts/lib/version.spec.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/scripts/lib/version.spec.js
@@ -1,0 +1,77 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+
+import {describe, expect, it} from 'vitest';
+import {compareVersions, isPrerelease, isSnapshot, parseVersion} from './version.js';
+
+describe('isSnapshot', () => {
+  it('recognizes development versions', () => {
+    expect(isSnapshot('18.8.0-SNAPSHOT')).toBe(true);
+    expect(isSnapshot('18.4.5')).toBe(false);
+    expect(isSnapshot('18.7.0-rc-1')).toBe(false);
+  });
+});
+
+describe('parseVersion', () => {
+  it('parses a final version', () => {
+    expect(parseVersion('18.4.5')).toEqual({major: 18, minor: 4, bugfix: 5, rc: null});
+  });
+
+  it('parses a release candidate', () => {
+    expect(parseVersion('18.7.0-rc-2')).toEqual({major: 18, minor: 7, bugfix: 0, rc: 2});
+  });
+
+  it.each(['18.7', '18.7.0-SNAPSHOT', '18.7.0-1757312345', '18.7.0.1', 'v18.7.0', ''])(
+    'rejects [%s] rather than guessing its order', version => {
+      expect(() => parseVersion(version)).toThrow(`Unsupported version format: [${version}]`);
+    });
+});
+
+describe('isPrerelease', () => {
+  it('distinguishes release candidates from final versions', () => {
+    expect(isPrerelease('18.7.0-rc-1')).toBe(true);
+    expect(isPrerelease('18.7.0')).toBe(false);
+  });
+});
+
+describe('compareVersions', () => {
+  it.each([
+    ['18.4.5', '18.7.0'],
+    ['18.4.0', '18.10.0'],
+    ['18.4.5', '19.0.0'],
+    ['18.4.4', '18.4.5'],
+    ['18.7.0-rc-1', '18.7.0'],
+    ['18.7.0-rc-1', '18.7.0-rc-2'],
+    ['18.7.0', '18.7.1-rc-1'],
+  ])('orders %s before %s', (older, newer) => {
+    expect(compareVersions(older, newer)).toBeLessThan(0);
+    expect(compareVersions(newer, older)).toBeGreaterThan(0);
+  });
+
+  it.each(['18.4.5', '18.7.0-rc-1'])('considers %s equal to itself', version => {
+    expect(compareVersions(version, version)).toBe(0);
+  });
+
+  it('compares the minor numerically and not lexically', () => {
+    // "18.10.0" sorts before "18.4.0" as a string.
+    expect(compareVersions('18.10.0', '18.4.0')).toBeGreaterThan(0);
+  });
+});

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/vitest.config.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/vitest.config.js
@@ -1,0 +1,31 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import {defineConfig} from 'vitest/config';
+
+// The tests of the scripts of this workspace root. The "include" is restricted on purpose: the
+// default one would also match the tests of every package of the workspace, which their own
+// projects already run.
+export default defineConfig({
+  test: {
+    include: ['scripts/**/*.spec.js'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Jira URL

https://jira.xwiki.org/browse/XWIKI-24828

## Changes

### Description

A release publishes the npm packages with `pnpm -r publish` without any `--tag`, so npm writes its
default dist-tag, `latest`, whatever the version being published. Releases are not published in
version order — a maintenance branch is released after a newer branch, and a release candidate
before its final version — so such a release moves `latest` backwards.

* A release is now published under a dist-tag of its own: `rc` for a release candidate,
  `stable-<major>.<minor>.x` for a final version (named after the branch it is released from, so a
  maintenance line stays installable explicitly with
  `npm install @xwiki/platform-api@stable-18.4.x`).
* `latest` is moved to the published version afterwards, and only for the packages where it is
  missing or points to an older version. A package that has no `latest` at all is bootstrapped even
  for a release candidate, since `npm install <package>` fails without it.
* A package whose dist-tags cannot be read is left untouched, rather than treated as having no
  `latest`, so that a transient registry error cannot make `latest` move blindly.
* The packages whose dist-tag could not be updated are reported together with the command to repair
  each of them, without failing the build: they are already published at that point, and failing
  here would recreate the situation `SKIP_NPM_PUBLICATION` exists to work around.
* The private packages are excluded from the published set, which `pnpm publish` already skips.
* The version, dist-tag and registry logic is extracted into `scripts/lib` and covered by unit
  tests.

### Clarifications

* `latest` cannot simply be passed to `pnpm publish` and repaired afterwards: that would leave a
  window where `latest` points to the older version, and would race two branches released the same
  day.
* The dist-tag of a maintenance line cannot be named `v18.4` or `18.4`: npm rejects a dist-tag name
  that is a valid SemVer range.
* No dependency is added. XWiki versions have a closed format
  (`Major.Minor.Bugfix[-rc-<number>]`), and a parser that throws on anything else is safer here than
  `semver`, which would silently accept and order formats that are never meant to be published.
* The dist-tag is computed from the version declared in the `package.json` files rather than from
  the published one, because a SNAPSHOT version has already been replaced by a timestamp by then.
* This does not repair the packages whose `latest` is currently wrong; the next final release newer
  than 18.4.5 does, on its own.
* The snapshot publication is unchanged: same registry, same `snapshot` dist-tag, no dist-tag
  update.

## Screenshots & Video

No visible result — this changes the publication of the npm packages. The equivalent evidence is the
dry run below, which reads the real registry and prints what a release would do.

## Executed Tests

`mvn -B -ntp -pl :xwiki-platform-node verify` — BUILD SUCCESS. The new tests run as part of it (53
tests), and so do the tests of the 39 packages of the workspace.

Dry runs (`DEPLOY_DRY_RUN=true`, which prints the publication commands instead of running them,
while still reading the registry) against `registry.npmjs.org`, on the trees of the release tags:

* tag `xwiki-platform-18.4.4`, a maintenance line whose `latest` is a newer version:

```
[dry run] pnpm -r publish --registry https://registry.npmjs.org --access public --tag stable-18.4.x --no-git-checks
Reading the "latest" dist-tag of 44 package(s) from https://registry.npmjs.org
"latest" moves to 18.4.4 for 0 package(s), 44 package(s) already point to 18.4.4 or to a newer version
```

* tag `xwiki-platform-18.7.0`, the newest line, whose `latest` currently points to 18.4.5:

```
[dry run] pnpm -r publish --registry https://registry.npmjs.org --access public --tag stable-18.7.x --no-git-checks
Reading the "latest" dist-tag of 54 package(s) from https://registry.npmjs.org
"latest" moves to 18.7.0 for 44 package(s), 10 package(s) already point to 18.7.0 or to a newer version
[dry run] npm dist-tag add @xwiki/platform-api@18.7.0 latest --registry https://registry.npmjs.org
[...]
```

  The 10 packages left alone are the ones that only exist on the newer branches and whose `latest`
  is therefore already correct.

* the current SNAPSHOT tree, unchanged behaviour:

```
[dry run] pnpm -r publish --registry https://nexus-snapshots.xwiki.org/repository/npmhosted/ --tag snapshot --no-git-checks
```

## Expected merging strategy

* Prefers squash: Yes
* Backport to `stable-18.7.x` and `stable-18.4.x` — those are the only maintenance branches that
  publish npm packages, and `stable-18.4.x` is the branch whose releases currently break `latest`.

Generated with Claude Code.
