### PR TITLE
XWIKI-24864: Active Installs searchInstalls() returns at most 10 pings while its javadoc promises all of them

### DIFF
--- a/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/DataManager.java
+++ b/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/DataManager.java
@@ -36,7 +36,12 @@ import org.xwiki.stability.Unstable;
 public interface DataManager
 {
     /**
-     * Executes a Search query for Active Installs.
+     * Executes a Search query for Active Installs. Note that this returns a bounded number of the matching pings and
+     * not all of them: a ping holds the whole extension list of an instance, and an instance sends a ping every day
+     * as well as every time it's restarted, so the matching pings are far too many and too big to be held in memory.
+     * Which pings of the matching ones are returned is not defined either, since they are not sorted. So this answers
+     * "what does a matching ping look like". It answers neither "how many instances match", which
+     * {@link #countDistinctInstalls(String)} does, nor "give me every matching ping", which is not supported.
      *
      * @param jsonQuery the Elastic Search JSON query used to search for installs. For example:
      *        <pre>{@code
@@ -44,8 +49,9 @@ public interface DataManager
      *                "term": { "distribution.extension.version" : "5.2" }
      *            }
      *        }</pre>
-     * @return the parsed JSON result coming from Elastic Search, as a list of {@link Ping} object. Passing an empty
-     *      or null json string results in returning all data found in the index (i.e no query constraint)
+     *      Passing an empty or null json string matches all the data found in the index (i.e no query constraint)
+     * @return the parsed JSON result coming from Elastic Search, as a list of {@link Ping} object. Implementations
+     *      are allowed to return only some of the matching pings, and document the number above which they do
      * @throws Exception when an error happens while retrieving the data
      * @since 14.4RC1
      */

--- a/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/internal/DefaultDataManager.java
+++ b/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/internal/DefaultDataManager.java
@@ -97,6 +97,14 @@ public class DefaultDataManager implements DataManager
         return count.count();
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Returns at most 10 pings, which is the number of hits Elasticsearch returns for a search request that doesn't
+     * ask for a size. No size is asked for since the pings are only meant to be sampled here: retrieving more of
+     * them, let alone all of them, would mean holding an unbounded number of extension lists in memory, which the
+     * counting methods avoid by aggregating server-side instead.
+     */
     @Override
     public List<Ping> searchInstalls(String jsonQuery) throws Exception
     {

--- a/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/script/ActiveInstallsScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api/src/main/java/org/xwiki/activeinstalls2/script/ActiveInstallsScriptService.java
@@ -66,7 +66,10 @@ public class ActiveInstallsScriptService implements ScriptService
     }
 
     /**
-     * Executes a Search query for Active Installs.
+     * Executes a Search query for Active Installs. Note that this returns only some of the matching pings, and which
+     * ones it returns is not defined, so it answers "what does a matching ping look like" rather than "give me every
+     * matching ping". Use {@link #countInstalls(String)} or {@link #countDistinctInstalls(String)} to count the
+     * matching pings or instances, since they count server-side instead of retrieving anything.
      *
      * @param jsonQuery the Elastic Search JSON query used to search for installs. For example:
      *        <pre>{@code
@@ -74,8 +77,11 @@ public class ActiveInstallsScriptService implements ScriptService
      *                "term": { "distribution.extension.version" : "5.2" }
      *            }
      *        }</pre>
-     * @return the parsed JSON result coming from Elastic Search, as a list of {@link Ping} object.
+     *      Passing an empty or null json string matches all the data found in the index (i.e no query constraint)
+     * @return the parsed JSON result coming from Elastic Search, as a list of {@link Ping} object. With the default
+     *      implementation, at most 10 pings are returned, however many of them match
      * @throws Exception when an error happens while retrieving the data
+     * @see DataManager#searchInstalls(String)
      * @since 14.4RC1
      */
     public List<Ping> searchInstalls(String jsonQuery) throws Exception


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24864

# Changes

## Description

`DataManager#searchInstalls(String)` is documented as returning all the matching pings, but `DefaultDataManager` never sets the search request's `size`, so Elasticsearch applies its default of 10 hits and the method returns at most 10 pings however many the query matches. It has been this way since the method was introduced in 14.4RC1 (`7a8d0ea6e71`).

This PR fixes the **documentation** rather than the behaviour:

* `DataManager#searchInstalls` now states that a bounded number of the matching pings comes back and not all of them, that *which* ones is undefined since the pings are not sorted, and why that bound exists. Its `@return` says implementations may return only some of the matching pings and must document the number, mirroring what `countDistinctInstalls`/`countDistinctInstallsByExtension` already do for their own approximations.
* `DefaultDataManager#searchInstalls` gets an `{@inheritDoc}` block naming the concrete bound (at most 10), where the 10 comes from (Elasticsearch's default for a request that asks for no size) and why sampling is the intent.
* `ActiveInstallsScriptService#searchInstalls` gets the same for script authors, and points at `countInstalls`/`countDistinctInstalls` for "how many" questions so nobody tries to retrieve pings in order to count them.
* The "an empty or null json string matches all the data in the index" sentence moves from `@return` to `@param`, which is what it actually describes.

The reference page was wrong for the same reason and has been fixed separately (no code change needed): https://www.xwiki.org/xwiki/bin/view/documentation/xs/dev/active-installs/script-service/ — its `searchInstalls` row no longer claims to return the matching pings, and a new "Retrieving Pings" section states the bound, that there is no paging, and the reason.

## Clarifications

The issue listed two options: set an explicit `size` (paginating for large result sets), or keep a cap deliberately and fix the documentation. This PR takes the second, because honouring the original javadoc is neither safe nor implementable:

* **It would be a DOS / OOM vector.** A `Ping` embeds the whole extension list of the instance that sent it (hundreds of `ExtensionPing` entries) plus ten other sub-objects, and the index holds one ping per instance *per day and per restart* since 2022 — millions of documents. Buffering that into an `ArrayList<Ping>` exhausts the heap, and `searchInstalls` is reachable from any script holding script right. It also runs against the project's "prefer streaming over buffering for user-sized data" convention.
* **Elasticsearch refuses it anyway**: `from + size` may not exceed `index.max_result_window` (10000 by default). Unbounded retrieval would need a point-in-time plus a `search_after` loop.
* **Paging was considered and dropped.** `from`/`size` paging over a live append-only index is not stable — pings arrive daily, so pages would silently duplicate and drop documents, trading this bug for a subtler one. Stable paging needs a PIT, which is a much larger API addition than any known caller justifies: the 18.8.0RC1 aggregation methods (XWIKI-24710) exist precisely so that nobody has to retrieve pings to count them, and there is no caller in xwiki-platform (`ExtensionCode.UpdateInstalledExtensionCountScheduler` calls `services.activeinstalls`, i.e. Active Installs **1**, with a different 3-argument signature). If real paging is ever wanted it deserves its own issue.

There is deliberately no behaviour change and therefore no `@since` addition, no release-note entry and no new test: there is no new behaviour to pin. Worth noting for whoever picks up that thread that the existing coverage could not have caught this — `PingSenderIT` only ever indexes 2 pings, so the bound is never reached, and there is no unit test for `DefaultDataManager` at all.

Found while documenting XWIKI-24710 for the 18.8.0RC1 release notes.

# Screenshots & Video

No UI change. The user-visible part of this fix is the reference page, whose updated "Retrieving Pings" section is live at https://www.xwiki.org/xwiki/bin/view/documentation/xs/dev/active-installs/script-service/#HRetrievingPings

# Executed Tests

```
mvn clean install -B -ntp -Plegacy,quality -pl xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api
```

BUILD SUCCESS — 12 tests pass, 0 Checkstyle violations on all three rulesets (`default`, `test`, `blocker`), JaCoCo coverage checks met, Revapi reports no API-compatibility failures.

```
mvn javadoc:javadoc -B -ntp -Plegacy -pl xwiki-platform-core/xwiki-platform-activeinstalls2/xwiki-platform-activeinstalls2-api
```

BUILD SUCCESS — the 4 remaining javadoc warnings are pre-existing and in other files (`ActiveInstallsConfiguration`, `TooManyExtensionsException`, and the default constructor of `ActiveInstallsScriptService`); the edited javadoc adds none.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * None. This is a documentation-only change to a method whose behaviour is unchanged, so there is nothing for a maintenance branch to gain from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
