### PR TITLE
XWIKI-24857: Navigation Panel administration: dragging pages in or out of the tree sometimes has no effect on the tree

### DIFF
--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-pageobjects/src/main/java/org/xwiki/panels/test/po/NavigationPanelAdministrationPage.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-pageobjects/src/main/java/org/xwiki/panels/test/po/NavigationPanelAdministrationPage.java
@@ -23,10 +23,13 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.xwiki.administration.test.po.AdministrationPage;
@@ -153,10 +156,45 @@ public class NavigationPanelAdministrationPage extends ViewPage
      */
     private void waitUntilTopLevelPagesState(List<String> pages, boolean visible)
     {
-        getDriver().waitUntilCondition(driver -> {
-            List<String> topLevelPages = getNavigationTree().getTopLevelPages();
-            return pages.stream().allMatch(page -> topLevelPages.contains(page) == visible);
-        });
+        // Remember the last observed state so that we can report it if we time out, without having to query the tree
+        // again from the catch block (which could fail on its own and thus hide the actual failure).
+        AtomicReference<List<String>> lastTopLevelPages = new AtomicReference<>();
+        try {
+            getDriver().waitUntilCondition(driver -> {
+                List<String> topLevelPages = getNavigationTree().getTopLevelPages();
+                lastTopLevelPages.set(topLevelPages);
+                // The navigation tree always displays at least the "no pages found" placeholder, so a tree without any
+                // visible top level page means the tree is in an inconsistent state. Don't consider the expected state
+                // reached in this case, otherwise the failure would surface much later, in an unrelated assertion.
+                return !topLevelPages.isEmpty()
+                    && pages.stream().allMatch(page -> topLevelPages.contains(page) == visible);
+            });
+        } catch (TimeoutException e) {
+            // Report the state that we could observe, in order to be able to diagnose the failure without access to
+            // the browser console.
+            throw new TimeoutException(String.format(
+                "Timed out waiting for %s to %s the top level pages of the navigation tree. Visible top level pages: "
+                    + "%s. Node types accepted by the tree root: %s.",
+                pages, visible ? "appear in" : "disappear from", lastTopLevelPages.get(),
+                getNavigationTreeRootValidChildren()), e);
+        }
+    }
+
+    /**
+     * @return the node types that the navigation tree accepts as children of its root node; the tree silently ignores
+     *     the attempts to create a node of a different type, so this is useful to diagnose why a page didn't show up
+     *     in (or disappear from) the tree
+     */
+    private Object getNavigationTreeRootValidChildren()
+    {
+        try {
+            return getDriver().executeScript(
+                "return jQuery.jstree.reference(jQuery(arguments[0]))?.get_node('#')?.data?.validChildren",
+                this.treeElement);
+        } catch (Exception e) {
+            // This is only used to enrich a failure message, so it must never hide the actual failure.
+            return "unknown (" + ExceptionUtils.getRootCauseMessage(e) + ")";
+        }
     }
 
     public boolean isExcludingTopLevelExtensionPages()

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/PanelsCode/NavigationConfigurationSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/PanelsCode/NavigationConfigurationSheet.xml
@@ -557,11 +557,42 @@ require([
 
   const $navigationTree = $('.navigationPanelConfiguration .xtree');
 
-  // Make sure the root node accepts known node types as children.
-  $navigationTree.on('ready.jstree', function(event, data) {
-    const tree = data.instance;
+  //
+  // Tree Initialization
+  //
+  // The navigation tree is initialized and loaded asynchronously, by a different module, while this module has to
+  // wait for its own dependencies (e.g. the translations, which are fetched from the server). There is thus no
+  // guarantee that this code is executed before the tree is ready, so everything we set up here through tree event
+  // listeners has to be applied also when the tree happens to be ready already by the time we register those
+  // listeners (see the catch-up code at the end of this module). See also XWIKI-24857.
+  //
+
+  // Specify the node types accepted as children by the tree root. We have to do this explicitly because otherwise the
+  // tree infers them from the nodes it receives from the server: when all the top level pages are excluded the server
+  // returns only the "empty" node, and otherwise it returns only document nodes. In both cases creating the missing
+  // node type on the client side, when the user drags a page out of or into the tree, would be rejected.
+  function setValidRootChildren(rootData) {
+    rootData.validChildren = ['document', 'pagination', 'empty'];
+    // Make sure the tree doesn't infer the valid child nodes again when the root node is loaded or refreshed.
+    delete rootData.validChildrenInferred;
+    return rootData;
+  }
+
+  // This covers the case where the root node hasn't been loaded yet: the tree takes the root node data from the tree
+  // element when it loads the root node.
+  $navigationTree.data('root', setValidRootChildren($navigationTree.data('root') || {}));
+
+  let treeInitialized = false;
+
+  function initializeTree(tree) {
+    if (treeInitialized) {
+      return;
+    }
+    treeInitialized = true;
+
+    // This covers the case where the root node has already been loaded, with its own copy of the root node data.
     const root = tree.get_node($.jstree.root);
-    root.data.validChildren = ['document', 'pagination', 'empty'];
+    root.data = setValidRootChildren(root.data || {});
 
     // Make sure top level nodes can't be moved to a lower level. We only allow reordering the top level nodes.
     const originalCheckCallback = tree.settings.core.check_callback;
@@ -572,17 +603,23 @@ require([
         return originalCheckCallback.apply(this, arguments);
       }
     };
+  }
 
   // Prevent drag &amp; drop for tree nodes that are not on the top level.
+  function preventChildNodeDragAndDrop(tree, nodeIds) {
+    nodeIds.forEach(nodeId =&gt; {
+      const node = tree.get_node(nodeId);
+      if (node?.data) {
+        node.data.draggable = false;
+      }
+    });
+  }
+
+  $navigationTree.on('ready.jstree', function(event, data) {
+    initializeTree(data.instance);
   }).on('model.jstree', function(event, data) {
     if (data.parent !== $.jstree.root) {
-      const tree = data.instance;
-      data.nodes.forEach(nodeId =&gt; {
-        const node = tree.get_node(nodeId);
-        if (node?.data) {
-          node.data.draggable = false;
-        }
-      });
+      preventChildNodeDragAndDrop(data.instance, data.nodes);
     }
   });
 
@@ -600,11 +637,8 @@ require([
     });
   } else {
     modifyNodeTemplate(nodeTemplate);
-    if (navigationTree._data.core.ready) {
-      // Tree nodes have already been created from the template. We have to redraw them in order to use the modified
-      // template.
-      navigationTree.redraw(true);
-    }
+    // Note that the tree nodes that have already been created from the original template are redrawn by the catch-up
+    // code at the end of this module, once all our tree event listeners are registered.
   }
 
   function modifyNodeTemplate(nodeTemplate) {
@@ -718,19 +752,22 @@ require([
     .map(value =&gt; decodeURIComponent(value.endsWith('/') ? value.substring(0, value.length - 1) : value));
   let pinnedTopLevelPagesDirty = false;
 
-  $navigationTree.on('model.jstree', function(event, data) {
-    // Mark pinned top level pages.
-    const tree = data.instance;
-    if (data.parent === $.jstree.root) {
-      data.nodes.forEach(nodeId =&gt; {
-        const node = tree.get_node(nodeId);
-        if (node?.data?.type === 'document') {
-          const documentReference = XWiki.Model.resolve(node.data.id, XWiki.EntityType.DOCUMENT);
-          if (pinnedTopLevelPages.includes(documentReference.parent.name)) {
-            node.a_attr['data-pinned'] = true;
-          }
+  // Mark pinned top level pages.
+  function markPinnedTopLevelPages(tree, nodeIds) {
+    nodeIds.forEach(nodeId =&gt; {
+      const node = tree.get_node(nodeId);
+      if (node?.data?.type === 'document') {
+        const documentReference = XWiki.Model.resolve(node.data.id, XWiki.EntityType.DOCUMENT);
+        if (pinnedTopLevelPages.includes(documentReference.parent.name)) {
+          node.a_attr['data-pinned'] = true;
         }
-      });
+      }
+    });
+  }
+
+  $navigationTree.on('model.jstree', function(event, data) {
+    if (data.parent === $.jstree.root) {
+      markPinnedTopLevelPages(data.instance, data.nodes);
     }
   });
 
@@ -887,6 +924,31 @@ require([
     // Add back the custom save handler.
     $saveButton.off(submitEvent).on(submitEvent, savePinnedTopLevelPages);
   });
+
+  //
+  // Tree Initialization Catch-up
+  //
+  // See the comment about the tree initialization race at the top of this module: when the tree is loaded before this
+  // module is executed, the tree events we listen to have already been fired, so we have to apply ourselves what our
+  // listeners would have applied.
+  //
+
+  if (navigationTree?._data?.core?.ready) {
+    initializeTree(navigationTree);
+    const catchUpWithLoadedNodes = function(parentNodeId) {
+      const childNodeIds = navigationTree.get_node(parentNodeId).children;
+      if (parentNodeId === $.jstree.root) {
+        markPinnedTopLevelPages(navigationTree, childNodeIds);
+      } else {
+        preventChildNodeDragAndDrop(navigationTree, childNodeIds);
+      }
+      childNodeIds.forEach(childNodeId =&gt; catchUpWithLoadedNodes(childNodeId));
+    };
+    catchUpWithLoadedNodes($.jstree.root);
+    // The tree nodes have been created before we modified the node template and before we marked the pinned top level
+    // pages, and the pin action is added only when a node is (re)drawn, so we need a full redraw.
+    navigationTree.redraw(true);
+  }
 });</code>
     </property>
     <property>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24857

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Make the navigation panel administration initialization independent of the initialization order.
* Improve the waiting condition in the page object and add more diagnostic information.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This is supposed to be the true fix for https://jira.xwiki.org/browse/XWIKI-23126 (which was closed with a wait that just changed the error message).
* I have reviewed the code, and it seems plausible, but I haven't taken the time to truly understand the logic of that file, I mostly relied on Opus 5 for that which found the issue and wrote and tested the fix.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

`:xwiki-platform-panels-ui` in three variants:

* The state of this PR, passes.
* The state of this PR, but with the change mentioned in https://jira.xwiki.org/browse/XWIKI-24857 to force the other, less likely code path, passes.
* The pre-fix version of NavigationConfigurationSheet with the change mentioned in https://jira.xwiki.org/browse/XWIKI-24857 showing that it indeed fails with the exact failure and the new diagnostics in the page object work.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-18.4.x
  * stable-17.10.x
  * stable-16.10.x for the flickering?