### PR TITLE
XWIKI-22502: ImageIT#editImageWithDataWidgetAttribute is flickering

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/ImageIT.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/ImageIT.java
@@ -915,8 +915,10 @@ class ImageIT extends AbstractCKEditorIT
         ViewPage page = setup.createPage(testReference, "[[image:image.gif||data-widget='uploadimage']]");
         WYSIWYGEditPage wysiwygEditPage = page.editWYSIWYG();
         CKEditor editor = new CKEditor("content").waitToLoad();
-        // Make sure the image can be clicked as a proof that the editor did not crash.
-        editor.executeOnEditedContent(() -> setup.getDriver().findElement(By.cssSelector("img")).click());
+        // Make sure the editor did not crash.
+        editor.getRichTextArea().verifyContent(content -> assertTrue(
+            content.getImages().stream().anyMatch(image -> image.getDomAttribute("src").endsWith("/image.gif")),
+            "The image is missing from the edited content."));
         ViewPage savedPage = wysiwygEditPage.clickSaveAndView();
         assertEquals("[[image:image.gif]]", savedPage.editWiki().getContent());
     }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22502

# Changes

## Description

* Replaced the click on the image with a check that the image is present in the edited content
* Matched the image on its source instead of counting the images of the edited content

## Clarifications

The flicker came from a click. The click was a liveness probe for [XWIKI-22073](https://jira.xwiki.org/browse/XWIKI-22073). 

The replacement cannot hit either window: `getRichTextArea()` waits for the content to become editable, which a crashed editor never does, and `verifyContent` only queries the DOM. `RichTextAreaContent#getImages()` also returns the widget drag handler, hence the match on the image source rather than a count of the images.

Clicking an image in the edited content remains covered by the other tests of `ImageIT`, where the click selects the image widget for the toolbar action that follows, 

# Screenshots & Video

N/A -- test-only change.

# Executed Tests

The test method was run 10 times on each browser, with a temporary `@RepeatedTest(value = 10, failureThreshold = 1)` in place of `@Test` that is not part of the commit.

`mvn verify -B -ntp -nsu -pl xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker -Pdocker,integration-tests -Dit.test='AllIT$NestedImageIT#editImageWithDataWidgetAttribute' -Dxwiki.test.ui.browser=firefox` -- Tests run: 10, Failures: 0, Errors: 0, Skipped: 0.

The same command with `-Dxwiki.test.ui.browser=chrome` -- Tests run: 10, Failures: 0, Errors: 0, Skipped: 0.

`mvn verify -B -ntp -nsu -pl xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker -Pdocker,integration-tests -Dit.test='AllIT$NestedImageIT'` -- Tests run: 26, Failures: 0, Errors: 0, Skipped: 1, the skip being `moveImageWithinEditedContentWithDragAndDrop`.

`mvn -B -ntp checkstyle:check@test -Pdocker,integration-tests -pl xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker` -- 0 Checkstyle violations.

Ran a `xwiki-review`, nothing more than a flicker testing (I did not run the test enough to validate the flicker was dealt with) warning was found.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * 17.10.X
  * 18.4.X

