### PR TITLE
[Misc] Replace the deprecated PackageAPI import report calls in imported.vm

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/imported.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/imported.vm
@@ -27,7 +27,7 @@
 #end
 #macro(_showFileList $contextKey $text)
   #_getImportedDocuments($contextKey)
-  #if($importedDocuments.size()>0)
+  #if($importedDocuments.size() > 0)
     <h4 class="legend">
       $escapetool.xml($services.localization.render("import_listof${text}files"))
     </h4>

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/imported.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/imported.vm
@@ -18,29 +18,42 @@
 ## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 ## ---------------------------------------------------------------------------
 #template("xwikivars.vm")
-#macro(showfilelist $list $text)
-  #if($list.size()>0)
+## Sets $importedDocuments to the documents that the importer reported under $contextKey.
+#macro(_getImportedDocuments $contextKey)
+  #set($importedDocuments = $xcontext.get($contextKey))
+  #if("$!importedDocuments" == '')
+    #set($importedDocuments = [])
+  #end
+#end
+#macro(_showFileList $contextKey $text)
+  #_getImportedDocuments($contextKey)
+  #if($importedDocuments.size()>0)
     <h4 class="legend">
       $escapetool.xml($services.localization.render("import_listof${text}files"))
     </h4>
     <ul>
-      #foreach($item in $list)
+      #foreach($item in $importedDocuments)
         <li><a href="$xwiki.getURL($item)">$escapetool.xml($item)</a></li>
       #end
     </ul>
   #end
 #end
+#macro(_showImportedCount $contextKey $translationKey)
+  #_getImportedDocuments($contextKey)
+  <li>$importedDocuments.size() $escapetool.xml($services.localization.render($translationKey))</li>
+#end
 #if($hasAdmin)
-  #set($status = $escapetool.xml($services.localization.render("import_install_${xwiki.package.status}")))
+  #set($importStatus = $xcontext.get('install_status'))
+  #set($status = $escapetool.xml($services.localization.render("import_install_${importStatus}")))
   #info("$escapetool.xml($services.localization.render('importing')) $!escapetool.xml($request.name): $status")
   <ul>
-    <li>$xwiki.package.installed.size() $escapetool.xml($services.localization.render('import_documentinstalled'))</li>
-    <li>$xwiki.package.skipped.size() $escapetool.xml($services.localization.render('import_documentskipped'))</li>
-    <li>$xwiki.package.errors.size() $escapetool.xml($services.localization.render('import_documenterrors'))</li>
+    #_showImportedCount('install_installed' 'import_documentinstalled')
+    #_showImportedCount('install_skipped' 'import_documentskipped')
+    #_showImportedCount('install_errors' 'import_documenterrors')
   </ul>
-  #showfilelist($xwiki.package.installed 'installed')
-  #showfilelist($xwiki.package.skipped 'skipped')
-  #showfilelist($xwiki.package.errors 'error')
+  #_showFileList('install_installed' 'installed')
+  #_showFileList('install_skipped' 'skipped')
+  #_showFileList('install_errors' 'error')
 #else
   ## If the current user does not have admin and this template is being displayed
   ## it means security settings have been changed with the import (probably a default XE XAR import)


### PR DESCRIPTION
# Jira URL

None, fix for a regression introduced by 60525743340ba2a1b806b88ad5d7711a5f5c2b85  (see https://github.com/xwiki/xwiki-platform/commit/60525743340ba2a1b806b88ad5d7711a5f5c2b85#r199380122).

# Changes

## Description

* Read the import report from the context instead of through the deprecated `PackageAPI` in `imported.vm`.
* Added `_showImportedCount` to display the number of documents reported under a context key.
* Passed the context key to `_showFileList` instead of the document list.
* Prefixed the template's internal macros with an underscore.

## Clarifications

* Follow-up of #6340, which fixed the same deprecation in `javascript.vm` and `importinline.vm` but skipped `imported.vm` as having no simple replacement.
* This is the remaining cause of the `AllIT$NestedXARImportIT` failure on master, `imported.vm` being rendered by every XAR import.
* A document list is absent from the context until a document ends up in it, hence the empty-list default.
* Dropped the `-1` status fallback, since `Importer.generateReport` always sets the status.

# Screenshots & Video

No visible result, the rendered import report is unchanged.

# Executed Tests

`mvn clean install -B -ntp -Plegacy,quality -pl xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates`: BUILD SUCCESS, 64 goals executed, 0 Checkstyle violations, coverage checks met.

`mvn verify -B -ntp -Pdocker,integration-tests -pl xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker -Dit.test='AllIT$NestedXARImportIT'`: BUILD SUCCESS, 9 tests, 0 failures, and 0 `Deprecated usage of` lines in the whole run. The same command against the WAR built from the unmodified template reproduces the 7 warnings per import that fail the suite on master.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None, the regression is only on master.
