### PR TITLE
XWIKI-24796: Live Data fails to render in PDF export on 17.10.x

### DIFF
--- a/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-ui/src/main/resources/Dashboard/XWikiUserDashboardSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-ui/src/main/resources/Dashboard/XWikiUserDashboardSheet.xml
@@ -304,8 +304,7 @@
     {{dashboard/}}
   #end
       #end
-      {{/velocity}}
-      </content>
+      {{/velocity}}</content>
     </property>
     <property>
       <extensionPointId>org.xwiki.plaftorm.user.profile.menu</extensionPointId>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/XWikiUserNotificationsSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/XWikiUserNotificationsSheet.xml
@@ -348,8 +348,7 @@
   {{notificationsCustomFiltersPreferences user="$userDoc" /}}
 )))
 #end
-      {{/velocity}}
-      </content>
+      {{/velocity}}</content>
     </property>
     <property>
       <extensionPointId>org.xwiki.plaftorm.user.profile.menu</extensionPointId>


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24796

Fixes the HTML5 validity regression that surfaced on `master` with c8d1f332e6b9933f105e5049c831c508cb967040 (same issue), which makes the `flavor-test-webstandards` `DefaultValidationTest` fail on `XWiki.Admin` since [build #8921](https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/8937/testReport/org.xwiki.test.webstandards.framework/DefaultValidationTest/Platform_Builds___main___distribution___flavor_test_webstandards___Build_for_Flavor_Test___Webstandards___Validating_HTML5_validity_for__http___127_0_0_1_8080_xwiki_bin_view_XWiki_Admin__executed_with_credentials_Admin_admin/):

```
ERROR: No "p" element in scope but a "p" end tag seen. at line [1708] column [73]
ERROR: No "p" element in scope but a "p" end tag seen. at line [1723] column [259]
```

# Changes

## Description

One line in each of the two profile category UI extensions that were producing the invalid markup —
`Dashboard.XWikiUserDashboardSheet` (the `dashboard` pane) and
`XWiki.Notifications.Code.XWikiUserNotificationsSheet` (the `notifications` pane):

```diff
-      {{/velocity}}
-      </content>
+      {{/velocity}}</content>
```

## Clarifications

**Root cause.** That trailing indentation sits *outside* the `{{velocity}}` macro, so Velocity's line
gobbling never removes it. It survives as a text node after the last block of the UI extension, and
the renderer therefore wraps the entire pane content — the block-level `<div>`s included — in a
single paragraph:

```html
<div id="dashboardPane"><p><div class="full column xform">…</div><div class="dashboard">…</div><br/>      </p></div>
```

Ending the content right at `{{/velocity}}</content>` — which is what other category sheets such as
`XWikiUserMembershipSheet` already do, and what `mvn xar:format` produces — removes the text node,
and the paragraph wrapping with it.

**Why this only showed up now.** It is a pre-existing defect in these two pages. Before
c8d1f332e6b, `XWikiUserSheet` rendered each pane with
`{{html}}$services.rendering.render($subcategory.uix.execute(), 'html/5.0'){{/html}}`; that outer
`{{html}}` macro defaults to `clean="true"`, so the HTML cleaner silently repaired the nesting.
Moving to the `{{uiextension}}` macro inserts the UI extension blocks straight into the page XDOM,
which is the right thing to do — it keeps the content syntax-agnostic instead of freezing it into an
`html/5.0` raw block that gets dropped when the page is rendered in another output syntax, which is
the very failure mode this issue is about. It just stopped hiding the bug in these two pages.

**`XWikiUserSheet` is left untouched on purpose.** Re-adding a cleaning `{{html}}` wrapper there
would fix the symptom but undo that improvement, so the fix is applied where the invalid markup is
actually produced.

# Screenshots & Video

No visible change — the rendered user profile is identical, only the HTML nesting differs.

Rendering the two UI extensions through the `{{uiextension}}` macro in the profile sheet, before and
after (with `{{dashboard}}` / the `notifications*` macros stubbed out so the pages render in a page
test):

| Pane | Before | After |
|---|---|---|
| `dashboard` | `<p><div class="full column xform">…</div><div class="dashboard">…</div><br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</p>` — 2 stray `<p>` | `<div class="full column xform">…</div><div class="dashboard">…</div>` — 0 `<p>` |
| `notifications` | trailing stray `</p>` | clean section markup, 0 `<p>` |

# Executed Tests

```
mvn -pl xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-ui,\
xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui xar:verify
  -> BUILD SUCCESS

mvn -pl <both modules> xar:format
  -> no further change (the new form is the canonical one)

mvn -pl xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui test
  -> Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

Additionally, both UI extensions' executed content was rendered through the `{{uiextension}}` macro
inside `XWiki.XWikiUserSheet` in a throwaway page test, asserting on the resulting pane markup:
0 paragraphs after the fix, and reverting either page reproduces the stray paragraphs. That harness
was not kept — see below.

**No automated test is added.** The defect is trailing whitespace in the content of two XAR pages,
and the guard that already exists for it is the functional
`flavor-test-webstandards` `DefaultValidationTest` on `XWiki.Admin`, which is what caught it and
which should go back to green. A unit test at this level would have to stub out `{{dashboard}}` and
every `notifications*` macro to render these pages, which seemed disproportionate — happy to add one
in `xwiki-platform-dashboard-ui` / `xwiki-platform-notifications-ui` if you would rather have it.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None — the invalid markup only becomes visible on `master`, where the panes are no longer
    rendered through a cleaning `{{html}}` macro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
