### PR TITLE
XWIKI-24854: A Live Data macro is no longer rendered in the in-place WYSIWYG editor after switching to Source and back

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/pom.xml
@@ -49,6 +49,19 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- Required to test the Live Data in the in-place WYSIWYG editor. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-edit-test-pageobjects</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-ckeditor-test-pageobjects</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
     <!-- Runtime dependencies. -->
     <dependency>
       <groupId>org.xwiki.platform</groupId>
@@ -74,6 +87,21 @@
       <artifactId>xwiki-platform-localization-rest-default</artifactId>
       <version>${project.version}</version>
       <scope>runtime</scope>
+    </dependency>
+    <!-- The in-place WYSIWYG editor the Live Data is tested in. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-edit-ui</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+      <type>xar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-ckeditor-ui</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+      <type>xar</type>
     </dependency>
     <dependency>
       <groupId>org.xwiki.rendering</groupId>

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/AllIT.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/AllIT.java
@@ -36,4 +36,9 @@ class AllIT
     class NestedLiveDataIT extends LiveDataIT
     {
     }
+
+    @Nested
+    class NestedLiveDataInplaceEditIT extends LiveDataInplaceEditIT
+    {
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/LiveDataInplaceEditIT.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/LiveDataInplaceEditIT.java
@@ -30,8 +30,6 @@ import org.xwiki.test.docker.junit5.TestReference;
 import org.xwiki.test.docker.junit5.UITest;
 import org.xwiki.test.ui.TestUtils;
 
-import static java.util.Collections.singletonMap;
-
 /**
  * Tests of the Live Data macro in the in-place WYSIWYG editor.
  *
@@ -70,19 +68,22 @@ class LiveDataInplaceEditIT
     void liveDataIsStillDisplayedAfterSourceRoundTrip(TestUtils setup, TestReference testReference) throws Exception
     {
         setup.loginAsSuperAdmin();
-        setup.deletePage(testReference, true);
 
         // In-place editing is used only when the default editor is the WYSIWYG one.
         setup.setWikiPreference("editor", "Wysiwyg");
 
+        DocumentReference classReference = new DocumentReference("EntryClass", testReference.getLastSpaceReference());
+        DocumentReference entryReference = new DocumentReference("Entry", testReference.getLastSpaceReference());
+        setup.rest().delete(testReference);
+        setup.rest().delete(classReference);
+        setup.rest().delete(entryReference);
+
         // Define the XClass of the Live Data entries and create the single entry, before the page holding the macro:
-        // the Live Data has to be displayable as soon as that page is created, since creating it displays it.
-        DocumentReference classReference =
-            new DocumentReference("EntryClass", testReference.getLastSpaceReference());
+        // the Live Data has to be displayable as soon as that page is created, since creating it displays it. Adding
+        // a class property has no REST API, so it goes through the browser.
         setup.addClassProperty(classReference, NAME_COLUMN, "String");
         String className = setup.serializeReference(classReference.getLocalDocumentReference());
-        setup.addObject(new DocumentReference("Entry", testReference.getLastSpaceReference()), className,
-            singletonMap(NAME_COLUMN, NAME_LYNDA));
+        setup.rest().addObject(entryReference, className, NAME_COLUMN, NAME_LYNDA);
 
         // The text around the macro gives the editor a place to put the caret that is not the Live Data itself.
         String content = """

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/LiveDataInplaceEditIT.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/LiveDataInplaceEditIT.java
@@ -1,0 +1,129 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.livedata.test.ui;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.xwiki.ckeditor.test.po.CKEditor;
+import org.xwiki.edit.test.po.InplaceEditablePage;
+import org.xwiki.livedata.test.po.LiveDataElement;
+import org.xwiki.livedata.test.po.TableLayoutElement;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.test.docker.junit5.TestReference;
+import org.xwiki.test.docker.junit5.UITest;
+import org.xwiki.test.ui.TestUtils;
+
+import static java.util.Collections.singletonMap;
+
+/**
+ * Tests of the Live Data macro in the in-place WYSIWYG editor.
+ *
+ * @version $Id$
+ * @since 18.8.0RC1
+ */
+@UITest(
+    extraJARs = {
+        // The macro service uses the extension index script service to get the list of uninstalled macros (from
+        // extensions) which expects an implementation of the extension index. The extension index script service is a
+        // core extension so we need to make the extension index also core.
+        "org.xwiki.platform:xwiki-platform-extension-index"
+    },
+    resolveExtraJARs = true
+)
+class LiveDataInplaceEditIT
+{
+    private static final String NAME_COLUMN = "name";
+
+    private static final String NAME_LYNDA = "Lynda";
+
+    private static final String LIVE_DATA_ID = "test";
+
+    @AfterEach
+    void afterEach(TestUtils setup)
+    {
+        setup.maybeLeaveEditMode();
+    }
+
+    /**
+     * A Live Data displayed in the in-place editor must still be displayed after a round trip through the Source mode.
+     * The editor re-inserts the content it edits, which used to display the Live Data a second time and replace the
+     * table by an empty element.
+     */
+    @Test
+    void liveDataIsStillDisplayedAfterSourceRoundTrip(TestUtils setup, TestReference testReference) throws Exception
+    {
+        setup.loginAsSuperAdmin();
+        setup.deletePage(testReference, true);
+
+        // In-place editing is used only when the default editor is the WYSIWYG one.
+        setup.setWikiPreference("editor", "Wysiwyg");
+
+        // Define the XClass of the Live Data entries and create the single entry, before the page holding the macro:
+        // the Live Data has to be displayable as soon as that page is created, since creating it displays it.
+        DocumentReference classReference =
+            new DocumentReference("EntryClass", testReference.getLastSpaceReference());
+        setup.addClassProperty(classReference, NAME_COLUMN, "String");
+        String className = setup.serializeReference(classReference.getLocalDocumentReference());
+        setup.addObject(new DocumentReference("Entry", testReference.getLastSpaceReference()), className,
+            singletonMap(NAME_COLUMN, NAME_LYNDA));
+
+        // The text around the macro gives the editor a place to put the caret that is not the Live Data itself.
+        String content = """
+            before
+
+            {{liveData
+              id="%s"
+              properties="%s"
+              source="liveTable"
+              sourceParameters="translationPrefix=&className=%s"
+            /}}
+
+            after
+            """.formatted(LIVE_DATA_ID, NAME_COLUMN, className);
+        setup.createPage(testReference, content, "Live Data in the in-place editor");
+        assertLiveDataIsDisplayed();
+
+        // Entering the in-place editor moves the displayed content into the editable area.
+        InplaceEditablePage editablePage = new InplaceEditablePage().editInplace();
+        assertLiveDataIsDisplayed();
+
+        // Switch to Source and back: the editor replaces the content it edits by the freshly rendered one.
+        CKEditor editor = new CKEditor("content");
+        // Focus the rich text area to get the floating tool bar.
+        editor.getRichTextArea().click();
+        editor.getToolBar().toggleSourceMode();
+        editor.getToolBar().toggleSourceMode();
+        assertLiveDataIsDisplayed();
+
+        editablePage.cancel();
+        assertLiveDataIsDisplayed();
+    }
+
+    /**
+     * Asserts that the Live Data of the test page is displayed with its single entry. The page objects are created
+     * anew on each call because the editor replaces the Live Data element in the DOM.
+     */
+    private void assertLiveDataIsDisplayed()
+    {
+        TableLayoutElement tableLayout = new LiveDataElement(LIVE_DATA_ID).getTableLayout();
+        tableLayout.waitUntilRowCountEqualsTo(1);
+        tableLayout.assertRow(NAME_COLUMN, NAME_LYNDA);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/node/src/__tests__/main.test.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/node/src/__tests__/main.test.js
@@ -1,0 +1,141 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import $ from "jquery";
+
+const init = vi.fn();
+const delayPageReady = vi.fn((promise) => promise);
+
+vi.mock("../services/init.js", () => ({ init: (...args) => init(...args) }));
+vi.mock("@xwiki/platform-livedata-ui", () => ({ populateStore: () => {} }));
+
+// The plugin is registered as a RequireJS module, on the jQuery instance it is given.
+globalThis.require = (dependencies, callback) => callback($, { delayPageReady });
+
+await import("../main.js");
+
+const liveDataMarkup = '<div class="liveData" data-config=\'{"id":"test"}\'></div>';
+
+/**
+ * Let the pending dynamic imports, promise callbacks and jQuery ready callbacks run.
+ */
+async function settle() {
+  for (let i = 0; i < 5; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+/**
+ * @returns the number of live data displays that were started, each display delaying the page ready
+ */
+function startedDisplays() {
+  return delayPageReady.mock.calls.filter(([, reason]) => reason === "livedata:display").length;
+}
+
+describe("$.fn.liveData", () => {
+  beforeEach(async () => {
+    // The plugin displays the live data elements found on the page as soon as the document is ready. Let that first
+    // pass run before clearing the counters, so that the tests below start from a known state.
+    await settle();
+    init.mockReset();
+    init.mockResolvedValue({});
+    delayPageReady.mockClear();
+    document.body.innerHTML = "";
+  });
+
+  it("displays a live data element", async () => {
+    document.body.innerHTML = liveDataMarkup;
+    const element = document.querySelector(".liveData");
+
+    $(element).liveData();
+    await settle();
+
+    expect(startedDisplays()).toBe(1);
+    expect(init).toHaveBeenCalledTimes(1);
+    expect(init.mock.calls[0][0]).toBe(element);
+    expect(element.dataset.config).toBe('{"id":"test"}');
+  });
+
+  it("does not display the same element twice when asked again before the first display completes", async () => {
+    document.body.innerHTML = liveDataMarkup;
+    const element = document.querySelector(".liveData");
+
+    $(element).liveData();
+    $(element).liveData();
+    await settle();
+
+    expect(startedDisplays()).toBe(1);
+  });
+
+  it("does not display an already displayed element again on xwiki:dom:updated", async () => {
+    document.body.innerHTML = liveDataMarkup;
+
+    $(document).trigger("xwiki:dom:updated");
+    await settle();
+    expect(startedDisplays()).toBe(1);
+
+    $(document).trigger("xwiki:dom:updated");
+    await settle();
+    expect(startedDisplays()).toBe(1);
+  });
+
+  it("does not display an element whose configuration has already been consumed", async () => {
+    // The editor puts the content it edits back in the page, so the displayed live data comes back as a new element,
+    // without the configuration that displaying it consumed and without the jQuery marker of the node it replaces.
+    document.body.innerHTML = '<div class="liveData"><table><tbody><tr></tr></tbody></table></div>';
+    const element = document.querySelector(".liveData");
+
+    $(document).trigger("xwiki:dom:updated");
+    await settle();
+
+    expect(startedDisplays()).toBe(0);
+    expect(init).not.toHaveBeenCalled();
+    expect(element.querySelector("tr")).not.toBeNull();
+    expect(element.hasAttribute("data-config")).toBe(false);
+  });
+
+  it("displays an element without configuration when one is passed to the plugin", async () => {
+    document.body.innerHTML = '<div class="liveData"></div>';
+    const element = document.querySelector(".liveData");
+
+    $(element).liveData({ id: "passed" });
+    await settle();
+
+    expect(startedDisplays()).toBe(1);
+    expect(element.dataset.config).toBe('{"id":"passed"}');
+  });
+
+  it("displays a live data element that replaced an already displayed one", async () => {
+    document.body.innerHTML = liveDataMarkup;
+
+    $(document).trigger("xwiki:dom:updated");
+    await settle();
+    expect(startedDisplays()).toBe(1);
+
+    // The editor re-inserts the content it edited as HTML, so the live data element is a new, freshly rendered node
+    // that has to be displayed again.
+    document.body.innerHTML = liveDataMarkup;
+    $(document).trigger("xwiki:dom:updated");
+    await settle();
+
+    expect(startedDisplays()).toBe(2);
+    expect(init.mock.calls[1][0]).toBe(document.querySelector(".liveData"));
+  });
+});

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/node/src/__tests__/main.test.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/node/src/__tests__/main.test.js
@@ -19,6 +19,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import $ from "jquery";
+import { flushPromises } from "@vue/test-utils";
 
 const init = vi.fn();
 const delayPageReady = vi.fn((promise) => promise);
@@ -34,15 +35,6 @@ await import("../main.js");
 const liveDataMarkup = '<div class="liveData" data-config=\'{"id":"test"}\'></div>';
 
 /**
- * Let the pending dynamic imports, promise callbacks and jQuery ready callbacks run.
- */
-async function settle() {
-  for (let i = 0; i < 5; i++) {
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
-}
-
-/**
  * @returns the number of live data displays that were started, each display delaying the page ready
  */
 function startedDisplays() {
@@ -53,7 +45,7 @@ describe("$.fn.liveData", () => {
   beforeEach(async () => {
     // The plugin displays the live data elements found on the page as soon as the document is ready. Let that first
     // pass run before clearing the counters, so that the tests below start from a known state.
-    await settle();
+    await flushPromises();
     init.mockReset();
     init.mockResolvedValue({});
     delayPageReady.mockClear();
@@ -65,7 +57,7 @@ describe("$.fn.liveData", () => {
     const element = document.querySelector(".liveData");
 
     $(element).liveData();
-    await settle();
+    await flushPromises();
 
     expect(startedDisplays()).toBe(1);
     expect(init).toHaveBeenCalledTimes(1);
@@ -79,7 +71,7 @@ describe("$.fn.liveData", () => {
 
     $(element).liveData();
     $(element).liveData();
-    await settle();
+    await flushPromises();
 
     expect(startedDisplays()).toBe(1);
   });
@@ -88,11 +80,11 @@ describe("$.fn.liveData", () => {
     document.body.innerHTML = liveDataMarkup;
 
     $(document).trigger("xwiki:dom:updated");
-    await settle();
+    await flushPromises();
     expect(startedDisplays()).toBe(1);
 
     $(document).trigger("xwiki:dom:updated");
-    await settle();
+    await flushPromises();
     expect(startedDisplays()).toBe(1);
   });
 
@@ -103,7 +95,7 @@ describe("$.fn.liveData", () => {
     const element = document.querySelector(".liveData");
 
     $(document).trigger("xwiki:dom:updated");
-    await settle();
+    await flushPromises();
 
     expect(startedDisplays()).toBe(0);
     expect(init).not.toHaveBeenCalled();
@@ -116,7 +108,7 @@ describe("$.fn.liveData", () => {
     const element = document.querySelector(".liveData");
 
     $(element).liveData({ id: "passed" });
-    await settle();
+    await flushPromises();
 
     expect(startedDisplays()).toBe(1);
     expect(element.dataset.config).toBe('{"id":"passed"}');
@@ -126,14 +118,14 @@ describe("$.fn.liveData", () => {
     document.body.innerHTML = liveDataMarkup;
 
     $(document).trigger("xwiki:dom:updated");
-    await settle();
+    await flushPromises();
     expect(startedDisplays()).toBe(1);
 
     // The editor re-inserts the content it edited as HTML, so the live data element is a new, freshly rendered node
     // that has to be displayed again.
     document.body.innerHTML = liveDataMarkup;
     $(document).trigger("xwiki:dom:updated");
-    await settle();
+    await flushPromises();
 
     expect(startedDisplays()).toBe(2);
     expect(init.mock.calls[1][0]).toBe(document.querySelector(".liveData"));

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/node/src/main.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/node/src/main.js
@@ -23,15 +23,25 @@
 // fetched by the module loader of the web browser. The entries are fetched asynchronously as well. We thus have to
 // delay the page ready ourselves until the Live Data is displayed, otherwise the page can be marked as ready too
 // early (e.g. the PDF export would print an empty Live Data).
-require(["jquery", "xwiki-page-ready"], ($, pageReady) => {
+// The RequireJS require function is read from the global object rather than used as a free variable, so that this
+// module can be loaded outside of a RequireJS environment (e.g. by the unit tests).
+globalThis.require(["jquery", "xwiki-page-ready"], ($, pageReady) => {
   $.fn.liveData = function(config) {
     return this.each(function() {
-      if (!$(this).data("liveData")) {
-        const instanceConfig = $.extend($(this).data("config"), config);
-        pageReady.delayPageReady(import("./services/init.js").then(({init}) => {
+      const elementConfig = $(this).data("config");
+      // An element that carries no configuration is a live data that is already displayed: displaying it consumes the
+      // configuration. The editor puts such an element back in the page when it moves the content it edits into its
+      // editable area, and displaying it a second time would replace the table by an empty element.
+      if (!$(this).data("liveData") && (elementConfig || config)) {
+        const instanceConfig = $.extend({}, elementConfig, config);
+        const displayed = import("./services/init.js").then(({init}) => {
           $(this).attr("data-config", JSON.stringify(instanceConfig));
           return init(this, $);
-        }), "livedata:display");
+        });
+        // Mark the element as displayed synchronously, before the asynchronous initialization completes: this method
+        // is called again for every xwiki:dom:updated event and displaying the same element twice destroys it.
+        $(this).data("liveData", displayed);
+        pageReady.delayPageReady(displayed, "livedata:display");
       }
     });
   };

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/node/src/services/__tests__/init.test.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/node/src/services/__tests__/init.test.js
@@ -1,0 +1,41 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@xwiki/platform-livedata-ui", () => ({ XWikiLivedata: {} }));
+vi.mock("@xwiki/platform-livedata-xwiki", () => ({
+  XWikiLiveDataSource: class {},
+  initTranslationsBuilder: () => () => () => {},
+}));
+vi.mock("xwiki-platform-localization-webjar", () => ({ resolver: {} }));
+
+const { init } = await import("../init.js");
+
+describe("init", () => {
+  it("leaves the element untouched when it has no configuration", async () => {
+    document.body.innerHTML = '<div class="liveData"><table id="displayed"></table></div>';
+    const element = document.querySelector(".liveData");
+
+    await expect(init(element, undefined)).rejects.toThrow(/Missing data-config attribute/);
+
+    // An already displayed live data must survive a redundant initialization attempt.
+    expect(element.querySelector("#displayed")).not.toBeNull();
+  });
+});

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/node/src/services/init.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/node/src/services/init.js
@@ -38,11 +38,17 @@ import { resolver } from "xwiki-platform-localization-webjar";
  */
 function init(element, $) {
 
+  const data = element.dataset.config
+  if (data === undefined) {
+    // Mounting the application replaces the content of the element, so it must not be attempted without a
+    // configuration: that would discard an already displayed live data and leave an empty element behind.
+    return Promise.reject(new Error("Missing data-config attribute, the live data cannot be displayed."));
+  }
+  element.removeAttribute("data-config")
+
   const locale = document.documentElement.getAttribute("lang");
   const i18n = createI18n({ legacy: false, locale });
 
-  const data = element.dataset.config
-  element.removeAttribute("data-config")
   let contentTrusted = false;
   try {
     const scriptEl = element.querySelector(':scope > script[type="application/json"]');


### PR DESCRIPTION
<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24854

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Skip the elements that carry no configuration when displaying the LDs of the page. 
* Mark a live data element as displayed as soon as its display starts, so that the xwiki:dom:updated
  event does not display it a second time.
* Reject the initialization when the element carries no configuration, instead of mounting the Vue
  application over it: mounting replaces the content of the element.
* **Add a functional test specifically for testing LD in CKEditor.**


## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install javadoc:javadoc -pl :xwiki-platform-livedata-test-docker,:xwiki-platform-livedata-webjar -Pquality,integration-tests,docker,legacy
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-18.4.x