### PR TITLE
[Misc] Widen the retry guard for the axe-core injection race

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/pom.xml
@@ -32,7 +32,7 @@
   <packaging>jar</packaging>
   <description>XWiki Platform - UI Tests Framework</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.05</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.06</xwiki.jacoco.instructionRatio>
 
     <!-- TODO: removing when not using Apache HttpClient 3 anymore -->
     <xwiki.enforcer.enforce-apache-http5.skip>true</xwiki.enforcer.enforce-apache-http5.skip>

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
@@ -66,6 +66,14 @@ public class BasePage extends BaseElement
     private static final int WCAG_ANALYZE_ATTEMPTS = 3;
 
     /**
+     * Message fragments identifying a JavaScript error raised because axe-core was not present in the frame when the
+     * analysis probed it. Browsers word it differently: Chrome reports the failing property read on the axe object
+     * ({@code runPartial} is the axe entry point the analysis calls), while Firefox reports the missing binding itself.
+     */
+    private static final List<String> AXE_NOT_READY_ERRORS =
+        List.of("runPartial", "window.axe", "axe is not defined", "axe is undefined");
+
+    /**
      * Used for sending keyboard shortcuts to.
      */
     @FindBy(id = "xwikimaincontainer")
@@ -755,7 +763,7 @@ public class BasePage extends BaseElement
             try {
                 return axeBuilder.analyze(driver);
             } catch (JavascriptException e) {
-                if (e.getMessage() == null || !e.getMessage().contains("window.axe")) {
+                if (!isAxeNotReadyError(e)) {
                     throw e;
                 }
                 lastError = e;
@@ -763,6 +771,12 @@ public class BasePage extends BaseElement
             }
         }
         throw lastError;
+    }
+
+    static boolean isAxeNotReadyError(JavascriptException error)
+    {
+        String message = error.getMessage();
+        return message != null && AXE_NOT_READY_ERRORS.stream().anyMatch(message::contains);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/test/java/org/xwiki/test/ui/po/BasePageTest.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/test/java/org/xwiki/test/ui/po/BasePageTest.java
@@ -1,0 +1,56 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.test.ui.po;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openqa.selenium.JavascriptException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link BasePage}.
+ *
+ * @version $Id$
+ */
+class BasePageTest
+{
+    @ParameterizedTest
+    @ValueSource(strings = {
+        // Chrome, when the axe object is gone: the analysis reads the entry point off it.
+        "javascript error: Cannot read properties of undefined (reading 'runPartial')",
+        // Firefox, when the axe binding itself is gone.
+        "ReferenceError: axe is not defined",
+        "TypeError: can't access property \"runPartial\", window.axe is undefined"
+    })
+    void isAxeNotReadyErrorWithAxeMissing(String message)
+    {
+        assertTrue(BasePage.isAxeNotReadyError(new JavascriptException(message)));
+    }
+
+    @Test
+    void isAxeNotReadyErrorWithUnrelatedError()
+    {
+        assertFalse(BasePage.isAxeNotReadyError(
+            new JavascriptException("javascript error: Cannot read properties of undefined (reading 'toLowerCase')")));
+    }
+}


### PR DESCRIPTION
## What

`BasePage.analyzeWithAxeReadyRetry()` (added in 570d0d983a8) retries the axe-core injection race, but only for errors whose message contains `window.axe`. That never matches the error the race actually produces — Chrome reports it as:

```
javascript error: Cannot read properties of undefined (reading 'runPartial')
```

so the retry rethrew immediately and the flicker survived. The original commit message quotes that exact message as the one it set out to fix.

## Why now

Found while triaging stable-17.10.x for the 17.10.13 release. `CopyPageIT#copyDoesNotCarryOverRightsTheUserCannotGrant` failed this way in Environment Tests #283 ([build scan](https://community.develocity.cloud/s/zj6uvxiadqts6)) — 1 failure in 29 runs on that branch since June.

## Changes

* Match the fragments the race really produces, in Chrome (`runPartial`) and in Firefox (`axe is not defined`, `window.axe is undefined`), instead of only `window.axe`.
* Extract the decision into `isAxeNotReadyError()` and unit test it against the real browser messages, so the guard is verified here rather than only by whether CI happens to flicker.
* Raise the module's JaCoCo instruction ratio to the newly achieved `0.06`.

## Verification

`mvn clean install -Pquality` on `xwiki-platform-test-ui` — 16 tests pass, Checkstyle clean, coverage gate green.

No before/after images: this is test-framework internals with no visible result.

Backport to `stable-17.10.x` (which never received 570d0d983a8 at all): #6339

🤖 Generated with [Claude Code](https://claude.com/claude-code)
