### PR TITLE
[Misc] Stop registering rendering and component API components twice in xwiki-platform-legacy-oldcore tests

### DIFF
--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/pom.xml
@@ -182,6 +182,8 @@
         <configuration>
           <classpathDependencyExcludes>
             <classpathDependencyExcludes>org.xwiki.platform:xwiki-platform-oldcore:jar</classpathDependencyExcludes>
+            <classpathDependencyExcludes>org.xwiki.rendering:xwiki-rendering-api:jar</classpathDependencyExcludes>
+            <classpathDependencyExcludes>org.xwiki.commons:xwiki-commons-component-api:jar</classpathDependencyExcludes>
           </classpathDependencyExcludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
# Jira URL

N/A — `[Misc]` change: build/test configuration only, no user-visible or API effect.

# Changes

## Description

* Add `xwiki-rendering-api` and `xwiki-commons-component-api` to the `maven-surefire-plugin`
  `<classpathDependencyExcludes>` of `xwiki-platform-legacy-oldcore`, next to the
  `xwiki-platform-oldcore` exclusion that was already there.

This removes **1080** `WARN o.x.c.a.ComponentAnnotationLoader - Component [...] tried to overwrite
component [...]. However, no action was taken since both components have the same priority level of
[1000].` lines from the module's test output.

## Clarifications

A `-legacy` artifact is a full replacement of its non-legacy twin: it contains the AspectJ-woven copy
of all the original classes plus a `META-INF/components.txt` that is a superset of the original's
(44 entries vs 41 for `xwiki-rendering-legacy-api`). On a **test** classpath the original cannot be
excluded through dependency scope, so both jars are present,
`classLoader.getResources("META-INF/components.txt")` finds both files, every shared class is
declared twice at the same default priority 1000, and `ComponentAnnotationLoader#addComponent` warns.

That is exactly the symptom of XWIKI-8038 (2012), whose fix introduced this very
`<classpathDependencyExcludes>` block for `xwiki-platform-oldcore`. The list simply never got the
other two twins: `xwiki-rendering-legacy-api` became a direct dependency of the module in 2017
(XRENDERING-482) and drags in `xwiki-commons-legacy-component-api`, while `xwiki-rendering-api` and
`xwiki-commons-component-api` keep arriving transitively.

Scanning the module's resolved test classpath shows 358 duplicated declarations in three pairs:

| duplicated pair | classes | warned before |
|---|---|---|
| `legacy-oldcore/target/classes` ++ `xwiki-platform-oldcore.jar` | 315 | no — already excluded |
| `xwiki-rendering-api` ++ `xwiki-rendering-legacy-api` | 41 | **yes** |
| `xwiki-commons-component-api` ++ `xwiki-commons-legacy-component-api` | 2 | **yes** |

The 36 distinct classes actually warned about were 34 `org.xwiki.rendering.internal.*` + 2
`org.xwiki.component.internal.*`, and zero `com.xpn.xwiki.*` — confirming only the two unexcluded
pairs leaked through.

Excluding the two originals is safe for the same reason the `xwiki-platform-oldcore` exclusion is:
each legacy jar is a strict superset of its twin. Comparing jar entries, 0 of the 268 entries of
`xwiki-rendering-api` and 0 of the 45 of `xwiki-commons-component-api` are missing from their legacy
counterparts.

Only the volume of these warnings is recent: they fire only under `@AllComponents`, and
`66beaf486e5` ("[Misc] Convert tests to JUnit5 + remove JMock usage", 2026-05-05) converted
`XWikiTest`, `XWikiNotificationTest` and `PropertyChangedRuleTest` to `@OldcoreTest` +
`@AllComponents`, joining `XWikiDocumentTest`.

I also swept the other 44 modules under `xwiki-platform-legacy` for the same gap.
`xwiki-platform-legacy-bridge`, `xwiki-platform-legacy-extension-handler-xar` and
`xwiki-platform-legacy-instance` have an unexcluded self-duplication pair, but none of them has any
test, so Surefire never runs there and no warning is emitted. I left them alone rather than adding
speculative configuration; every other legacy module is already clean.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

```bash
mvn clean install -B -ntp -pl xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore -Plegacy,quality
```

`BUILD SUCCESS` — Checkstyle 0 violations, license check OK, JaCoCo "All coverage checks have been
met", Revapi "API checks completed without failures", Spoon OK.

Surefire, parsed from `target/surefire-reports`:

* 48 tests, 0 failures, 0 errors, 0 skipped (unchanged)
* `tried to overwrite component` warnings: **1080 → 0**

Per class, warnings before → after: `PropertyChangedRuleTest` 720 → 0, `XWikiDocumentTest` 252 → 0,
`XWikiNotificationTest` 72 → 0, `XWikiTest` 36 → 0.

No SonarCloud PR analysis: this PR changes no Java.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None — test-output noise only, no need to carry it to the maintenance branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
