### PR TITLE
Xwiki 24763

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
@@ -65,6 +65,7 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
   border: none;
   cursor: default;
   background: transparent;
+  min-height: 24px;
 }
 
 .xobject:hover .xobject-title,
@@ -116,10 +117,6 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
 
 .xobject-title .edit {
   right: 28px;
-}
-
-.xobject-row {
-  min-height: 24px;
 }
 
 /* XProperty definition */
@@ -241,7 +238,6 @@ The default state is collapsed for xobjects and xproperties, but expanded for xc
   height: 16px;
   padding: 4px;
   box-sizing: content-box;
-  background-clip: content-box;
   float: left;
   background: transparent none center no-repeat;
   margin-top: -4px;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
@@ -99,14 +99,14 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
 }
 
 .xobject-action {
-    display: block;
-    position: absolute;
-    top: -5px;
-    padding: 7px;
+   display: block;
+   position: absolute;
+   top: -5px;
+   padding: 7px;
 }
 
 .xobject-action.delete {
-    right: 0px;
+   right: 0px;
 }
 
 .xobject-title .delete {
@@ -119,7 +119,7 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
 }
 
 .xobject-row {
-    min-height: 24px;
+   min-height: 24px;
 }
 
 /* XProperty definition */
@@ -237,14 +237,14 @@ The default state is collapsed for xobjects and xproperties, but expanded for xc
 }
 
 .xproperty-title .tools .tool {
-    width: 16px;
-    height: 16px;
-    padding: 4px;
-    box-sizing: content-box;
-    background-clip: content-box;
-    float: left;
-    background: transparent none center no-repeat;
-    margin-top: -4px;
+   width: 16px;
+   height: 16px;
+   padding: 4px;
+   box-sizing: content-box;
+   background-clip: content-box;
+   float: left;
+   background: transparent none center no-repeat;
+   margin-top: -4px;
 }
 
 .xproperty-title .tools .move {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
@@ -65,7 +65,7 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
   border: none;
   cursor: default;
   background: transparent;
-  min-height: 24px;
+  min-height: 24px;   /* Ensures minimum row height so vertically adjacent targets do not overlap */
 }
 
 .xobject:hover .xobject-title,
@@ -103,11 +103,11 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
   display: block;
   position: absolute;
   top: -5px;
-  padding: 7px;
+  padding: 7px;  /* Ensures the clickable area meets the WCAG 2.5.8 minimum target size of 24x24px */
 }
 
 .xobject-action.delete {
-   right: 0px;
+   right: 0;
 }
 
 .xobject-title .delete {
@@ -116,7 +116,7 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
 }
 
 .xobject-title .edit {
-  right: 28px;
+  right: 28px;   /* Offset accounts for the delete button width plus its padding to prevent overlap */
 }
 
 /* XProperty definition */
@@ -236,7 +236,7 @@ The default state is collapsed for xobjects and xproperties, but expanded for xc
 .xproperty-title .tools .tool {
   width: 16px;
   height: 16px;
-  padding: 4px;
+  padding: 4px;   /* Extra padding increases the clickable area to meet WCAG 2.5.8 minimum target size */
   box-sizing: content-box;
   float: left;
   background: transparent none center no-repeat;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
@@ -99,9 +99,14 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
 }
 
 .xobject-action {
-  display: block;
-  position: absolute;
-  top: 2px;
+    display: block;
+    position: absolute;
+    top: -5px;
+    padding: 7px;
+}
+
+.xobject-action.delete {
+    right: 0px;
 }
 
 .xobject-title .delete {
@@ -110,7 +115,11 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
 }
 
 .xobject-title .edit {
-  right: 16px;
+  right: 28px;
+}
+
+.xobject-row {
+    min-height: 24px;
 }
 
 /* XProperty definition */
@@ -228,10 +237,14 @@ The default state is collapsed for xobjects and xproperties, but expanded for xc
 }
 
 .xproperty-title .tools .tool {
-  width: 16px;
-  height: 16px;
-  float: left;
-  background: transparent none center no-repeat;
+    width: 16px;
+    height: 16px;
+    padding: 4px;
+    box-sizing: content-box;
+    background-clip: content-box;
+    float: left;
+    background: transparent none center no-repeat;
+    margin-top: -4px;
 }
 
 .xproperty-title .tools .move {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
@@ -237,14 +237,14 @@ The default state is collapsed for xobjects and xproperties, but expanded for xc
 }
 
 .xproperty-title .tools .tool {
-   width: 16px;
-   height: 16px;
-   padding: 4px;
-   box-sizing: content-box;
-   background-clip: content-box;
-   float: left;
-   background: transparent none center no-repeat;
-   margin-top: -4px;
+  width: 16px;
+  height: 16px;
+  padding: 4px;
+  box-sizing: content-box;
+  background-clip: content-box;
+  float: left;
+  background: transparent none center no-repeat;
+  margin-top: -4px;
 }
 
 .xproperty-title .tools .move {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
@@ -99,10 +99,10 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
 }
 
 .xobject-action {
-   display: block;
-   position: absolute;
-   top: -5px;
-   padding: 7px;
+  display: block;
+  position: absolute;
+  top: -5px;
+  padding: 7px;
 }
 
 .xobject-action.delete {
@@ -119,7 +119,7 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
 }
 
 .xobject-row {
-   min-height: 24px;
+  min-height: 24px;
 }
 
 /* XProperty definition */


### PR DESCRIPTION
# Jira URL
https://jira.xwiki.org/browse/XWIKI-24763

# Changes

## Description
* Increased the clickable target size of action buttons in the class editor 
  and object editor to meet WCAG 2.5.8 minimum target size requirement of 24x24 CSS pixels.
* Updated `.xproperty-title .tools .tool` in the class editor and `.xobject-action` 
  in the object editor in `dataeditors.css`.

## Clarifications
* The fix uses padding to increase the clickable area without visually 
  enlarging the icon itself.
* Both the class editor (`.xproperty-title .tools .tool`) and object editor 
  (`.xobject-action`, `.xobject-title .edit`, `.xobject-title .delete`) were affected.
* The icons are Font Awesome glyphs whose size is controlled by font-size, 
  so width/height alone had no effect; padding was used instead to grow the tap target.

# Screenshots & Video
<img width="2530" height="329" alt="Screenshot 2026-09-11 at 1 08 31 PM" src="https://github.com/user-attachments/assets/4627f44d-207c-45cc-b920-4cc28948c0aa" />
<img width="2536" height="284" alt="Screenshot 2026-09-11 at 1 08 56 PM" src="https://github.com/user-attachments/assets/a57b1fec-cbcf-4b40-84f8-ff0db781bfab" />


# Executed Tests
Manually tested on XWiki 17.10.13 standalone distribution on macOS.
Verified in Chrome devtools that computed sizes now meet the 24x24 minimum.
No automated tests added as this is a pure CSS accessibility fix.

# Expected merging strategy
* Prefers squash: Yes
* Backport on branches:
  * Please advise which branches need backporting.