### PR TITLE
XWIKI-24855: Improve typography on "Supported By"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/extension.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/extension.css
@@ -48,9 +48,7 @@
 .supported-by h3,
 .supported-by h4{
   color: var(--text-muted);
-  font-size: 1.1rem;
-  font-weight: 600;
-  text-transform: uppercase;
+  font-size: .9em;
 }
 
 .supporter-listing {
@@ -82,8 +80,12 @@
 .plan-name.infomessage {
   border-radius: 96px;
   white-space: nowrap;
-  font-size: 1.2rem;
-  padding: 4px 6px;
+  font-size: 1rem;
+  padding: 4px 12px;
+}
+
+.plan-name.infomessage .wikiexternallink{
+  padding-right: 16px;
 }
 
 .plan-name.infomessage a {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/extension.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/extension.css
@@ -48,6 +48,9 @@
 .supported-by h3,
 .supported-by h4{
   color: var(--text-muted);
+  /*TODO: Change font-size to use CSS variables in future work.
+  For XWIKI-24855, the 0.9em values was used since it's used in other places of this CSS file,
+  making it 'locally' consistent. But they too should be updated to font variables */
   font-size: .9em;
 }
 


### PR DESCRIPTION
* Changed the basic styles for affect UI elements

# Jira URL

https://jira.xwiki.org/browse/XWIKI-24855
# Changes

## Description


* Improvements to the basic typography of Supported By

## Clarifications

* I didn't adapt the CSS for variables, just did a quick fix for the pressing issues

# Screenshots & Video

**Before:**

<img width="488" height="274" alt="Screenshot 2026-09-09 at 15 14 27" src="https://github.com/user-attachments/assets/923f4172-0884-4e40-9275-6dd7a6ed8769" />


**After:**

<img width="509" height="263" alt="Screenshot 2026-09-09 at 15 10 25" src="https://github.com/user-attachments/assets/0634d45e-8555-4dfe-9715-3f937308b2a5" />



# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 