### PR TITLE
[stable-17.10.x] [Misc] Fix flickering WCAG validation due to axe-core injection race

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
@@ -66,6 +66,14 @@ public class BasePage extends BaseElement
     private static final int WCAG_ANALYZE_ATTEMPTS = 3;
 
     /**
+     * Message fragments identifying a JavaScript error raised because axe-core was not present in the frame when the
+     * analysis probed it. Browsers word it differently: Chrome reports the failing property read on the axe object
+     * ({@code runPartial} is the axe entry point the analysis calls), while Firefox reports the missing binding itself.
+     */
+    private static final List<String> AXE_NOT_READY_ERRORS =
+        List.of("runPartial", "window.axe", "axe is not defined", "axe is undefined");
+
+    /**
      * Used for sending keyboard shortcuts to.
      */
     @FindBy(id = "xwikimaincontainer")
@@ -755,7 +763,7 @@ public class BasePage extends BaseElement
             try {
                 return axeBuilder.analyze(driver);
             } catch (JavascriptException e) {
-                if (e.getMessage() == null || !e.getMessage().contains("window.axe")) {
+                if (!isAxeNotReadyError(e)) {
                     throw e;
                 }
                 lastError = e;
@@ -763,6 +771,12 @@ public class BasePage extends BaseElement
             }
         }
         throw lastError;
+    }
+
+    static boolean isAxeNotReadyError(JavascriptException error)
+    {
+        String message = error.getMessage();
+        return message != null && AXE_NOT_READY_ERRORS.stream().anyMatch(message::contains);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.LocaleUtils;
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptException;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
@@ -57,6 +58,12 @@ public class BasePage extends BaseElement
     private static final Logger LOGGER = LoggerFactory.getLogger(BasePage.class);
 
     private static final By EDIT_BUTTON_LOCATOR = By.xpath("//li[@id='tmEdit']/a[contains(@class, 'btn')]");
+
+    /**
+     * Number of times the axe-core accessibility analysis is attempted before giving up, to work around the
+     * axe-injection race (see {@link #analyzeWithAxeReadyRetry}).
+     */
+    private static final int WCAG_ANALYZE_ATTEMPTS = 3;
 
     /**
      * Used for sending keyboard shortcuts to.
@@ -716,7 +723,7 @@ public class BasePage extends BaseElement
             if (!checkCache || wcagContext.isNotCached(this.getPageURL(), this.getClass().getName())) {
                 XWikiWebDriver driver = this.getDriver();
                 AxeBuilder axeBuilder = wcagContext.getAxeBuilder();
-                Results axeResult = axeBuilder.analyze(driver);
+                Results axeResult = analyzeWithAxeReadyRetry(axeBuilder, driver);
                 wcagContext.addWCAGResults(driver.getCurrentUrl(), this.getClass().getName(), axeResult);
                 long stopTime = System.currentTimeMillis();
                 long deltaTime = stopTime - startTime;
@@ -735,6 +742,27 @@ public class BasePage extends BaseElement
                 LOGGER.debug("Error during WCAG execution, but ignored thanks to wcagStopOnError flag: ", e);
             }
         }
+    }
+
+    private Results analyzeWithAxeReadyRetry(AxeBuilder axeBuilder, XWikiWebDriver driver)
+    {
+        // The axe-core library injects its script and then immediately probes window.axe. On a page that changes
+        // underneath the analysis (e.g. the refactoring job status page refreshing while the job runs), the page can
+        // navigate between the injection and the probe, leaving window.axe undefined and making analyze() fail. Waiting
+        // for the page to settle and re-running the analysis avoids this race.
+        JavascriptException lastError = null;
+        for (int attempt = 0; attempt < WCAG_ANALYZE_ATTEMPTS; attempt++) {
+            try {
+                return axeBuilder.analyze(driver);
+            } catch (JavascriptException e) {
+                if (e.getMessage() == null || !e.getMessage().contains("window.axe")) {
+                    throw e;
+                }
+                lastError = e;
+                waitUntilPageIsReady();
+            }
+        }
+        throw lastError;
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/test/java/org/xwiki/test/ui/po/BasePageTest.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/test/java/org/xwiki/test/ui/po/BasePageTest.java
@@ -1,0 +1,56 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.test.ui.po;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openqa.selenium.JavascriptException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link BasePage}.
+ *
+ * @version $Id$
+ */
+class BasePageTest
+{
+    @ParameterizedTest
+    @ValueSource(strings = {
+        // Chrome, when the axe object is gone: the analysis reads the entry point off it.
+        "javascript error: Cannot read properties of undefined (reading 'runPartial')",
+        // Firefox, when the axe binding itself is gone.
+        "ReferenceError: axe is not defined",
+        "TypeError: can't access property \"runPartial\", window.axe is undefined"
+    })
+    void isAxeNotReadyErrorWithAxeMissing(String message)
+    {
+        assertTrue(BasePage.isAxeNotReadyError(new JavascriptException(message)));
+    }
+
+    @Test
+    void isAxeNotReadyErrorWithUnrelatedError()
+    {
+        assertFalse(BasePage.isAxeNotReadyError(
+            new JavascriptException("javascript error: Cannot read properties of undefined (reading 'toLowerCase')")));
+    }
+}


### PR DESCRIPTION
Backport of the axe-core WCAG injection-race fix to `stable-17.10.x`, which never received it.

## Why

Triaging this branch for 17.10.13 turned up one failing test — `CopyPageIT#copyDoesNotCarryOverRightsTheUserCannotGrant` in Environment Tests #283 ([build scan](https://community.develocity.cloud/s/zj6uvxiadqts6)):

```
org.openqa.selenium.JavascriptException: javascript error:
  Cannot read properties of undefined (reading 'runPartial')
```

That is the axe-core injection race in `BasePage.validateWCAG()`: axe was not present in the frame when the analysis probed it. The mitigation for it (570d0d983a8, 2026-06-29) is on master but was never backported here — this branch still calls `axeBuilder.analyze(driver)` bare.

## Commits

* `104162d1fac` — cherry-pick `-x` of 570d0d983a8, the original retry. Applied cleanly and reproduces the original `--stat` (1 file, +29/-1).
* Cherry-pick `-x` of the follow-up that widens the guard (master PR #6338). The original guard only retried messages containing `window.axe`, which does not match the `runPartial` message above, so without the follow-up the backport would not fix the failure that motivated it.

## Adaptation

The follow-up also raises the module's JaCoCo instruction ratio to `0.06` on master. That is **left out** here: this branch has no `XWikiWebDriverTest`, so the module reaches only `0.0522`, and the `0.05` already in the pom is the correct floor. Taking master's value verbatim would have failed the build.

## Verification

`mvn clean install -Pquality` on `xwiki-platform-test-ui` with **JDK 17** (the level this branch targets) — 6 tests pass, Checkstyle clean, coverage gate green.

No before/after images: test-framework internals, no visible result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
