### PR TITLE
XWIKI-24831: Implement an xobjects display macro

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -443,7 +443,7 @@ importers:
         version: link:../../../../../xwiki-platform-node/src/main/node/tools/tool-tsconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@7.2.0)
       globals:
         specifier: 'catalog:'
         version: 17.12.0
@@ -473,7 +473,7 @@ importers:
     devDependencies:
       '@eslint/js':
         specifier: 'catalog:'
-        version: 10.0.1(eslint@10.10.0(jiti@2.7.0))
+        version: 10.0.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.63.0
@@ -482,7 +482,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       globals:
         specifier: 'catalog:'
         version: 17.12.0
@@ -494,7 +494,7 @@ importers:
         version: 2.26.0
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       vite:
         specifier: 'catalog:'
         version: 8.2.2(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.28))(yaml@2.9.0)
@@ -522,7 +522,7 @@ importers:
         version: link:../../../../../xwiki-platform-node/src/main/node/tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       vite:
         specifier: 'catalog:'
         version: 8.2.2(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.28))(yaml@2.9.0)
@@ -577,7 +577,7 @@ importers:
         version: link:../../../../../../xwiki-platform-node/src/main/node/tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       jquery:
         specifier: 'catalog:'
         version: 4.0.0
@@ -611,7 +611,7 @@ importers:
         version: link:../../../../../../xwiki-platform-node/src/main/node/tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       vite:
         specifier: 'catalog:'
         version: 8.2.2(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.28))(yaml@2.9.0)
@@ -630,7 +630,7 @@ importers:
         version: link:../../../../../../xwiki-platform-node/src/main/node/tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       vite:
         specifier: 'catalog:'
         version: 8.2.2(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.28))(yaml@2.9.0)
@@ -667,13 +667,13 @@ importers:
         version: 6.0.8(vite@8.2.2(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.28))(yaml@2.9.0))(vue@3.5.42(typescript@5.9.3))
       '@vitest/eslint-plugin':
         specifier: 'catalog:'
-        version: 1.6.27(@typescript-eslint/eslint-plugin@8.69.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)(vitest@5.0.0(@types/node@24.13.3)(happy-dom@20.9.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.28))(yaml@2.9.0)))
+        version: 1.6.27(@typescript-eslint/eslint-plugin@8.69.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)(vitest@5.0.0(@types/node@24.13.3)(happy-dom@20.9.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.28))(yaml@2.9.0)))
       '@vue/eslint-config-prettier':
         specifier: 'catalog:'
-        version: 10.2.0(eslint@10.10.0(jiti@2.7.0))(prettier@3.6.2)
+        version: 10.2.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(prettier@3.6.2)
       '@vue/eslint-config-typescript':
         specifier: 'catalog:'
-        version: 14.9.0(eslint-plugin-vue@10.11.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.10.0(jiti@2.7.0))))(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
+        version: 14.9.0(eslint-plugin-vue@10.11.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       '@vue/test-utils':
         specifier: 'catalog:'
         version: 2.5.0(@vue/compiler-dom@3.5.42)(@vue/server-renderer@3.5.42)(vue@3.5.42(typescript@5.9.3))
@@ -682,10 +682,10 @@ importers:
         version: 0.9.1(typescript@5.9.3)(vue@3.5.42(typescript@5.9.3))
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       eslint-plugin-vue:
         specifier: 'catalog:'
-        version: 10.11.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.10.0(jiti@2.7.0)))
+        version: 10.11.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))
       flush-promises:
         specifier: 'catalog:'
         version: 1.0.2
@@ -752,7 +752,7 @@ importers:
         version: link:../../../../../xwiki-platform-node/src/main/node/tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       npm-run-all:
         specifier: 'catalog:'
         version: 4.1.5
@@ -776,13 +776,13 @@ importers:
         version: link:tools/tool-eslintconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       globals:
         specifier: 'catalog:'
         version: 17.12.0
       npm-package-json-lint:
         specifier: 'catalog:'
-        version: 11.0.0
+        version: 11.0.0(supports-color@7.2.0)
       publint:
         specifier: 'catalog:'
         version: 0.3.24
@@ -822,7 +822,7 @@ importers:
         version: link:../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       inversify:
         specifier: 'catalog:'
         version: 8.2.3(reflect-metadata@0.2.2)
@@ -877,7 +877,7 @@ importers:
         version: link:../../../tools/tool-tsdocconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -935,7 +935,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       inversify:
         specifier: 'catalog:'
         version: 8.2.3(reflect-metadata@0.2.2)
@@ -980,7 +980,7 @@ importers:
         version: link:../../../tools/tool-tsdocconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       reflect-metadata:
         specifier: 'catalog:'
         version: 0.2.2
@@ -1020,7 +1020,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       inversify:
         specifier: 'catalog:'
         version: 8.2.3(reflect-metadata@0.2.2)
@@ -1078,7 +1078,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       inversify:
         specifier: 'catalog:'
         version: 8.2.3(reflect-metadata@0.2.2)
@@ -1151,7 +1151,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       inversify:
         specifier: 'catalog:'
         version: 8.2.3(reflect-metadata@0.2.2)
@@ -1197,7 +1197,7 @@ importers:
         version: link:../../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       jsdom:
         specifier: 'catalog:'
         version: 30.0.1
@@ -1237,7 +1237,7 @@ importers:
         version: link:../../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       jsdom:
         specifier: 'catalog:'
         version: 30.0.1
@@ -1270,7 +1270,7 @@ importers:
         version: link:../../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -1313,7 +1313,7 @@ importers:
         version: link:../../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       jsdom:
         specifier: 'catalog:'
         version: 30.0.1
@@ -1356,7 +1356,7 @@ importers:
         version: link:../../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       jsdom:
         specifier: 'catalog:'
         version: 30.0.1
@@ -1393,7 +1393,7 @@ importers:
         version: link:../../../tools/tool-tsdocconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -1436,7 +1436,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       jsdom:
         specifier: 'catalog:'
         version: 30.0.1
@@ -1482,7 +1482,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       jsdom:
         specifier: 'catalog:'
         version: 30.0.1
@@ -1521,7 +1521,7 @@ importers:
         version: link:../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       jsdom:
         specifier: 'catalog:'
         version: 30.0.1
@@ -1564,7 +1564,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1622,7 +1622,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       inversify:
         specifier: 'catalog:'
         version: 8.2.3(reflect-metadata@0.2.2)
@@ -1671,7 +1671,7 @@ importers:
         version: link:../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       jsdom:
         specifier: 'catalog:'
         version: 30.0.1
@@ -1759,7 +1759,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       inversify:
         specifier: 'catalog:'
         version: 8.2.3(reflect-metadata@0.2.2)
@@ -1811,7 +1811,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       inversify:
         specifier: 'catalog:'
         version: 8.2.3(reflect-metadata@0.2.2)
@@ -1866,7 +1866,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       inversify:
         specifier: 'catalog:'
         version: 8.2.3(reflect-metadata@0.2.2)
@@ -1905,7 +1905,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1944,7 +1944,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       jsdom:
         specifier: 'catalog:'
         version: 30.0.1
@@ -2029,7 +2029,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       flush-promises:
         specifier: 'catalog:'
         version: 1.0.2
@@ -2099,7 +2099,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       jquery:
         specifier: 'catalog:'
         version: 4.0.0
@@ -2148,7 +2148,7 @@ importers:
         version: link:../../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -2187,7 +2187,7 @@ importers:
         version: link:../../../tools/tool-tsdocconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -2224,7 +2224,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       jsdom:
         specifier: 'catalog:'
         version: 30.0.1
@@ -2267,7 +2267,7 @@ importers:
         version: link:../../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       jsdom:
         specifier: 'catalog:'
         version: 30.0.1
@@ -2306,7 +2306,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       jsdom:
         specifier: 'catalog:'
         version: 30.0.1
@@ -2355,7 +2355,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       inversify:
         specifier: 'catalog:'
         version: 8.2.3(reflect-metadata@0.2.2)
@@ -2404,7 +2404,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       inversify:
         specifier: 'catalog:'
         version: 8.2.3(reflect-metadata@0.2.2)
@@ -2446,7 +2446,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       jsdom:
         specifier: 'catalog:'
         version: 30.0.1
@@ -2489,7 +2489,7 @@ importers:
         version: link:../../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       inversify:
         specifier: 'catalog:'
         version: 8.2.3(reflect-metadata@0.2.2)
@@ -2538,7 +2538,7 @@ importers:
         version: link:../../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       inversify:
         specifier: 'catalog:'
         version: 8.2.3(reflect-metadata@0.2.2)
@@ -2587,7 +2587,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -2620,7 +2620,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       inversify:
         specifier: 'catalog:'
         version: 8.2.3(reflect-metadata@0.2.2)
@@ -2669,7 +2669,7 @@ importers:
         version: link:../../../tools/tool-tsdocconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -2709,7 +2709,7 @@ importers:
         version: link:../../../tools/tool-tsdocconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -2743,7 +2743,7 @@ importers:
         version: link:../../../tools/tool-tsdocconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -2783,7 +2783,7 @@ importers:
         version: link:../../../tools/tool-tsdocconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -2829,7 +2829,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -2859,7 +2859,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       jsdom:
         specifier: 'catalog:'
         version: 30.0.1
@@ -2893,7 +2893,7 @@ importers:
         version: link:../../../tools/tool-tsdocconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -2923,13 +2923,13 @@ importers:
         version: link:../uniast-api
       mdast-util-gfm-strikethrough:
         specifier: 'catalog:'
-        version: 2.0.0
+        version: 2.0.0(supports-color@7.2.0)
       mdast-util-gfm-table:
         specifier: 'catalog:'
-        version: 2.0.0
+        version: 2.0.0(supports-color@8.1.1)
       mdast-util-gfm-task-list-item:
         specifier: 'catalog:'
-        version: 2.0.0
+        version: 2.0.0(supports-color@8.1.1)
       micromark-extension-gfm-strikethrough:
         specifier: 'catalog:'
         version: 2.1.0
@@ -2941,7 +2941,7 @@ importers:
         version: 2.1.0
       remark-parse:
         specifier: 'catalog:'
-        version: 11.0.0
+        version: 11.0.0(supports-color@8.1.1)
       unified:
         specifier: 'catalog:'
         version: 11.0.5
@@ -2975,7 +2975,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       inversify:
         specifier: 'catalog:'
         version: 8.2.3(reflect-metadata@0.2.2)
@@ -3021,7 +3021,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       inversify:
         specifier: 'catalog:'
         version: 8.2.3(reflect-metadata@0.2.2)
@@ -3064,7 +3064,7 @@ importers:
         version: link:../../../tools/tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       jsdom:
         specifier: 'catalog:'
         version: 30.0.1
@@ -3088,7 +3088,7 @@ importers:
         version: link:../../tools/tool-tsconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -3176,7 +3176,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       inversify:
         specifier: 'catalog:'
         version: 8.2.3(reflect-metadata@0.2.2)
@@ -3324,7 +3324,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       inversify:
         specifier: 'catalog:'
         version: 8.2.3(reflect-metadata@0.2.2)
@@ -3365,34 +3365,34 @@ importers:
         version: 0.7.0
       '@eslint/js':
         specifier: 'catalog:'
-        version: 10.0.1(eslint@10.10.0(jiti@2.7.0))
+        version: 10.0.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))
       eslint-import-resolver-typescript:
         specifier: 'catalog:'
-        version: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0)))(eslint@10.10.0(jiti@2.7.0))
+        version: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@7.2.0))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@7.2.0)
       eslint-plugin-headers:
         specifier: 'catalog:'
-        version: 1.3.4(eslint@10.10.0(jiti@2.7.0))
+        version: 1.3.4(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))
       eslint-plugin-import-x:
         specifier: 'catalog:'
-        version: 4.17.1(@typescript-eslint/utils@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0))
+        version: 4.17.1(@typescript-eslint/utils@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@7.2.0)
       eslint-plugin-prettier:
         specifier: 'catalog:'
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.10.0(jiti@2.7.0)))(eslint@10.10.0(jiti@2.7.0))(prettier@3.6.2)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1)))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(prettier@3.6.2)
       eslint-plugin-promise:
         specifier: 'catalog:'
-        version: 7.3.0(eslint@10.10.0(jiti@2.7.0))
+        version: 7.3.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))
       eslint-plugin-tsdoc:
         specifier: 'catalog:'
-        version: 0.5.2(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
+        version: 0.5.2(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@7.2.0)(typescript@5.9.3)
       eslint-plugin-vue:
         specifier: 'catalog:'
-        version: 10.11.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.10.0(jiti@2.7.0)))
+        version: 10.11.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       vue-eslint-parser:
         specifier: 'catalog:'
-        version: 10.4.1(eslint@10.10.0(jiti@2.7.0))
+        version: 10.4.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     devDependencies:
       '@xwiki/platform-tool-tsconfig':
         specifier: workspace:*
@@ -3402,7 +3402,7 @@ importers:
         version: link:../tool-viteconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       vite:
         specifier: 'catalog:'
         version: 8.2.2(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.28))(yaml@2.9.0)
@@ -3431,7 +3431,7 @@ importers:
         version: 5.0.2(vite@8.2.2(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.28))(yaml@2.9.0))
       vite-plugin-dts:
         specifier: 'catalog:'
-        version: 4.5.4(@types/node@24.13.3)(rollup@4.55.1)(typescript@5.9.3)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.28))(yaml@2.9.0))
+        version: 4.5.4(@types/node@24.13.3)(rollup@4.55.1)(supports-color@7.2.0)(typescript@5.9.3)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.28))(yaml@2.9.0))
     devDependencies:
       '@xwiki/platform-tool-tsconfig':
         specifier: workspace:*
@@ -3441,7 +3441,7 @@ importers:
         version: link:../tool-tsdocconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
 
   xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-webjar/src/main/node:
     dependencies:
@@ -3481,7 +3481,7 @@ importers:
         version: link:../../../../../xwiki-platform-node/src/main/node/tools/tool-eslintconfig
       eslint:
         specifier: 'catalog:'
-        version: 10.10.0(jiti@2.7.0)
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       jiti:
         specifier: 'catalog:'
         version: 2.7.0
@@ -3506,6 +3506,48 @@ importers:
       vue-tsc:
         specifier: 'catalog:'
         version: 3.3.11(typescript@5.9.3)
+
+  xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node:
+    devDependencies:
+      '@types/jquery':
+        specifier: 'catalog:'
+        version: 4.0.1
+      '@types/jsdom':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.3
+      '@types/requirejs':
+        specifier: 'catalog:'
+        version: 2.1.37
+      '@xwiki/platform-tool-eslintconfig':
+        specifier: workspace:*
+        version: link:../../../../../xwiki-platform-node/src/main/node/tools/tool-eslintconfig
+      '@xwiki/platform-tool-tsconfig':
+        specifier: workspace:*
+        version: link:../../../../../xwiki-platform-node/src/main/node/tools/tool-tsconfig
+      '@xwiki/platform-tool-viteconfig':
+        specifier: workspace:*
+        version: link:../../../../../xwiki-platform-node/src/main/node/tools/tool-viteconfig
+      eslint:
+        specifier: 'catalog:'
+        version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
+      jsdom:
+        specifier: 'catalog:'
+        version: 30.0.1
+      npm-run-all:
+        specifier: 'catalog:'
+        version: 4.1.5
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.2.2(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.28))(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 5.0.0(@types/node@24.13.3)(happy-dom@20.9.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.28))(yaml@2.9.0))
 
 packages:
 
@@ -4831,6 +4873,11 @@ packages:
 
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@vue-macros/common@3.1.4':
     resolution: {integrity: sha512-/5Fv+6DgIcM9ajY05ZmKBv+LMX1M9A0X+IUwDRVdt67ciw8OV9bvG2r34p3RiEadlsQybjhKPRKNXDC8Bp23cw==}
@@ -8143,17 +8190,30 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.10.0(jiti@2.7.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.10.0(jiti@2.7.0)(supports-color@7.2.0))':
     dependencies:
-      eslint: 10.10.0(jiti@2.7.0)
+      eslint: 10.10.0(jiti@2.7.0)(supports-color@7.2.0)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))':
+    dependencies:
+      eslint: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.5':
+  '@eslint/config-array@0.23.5(supports-color@7.2.0)':
     dependencies:
       '@eslint/object-schema': 3.0.5
       debug: 4.4.3(supports-color@7.2.0)
+      minimatch: 10.2.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-array@0.23.5(supports-color@8.1.1)':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.6
     transitivePeerDependencies:
       - supports-color
@@ -8166,9 +8226,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.10.0(jiti@2.7.0))':
+  '@eslint/js@10.0.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))':
     optionalDependencies:
-      eslint: 10.10.0(jiti@2.7.0)
+      eslint: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -8852,15 +8912,15 @@ snapshots:
       '@types/node': 24.13.3
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.69.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.69.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.69.0
-      '@typescript-eslint/type-utils': 8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.69.0
-      eslint: 10.10.0(jiti@2.7.0)
+      eslint: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -8868,19 +8928,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.69.0
       '@typescript-eslint/types': 8.69.0
-      '@typescript-eslint/typescript-estree': 8.69.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.69.0(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.69.0
-      debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.10.0(jiti@2.7.0)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.56.1(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.56.1(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.69.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.69.0
@@ -8889,11 +8949,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.69.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.69.0(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.69.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.69.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -8916,13 +8976,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.69.0
-      '@typescript-eslint/typescript-estree': 8.69.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
-      debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.10.0(jiti@2.7.0)
+      '@typescript-eslint/typescript-estree': 8.69.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -8932,9 +8992,9 @@ snapshots:
 
   '@typescript-eslint/types@8.69.0': {}
 
-  '@typescript-eslint/typescript-estree@8.56.1(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.56.1(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.56.1(supports-color@7.2.0)(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
@@ -8947,13 +9007,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.69.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.69.0(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.69.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.69.0(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.69.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.69.0
       '@typescript-eslint/visitor-keys': 8.69.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.6
       semver: 7.8.5
       tinyglobby: 0.2.17
@@ -8962,24 +9022,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.56.1(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.56.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.10.0(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))
       '@typescript-eslint/scope-manager': 8.56.1
       '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
-      eslint: 10.10.0(jiti@2.7.0)
+      '@typescript-eslint/typescript-estree': 8.56.1(supports-color@7.2.0)(typescript@5.9.3)
+      eslint: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.10.0(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))
       '@typescript-eslint/scope-manager': 8.69.0
       '@typescript-eslint/types': 8.69.0
-      '@typescript-eslint/typescript-estree': 8.69.0(typescript@5.9.3)
-      eslint: 10.10.0(jiti@2.7.0)
+      '@typescript-eslint/typescript-estree': 8.69.0(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -9064,13 +9124,13 @@ snapshots:
       vite: 8.2.2(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.28))(yaml@2.9.0)
       vue: 3.5.42(typescript@5.9.3)
 
-  '@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.69.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)(vitest@5.0.0(@types/node@24.13.3)(happy-dom@20.9.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.28))(yaml@2.9.0)))':
+  '@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.69.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)(vitest@5.0.0(@types/node@24.13.3)(happy-dom@20.9.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.28))(yaml@2.9.0)))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.69.0
-      '@typescript-eslint/utils': 8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 10.10.0(jiti@2.7.0)
+      '@typescript-eslint/utils': 8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.69.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.69.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       typescript: 5.9.3
       vitest: 5.0.0(@types/node@24.13.3)(happy-dom@20.9.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.28))(yaml@2.9.0))
     transitivePeerDependencies:
@@ -9093,11 +9153,13 @@ snapshots:
 
   '@volar/source-map@2.4.28': {}
 
-  '@volar/typescript@2.4.28':
+  '@volar/typescript@2.4.28(typescript@5.9.3)':
     dependencies:
       '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
+    optionalDependencies:
+      typescript: 5.9.3
 
   '@vue-macros/common@3.1.4(vue@3.5.42(typescript@5.9.3))':
     dependencies:
@@ -9159,23 +9221,23 @@ snapshots:
 
   '@vue/devtools-shared@8.2.1': {}
 
-  '@vue/eslint-config-prettier@10.2.0(eslint@10.10.0(jiti@2.7.0))(prettier@3.6.2)':
+  '@vue/eslint-config-prettier@10.2.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(prettier@3.6.2)':
     dependencies:
-      eslint: 10.10.0(jiti@2.7.0)
-      eslint-config-prettier: 10.1.8(eslint@10.10.0(jiti@2.7.0))
-      eslint-plugin-prettier: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.10.0(jiti@2.7.0)))(eslint@10.10.0(jiti@2.7.0))(prettier@3.6.2)
+      eslint: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-config-prettier: 10.1.8(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))
+      eslint-plugin-prettier: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1)))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(prettier@3.6.2)
       prettier: 3.6.2
     transitivePeerDependencies:
       - '@types/eslint'
 
-  '@vue/eslint-config-typescript@14.9.0(eslint-plugin-vue@10.11.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.10.0(jiti@2.7.0))))(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)':
+  '@vue/eslint-config-typescript@14.9.0(eslint-plugin-vue@10.11.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 10.10.0(jiti@2.7.0)
-      eslint-plugin-vue: 10.11.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.10.0(jiti@2.7.0)))
+      '@typescript-eslint/utils': 8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-plugin-vue: 10.11.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))
       fast-glob: 3.3.3
-      typescript-eslint: 8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
-      vue-eslint-parser: 10.4.1(eslint@10.10.0(jiti@2.7.0))
+      typescript-eslint: 8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      vue-eslint-parser: 10.4.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -9588,6 +9650,12 @@ snapshots:
     optionalDependencies:
       supports-color: 7.2.0
 
+  debug@4.4.3(supports-color@8.1.1):
+    dependencies:
+      ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
+
   decamelize-keys@1.1.1:
     dependencies:
       decamelize: 1.2.0
@@ -9807,9 +9875,9 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@10.10.0(jiti@2.7.0)):
+  eslint-config-prettier@10.1.8(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1)):
     dependencies:
-      eslint: 10.10.0(jiti@2.7.0)
+      eslint: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
 
   eslint-import-context@0.1.9(unrs-resolver@1.11.1):
     dependencies:
@@ -9818,10 +9886,10 @@ snapshots:
     optionalDependencies:
       unrs-resolver: 1.11.1
 
-  eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0)))(eslint@10.10.0(jiti@2.7.0)):
+  eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@7.2.0))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@7.2.0):
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.10.0(jiti@2.7.0)
+      eslint: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       get-tsconfig: 4.13.0
       is-bun-module: 2.0.0
@@ -9829,20 +9897,20 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import-x: 4.17.1(@typescript-eslint/utils@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0))
+      eslint-plugin-import-x: 4.17.1(@typescript-eslint/utils@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-headers@1.3.4(eslint@10.10.0(jiti@2.7.0)):
+  eslint-plugin-headers@1.3.4(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1)):
     dependencies:
-      eslint: 10.10.0(jiti@2.7.0)
+      eslint: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
 
-  eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0)):
+  eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@7.2.0):
     dependencies:
       '@typescript-eslint/types': 8.69.0
       comment-parser: 1.4.6
       debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.10.0(jiti@2.7.0)
+      eslint: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       is-glob: 4.0.3
       minimatch: 10.2.6
@@ -9850,46 +9918,46 @@ snapshots:
       stable-hash-x: 0.2.0
       unrs-resolver: 1.11.1
     optionalDependencies:
-      '@typescript-eslint/utils': 8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@10.10.0(jiti@2.7.0)))(eslint@10.10.0(jiti@2.7.0))(prettier@3.6.2):
+  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1)))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(prettier@3.6.2):
     dependencies:
-      eslint: 10.10.0(jiti@2.7.0)
+      eslint: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       prettier: 3.6.2
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.13
     optionalDependencies:
-      eslint-config-prettier: 10.1.8(eslint@10.10.0(jiti@2.7.0))
+      eslint-config-prettier: 10.1.8(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))
 
-  eslint-plugin-promise@7.3.0(eslint@10.10.0(jiti@2.7.0)):
+  eslint-plugin-promise@7.3.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.10.0(jiti@2.7.0))
-      eslint: 10.10.0(jiti@2.7.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))
+      eslint: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
 
-  eslint-plugin-tsdoc@0.5.2(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3):
+  eslint-plugin-tsdoc@0.5.2(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@7.2.0)(typescript@5.9.3):
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@typescript-eslint/utils': 8.56.1(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@7.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint
       - supports-color
       - typescript
 
-  eslint-plugin-vue@10.11.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.10.0(jiti@2.7.0))):
+  eslint-plugin-vue@10.11.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.10.0(jiti@2.7.0))
-      eslint: 10.10.0(jiti@2.7.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))
+      eslint: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 7.1.4
       semver: 7.8.5
-      vue-eslint-parser: 10.4.1(eslint@10.10.0(jiti@2.7.0))
+      vue-eslint-parser: 10.4.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       xml-name-validator: 5.0.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
 
   eslint-scope@9.1.2:
     dependencies:
@@ -9902,11 +9970,11 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.10.0(jiti@2.7.0):
+  eslint@10.10.0(jiti@2.7.0)(supports-color@7.2.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.10.0(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.10.0(jiti@2.7.0)(supports-color@7.2.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5
+      '@eslint/config-array': 0.23.5(supports-color@7.2.0)
       '@eslint/config-helpers': 0.7.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.3
@@ -9917,6 +9985,43 @@ snapshots:
       ajv: 6.15.0
       cross-spawn: 7.0.6
       debug: 4.4.3(supports-color@7.2.0)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 11.1.5
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.6
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5(supports-color@8.1.1)
+      '@eslint/config-helpers': 0.7.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.3
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -10608,14 +10713,14 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mdast-util-from-markdown@2.0.2:
+  mdast-util-from-markdown@2.0.2(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@7.2.0)
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -10625,29 +10730,46 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0:
+  mdast-util-from-markdown@2.0.2(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2(supports-color@8.1.1)
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0(supports-color@7.2.0):
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0:
+  mdast-util-gfm-table@2.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0:
+  mdast-util-gfm-task-list-item@2.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -10830,10 +10952,32 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2:
+  micromark@4.0.2(supports-color@7.2.0):
     dependencies:
       '@types/debug': 4.1.12
       debug: 4.4.3(supports-color@7.2.0)
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  micromark@4.0.2(supports-color@8.1.1):
+    dependencies:
+      '@types/debug': 4.1.12
+      debug: 4.4.3(supports-color@8.1.1)
       decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -10942,7 +11086,7 @@ snapshots:
 
   npm-normalize-package-bin@6.0.0: {}
 
-  npm-package-json-lint@11.0.0:
+  npm-package-json-lint@11.0.0(supports-color@7.2.0):
     dependencies:
       chalk: 4.1.2
       cosmiconfig: 10.0.0
@@ -11570,10 +11714,10 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
-  remark-parse@11.0.0:
+  remark-parse@11.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@8.1.1)
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -12024,13 +12168,13 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3):
+  typescript-eslint@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.69.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.69.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 10.10.0(jiti@2.7.0)
+      '@typescript-eslint/eslint-plugin': 8.69.0(@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.69.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -12173,11 +12317,11 @@ snapshots:
     dependencies:
       vite: 8.2.2(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.28))(yaml@2.9.0)
 
-  vite-plugin-dts@4.5.4(@types/node@24.13.3)(rollup@4.55.1)(typescript@5.9.3)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.28))(yaml@2.9.0)):
+  vite-plugin-dts@4.5.4(@types/node@24.13.3)(rollup@4.55.1)(supports-color@7.2.0)(typescript@5.9.3)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.28))(yaml@2.9.0)):
     dependencies:
       '@microsoft/api-extractor': 7.59.0(@types/node@24.13.3)
       '@rollup/pluginutils': 5.3.0(rollup@4.55.1)
-      '@volar/typescript': 2.4.28
+      '@volar/typescript': 2.4.28(typescript@5.9.3)
       '@vue/language-core': 2.2.0(typescript@5.9.3)
       compare-versions: 6.1.1
       debug: 4.4.3(supports-color@7.2.0)
@@ -12240,10 +12384,10 @@ snapshots:
 
   vue-component-type-helpers@3.2.8: {}
 
-  vue-eslint-parser@10.4.1(eslint@10.10.0(jiti@2.7.0)):
+  vue-eslint-parser@10.4.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.10.0(jiti@2.7.0)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
       espree: 11.2.0
@@ -12300,7 +12444,7 @@ snapshots:
 
   vue-tsc@3.3.11(typescript@5.9.3):
     dependencies:
-      '@volar/typescript': 2.4.28
+      '@volar/typescript': 2.4.28(typescript@5.9.3)
       '@vue/language-core': 3.3.11
       typescript: 5.9.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,6 +65,7 @@ packages:
   - xwiki-platform-core/xwiki-platform-node/src/main/node/tools/tool-tsdocconfig
   - xwiki-platform-core/xwiki-platform-node/src/main/node/tools/tool-viteconfig
   - xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-webjar/src/main/node/
+  - xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/
 
 catalogMode: strict
 cleanupUnusedCatalogs: true

--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -336,6 +336,7 @@
     <module>xwiki-platform-query</module>
     <module>xwiki-platform-ratings</module>
     <module>xwiki-platform-realtime</module>
+    <module>xwiki-platform-records</module>
     <module>xwiki-platform-refactoring</module>
     <module>xwiki-platform-release</module>
     <module>xwiki-platform-rendering</module>

--- a/xwiki-platform-core/xwiki-platform-records/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-records/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.platform</groupId>
+    <artifactId>xwiki-platform-core</artifactId>
+    <version>18.8.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>xwiki-platform-records</artifactId>
+  <name>XWiki Platform - Records - Parent POM</name>
+  <packaging>pom</packaging>
+  <description>XWiki Platform - Records - Parent POM</description>
+  <modules>
+    <module>xwiki-platform-records-webjar</module>
+    <module>xwiki-platform-records-macro</module>
+  </modules>
+</project>

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.platform</groupId>
+    <artifactId>xwiki-platform-records</artifactId>
+    <version>18.8.0-SNAPSHOT</version>
+  </parent>
+  <packaging>jar</packaging>
+  <artifactId>xwiki-platform-records-macro</artifactId>
+  <name>XWiki Platform - Records - Macro</name>
+  <description>Lists the entries of a data type as a table, configurable from the WYSIWYG macro dialog.</description>
+  <properties>
+    <!-- Name to display by the Extension Manager -->
+    <xwiki.extension.name>Records Macro</xwiki.extension.name>
+    <xwiki.jacoco.instructionRatio>1.00</xwiki.jacoco.instructionRatio>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>xwiki-platform-livedata-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.rendering</groupId>
+      <artifactId>xwiki-rendering-transformation-macro</artifactId>
+      <version>${rendering.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-properties</artifactId>
+      <version>${commons.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-model-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <!-- The field picker the columns displayer loads. Runtime only: the macro never calls into it from Java. -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>xwiki-platform-records-webjar</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-tool-test-component</artifactId>
+      <version>${commons.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/internal/macro/RecordsMacro.java
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/internal/macro/RecordsMacro.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -107,6 +108,11 @@ public class RecordsMacro extends AbstractMacro<RecordsMacroParameters>
      * The identifier prefix of the Live Data pseudo-columns, which are rendering affordances rather than data.
      */
     private static final String INTERNAL_PREFIX = "_";
+
+    /**
+     * The column identifying the entry, which the default column list opens with.
+     */
+    private static final String TITLE_PROPERTY = "doc.title";
 
     private static final String DESCRIPTION =
         "Displays a collection of entries of the same data type, as a table readers can sort and filter.";
@@ -197,13 +203,17 @@ public class RecordsMacro extends AbstractMacro<RecordsMacroParameters>
     /**
      * Returns the columns to display.
      *
-     * An author who has not chosen any expects to see the data type's own fields, which is what the parameter's
-     * default says. That default has to be resolved here rather than left to Live Data: the {@code liveTable}
-     * source needs an explicit column list, and an absent one yields a table with no columns at all rather than
-     * one with every column. The {@code documents} macro assembles its list for the same reason.
+     * The default has to be resolved here rather than left to Live Data: the {@code liveTable} source needs an
+     * explicit column list, and an absent one yields a table with no columns at all rather than one with every
+     * column. The {@code documents} macro assembles its list for the same reason.
+     *
+     * It opens with the entry's title. A table of nothing but field values gives a reader no way to tell one entry
+     * from another, and no way to reach the page an entry lives in; the title column is what makes the rest of the
+     * row mean something. An author who wants the fields alone can say so, since naming any column replaces this
+     * list entirely.
      *
      * @param parameters the macro parameters
-     * @return the columns the author chose, or every field of the data type when they chose none
+     * @return the columns the author chose, or the entry title followed by every field of the data type
      * @throws MacroExecutionException when the data type's fields cannot be read
      */
     private String getProperties(RecordsMacroParameters parameters) throws MacroExecutionException
@@ -211,16 +221,17 @@ public class RecordsMacro extends AbstractMacro<RecordsMacroParameters>
         if (StringUtils.isNotBlank(parameters.getProperties())) {
             return parameters.getProperties();
         }
-        return getFields(this.entityReferenceSerializer.serialize(parameters.getDataType())).stream()
+        String dataType = this.entityReferenceSerializer.serialize(parameters.getDataType());
+        return Stream.concat(Stream.of(TITLE_PROPERTY), getFields(dataType).stream())
             .collect(Collectors.joining(","));
     }
 
     /**
      * Reads the field identifiers of a data type, in the order the data type declares them.
      *
-     * The entry metadata is left out: the property store reports it alongside the fields, but a default built from
-     * the data type is about the data type, and the author can add any {@code doc.*} column themselves. The Live
-     * Data pseudo-columns are left out because they are affordances rather than data.
+     * The entry metadata is left out here: the property store reports it alongside the fields, and the only piece
+     * of it the default wants is the title, which {@link #getProperties} adds itself. The Live Data pseudo-columns
+     * are left out because they are affordances rather than data.
      *
      * @param dataType the serialized reference of the data type
      * @return its field identifiers

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/internal/macro/RecordsMacro.java
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/internal/macro/RecordsMacro.java
@@ -203,7 +203,6 @@ public class RecordsMacro extends AbstractMacro<RecordsMacroParameters>
         liveDataParameters.setProperties(getProperties(parameters));
         liveDataParameters.setFilters(parameters.getFilters());
         liveDataParameters.setSort(parameters.getSort());
-        liveDataParameters.setLimit(parameters.getLimit());
         liveDataParameters.setLayouts(parameters.getLayouts());
         liveDataParameters.setDescription(parameters.getDescription());
         return liveDataParameters;

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/internal/macro/RecordsMacro.java
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/internal/macro/RecordsMacro.java
@@ -46,6 +46,7 @@ import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.macro.AbstractMacro;
 import org.xwiki.rendering.macro.MacroExecutionException;
 import org.xwiki.rendering.transformation.MacroTransformationContext;
+import org.xwiki.rendering.util.IdGenerator;
 
 /**
  * Lists the entries of a data type as a table readers can sort and filter.
@@ -114,6 +115,12 @@ public class RecordsMacro extends AbstractMacro<RecordsMacroParameters>
      */
     private static final String TITLE_PROPERTY = "doc.title";
 
+    /**
+     * The prefix of a generated table identifier. Has to be alphabetical: {@link IdGenerator} builds HTML ids, which
+     * may not start with a digit.
+     */
+    private static final String ID_PREFIX = ID;
+
     private static final String DESCRIPTION =
         "Displays a collection of entries of the same data type, as a table readers can sort and filter.";
 
@@ -154,7 +161,8 @@ public class RecordsMacro extends AbstractMacro<RecordsMacroParameters>
         try {
             boolean restricted = context.getTransformationContext().isRestricted();
             // The advanced configuration is left blank on purpose, see the class javadoc.
-            return List.of(this.liveDataRenderer.execute(toLiveDataParameters(parameters), (String) null, restricted));
+            return List.of(
+                this.liveDataRenderer.execute(toLiveDataParameters(parameters, context), (String) null, restricted));
         } catch (LiveDataException e) {
             throw new MacroExecutionException("Failed to render the Records macro.", e);
         }
@@ -182,13 +190,14 @@ public class RecordsMacro extends AbstractMacro<RecordsMacroParameters>
      * a {@code liveData} macro.
      *
      * @param parameters the macro parameters
+     * @param context the transformation context, which carries the document's identifier generator
      * @return the equivalent Live Data renderer parameters
      */
-    private LiveDataRendererParameters toLiveDataParameters(RecordsMacroParameters parameters)
-        throws MacroExecutionException
+    private LiveDataRendererParameters toLiveDataParameters(RecordsMacroParameters parameters,
+        MacroTransformationContext context) throws MacroExecutionException
     {
         LiveDataRendererParameters liveDataParameters = new LiveDataRendererParameters();
-        liveDataParameters.setId(parameters.getId());
+        liveDataParameters.setId(getId(parameters, context));
         liveDataParameters.setSource(SOURCE);
         liveDataParameters.setSourceParameters(getSourceParameters(parameters));
         liveDataParameters.setProperties(getProperties(parameters));
@@ -198,6 +207,42 @@ public class RecordsMacro extends AbstractMacro<RecordsMacroParameters>
         liveDataParameters.setLayouts(parameters.getLayouts());
         liveDataParameters.setDescription(parameters.getDescription());
         return liveDataParameters;
+    }
+
+    /**
+     * Returns the identifier of this table, which is always set.
+     *
+     * Live Data needs one whether or not the author supplied it. Its layout builds the element id of the table's
+     * description as {@code <id>-description} and points at it with {@code aria-describedby}, so a table without an
+     * id gets the literal id {@code undefined-description}: harmless alone, but two such tables on one page share
+     * that element id and the second is then described by the first one's text.
+     *
+     * The document's {@link IdGenerator} is used rather than a counter of our own, so a Records table takes its
+     * place among the ids the rest of the page generates — headings included — and cannot collide with them. It
+     * appends {@code -1}, {@code -2} and so on, which is what makes two tables on a page distinct whether the author
+     * named them the same thing or named neither.
+     *
+     * @param parameters the macro parameters
+     * @param context the transformation context, which carries the generator
+     * @return the authored identifier, made unique, or a generated one when the author supplied none
+     */
+    private String getId(RecordsMacroParameters parameters, MacroTransformationContext context)
+    {
+        IdGenerator idGenerator = context.getXDOM() == null ? null : context.getXDOM().getIdGenerator();
+        String authored = parameters.getId();
+        if (idGenerator == null) {
+            // Nothing to be unique against, which happens when the macro is executed outside a document.
+            return StringUtils.defaultIfBlank(authored, ID_PREFIX);
+        }
+        if (StringUtils.isBlank(authored)) {
+            return idGenerator.generateUniqueId(ID_PREFIX, "");
+        }
+        if (Character.isLetter(authored.charAt(0))) {
+            return idGenerator.adaptId(authored);
+        }
+        // adaptId takes the first character of the id as the prefix and rejects one that is not a letter, so an
+        // identifier the author started with anything else is prefixed rather than refused.
+        return idGenerator.generateUniqueId(ID_PREFIX, authored);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/internal/macro/RecordsMacro.java
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/internal/macro/RecordsMacro.java
@@ -1,0 +1,270 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.records.internal.macro;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.StringUtils;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.livedata.LiveDataException;
+import org.xwiki.livedata.LiveDataPropertyDescriptor;
+import org.xwiki.livedata.LiveDataQuery.Source;
+import org.xwiki.livedata.LiveDataSourceManager;
+import org.xwiki.livedata.internal.LiveDataRenderer;
+import org.xwiki.livedata.internal.LiveDataRendererParameters;
+import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.records.macro.RecordsMacroParameters;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.macro.AbstractMacro;
+import org.xwiki.rendering.macro.MacroExecutionException;
+import org.xwiki.rendering.transformation.MacroTransformationContext;
+
+/**
+ * Lists the entries of a data type as a table readers can sort and filter.
+ * <p>
+ * The macro owns no rendering of its own: it maps its parameters onto a Live Data backed by the {@code liveTable}
+ * source and hands them to {@link LiveDataRenderer}, which is the same component the {@code liveData} macro uses. So
+ * the table, its layouts, its filter row, its pagination and its view-rights enforcement are Live Data's, and this
+ * class is only the translation layer.
+ * <p>
+ * The one thing worth knowing about that translation is what it deliberately does <em>not</em> do. The renderer also
+ * accepts an advanced configuration, which is the only way to reach the parts of a Live Data that are not macro
+ * parameters. It is not used here, and cannot be while it stays the trust switch it is today: the renderer marks the
+ * content trusted only when the advanced configuration is blank or the author holds script right, so passing one
+ * would downgrade every table authored by someone without that right and get its HTML displayers sanitized. The
+ * mapping below therefore sticks to what the parameters can express.
+ *
+ * @version $Id$
+ * @since 18.8.0RC1
+ */
+@Component
+@Named(RecordsMacro.ID)
+@Singleton
+public class RecordsMacro extends AbstractMacro<RecordsMacroParameters>
+{
+    /**
+     * The identifier of this macro.
+     */
+    public static final String ID = "records";
+
+    /**
+     * The Live Data source listing the XObjects of an XClass.
+     */
+    static final String SOURCE = "liveTable";
+
+    /**
+     * Source parameter naming the XClass whose objects are listed.
+     */
+    static final String CLASS_NAME_PARAMETER = "className";
+
+    /**
+     * Source parameter prefixing the translation keys of the column headers.
+     */
+    static final String TRANSLATION_PREFIX_PARAMETER = "translationPrefix";
+
+    /**
+     * The prefix the {@code doc.*} column headers are translated under.
+     * <p>
+     * Set by the macro rather than exposed as a parameter, exactly as the {@code documents} macro does. It only ever
+     * resolves the metadata columns: a data type's own fields have no key under this prefix, so they keep the
+     * translated pretty name the property store already put on their descriptor.
+     */
+    static final String DOC_TRANSLATION_PREFIX = "platform.index.";
+
+    /**
+     * The identifier prefix of the entry metadata properties, which the default column list leaves out.
+     */
+    private static final String METADATA_PREFIX = "doc.";
+
+    /**
+     * The identifier prefix of the Live Data pseudo-columns, which are rendering affordances rather than data.
+     */
+    private static final String INTERNAL_PREFIX = "_";
+
+    private static final String DESCRIPTION =
+        "Displays a collection of entries of the same data type, as a table readers can sort and filter.";
+
+    @Inject
+    private LiveDataRenderer liveDataRenderer;
+
+    /**
+     * Reads the fields of the chosen data type, to fill in the default column list.
+     */
+    @Inject
+    private LiveDataSourceManager liveDataSourceManager;
+
+    /**
+     * Serializes the picked data type for the source. The compact form keeps the wiki only when it is not the
+     * current one, which is what a class reference looks like in a Live Data source parameter.
+     */
+    @Inject
+    @Named("compactwiki")
+    private EntityReferenceSerializer<String> entityReferenceSerializer;
+
+    /**
+     * Default constructor.
+     */
+    public RecordsMacro()
+    {
+        super("Records", DESCRIPTION, null, RecordsMacroParameters.class);
+        setDefaultCategories(Set.of(DEFAULT_CATEGORY_CONTENT));
+    }
+
+    @Override
+    public List<Block> execute(RecordsMacroParameters parameters, String content, MacroTransformationContext context)
+        throws MacroExecutionException
+    {
+        if (parameters.getDataType() == null) {
+            throw new MacroExecutionException("The [class] parameter is mandatory.");
+        }
+
+        try {
+            boolean restricted = context.getTransformationContext().isRestricted();
+            // The advanced configuration is left blank on purpose, see the class javadoc.
+            return List.of(this.liveDataRenderer.execute(toLiveDataParameters(parameters), (String) null, restricted));
+        } catch (LiveDataException e) {
+            throw new MacroExecutionException("Failed to render the Records macro.", e);
+        }
+    }
+
+    @Override
+    public boolean supportsInlineMode()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isExecutionIsolated(RecordsMacroParameters parameters, String content)
+    {
+        return true;
+    }
+
+    /**
+     * Maps the macro parameters onto the Live Data ones.
+     * <p>
+     * Only {@code class} needs real work, because it is the only parameter that is not already in the shape Live Data
+     * expects: it becomes a source parameter of the {@code liveTable} source. The rest are passed through, since the
+     * macro deliberately reuses Live Data's own encodings — a comma-separated properties list, a query-string filter
+     * and a {@code name:asc} sort list — so that a value an author writes here means the same thing it would mean in
+     * a {@code liveData} macro.
+     *
+     * @param parameters the macro parameters
+     * @return the equivalent Live Data renderer parameters
+     */
+    private LiveDataRendererParameters toLiveDataParameters(RecordsMacroParameters parameters)
+        throws MacroExecutionException
+    {
+        LiveDataRendererParameters liveDataParameters = new LiveDataRendererParameters();
+        liveDataParameters.setId(parameters.getId());
+        liveDataParameters.setSource(SOURCE);
+        liveDataParameters.setSourceParameters(getSourceParameters(parameters));
+        liveDataParameters.setProperties(getProperties(parameters));
+        liveDataParameters.setFilters(parameters.getFilters());
+        liveDataParameters.setSort(parameters.getSort());
+        liveDataParameters.setLimit(parameters.getLimit());
+        liveDataParameters.setLayouts(parameters.getLayouts());
+        liveDataParameters.setDescription(parameters.getDescription());
+        return liveDataParameters;
+    }
+
+    /**
+     * Returns the columns to display.
+     *
+     * An author who has not chosen any expects to see the data type's own fields, which is what the parameter's
+     * default says. That default has to be resolved here rather than left to Live Data: the {@code liveTable}
+     * source needs an explicit column list, and an absent one yields a table with no columns at all rather than
+     * one with every column. The {@code documents} macro assembles its list for the same reason.
+     *
+     * @param parameters the macro parameters
+     * @return the columns the author chose, or every field of the data type when they chose none
+     * @throws MacroExecutionException when the data type's fields cannot be read
+     */
+    private String getProperties(RecordsMacroParameters parameters) throws MacroExecutionException
+    {
+        if (StringUtils.isNotBlank(parameters.getProperties())) {
+            return parameters.getProperties();
+        }
+        return getFields(this.entityReferenceSerializer.serialize(parameters.getDataType())).stream()
+            .collect(Collectors.joining(","));
+    }
+
+    /**
+     * Reads the field identifiers of a data type, in the order the data type declares them.
+     *
+     * The entry metadata is left out: the property store reports it alongside the fields, but a default built from
+     * the data type is about the data type, and the author can add any {@code doc.*} column themselves. The Live
+     * Data pseudo-columns are left out because they are affordances rather than data.
+     *
+     * @param dataType the serialized reference of the data type
+     * @return its field identifiers
+     * @throws MacroExecutionException when the source cannot be reached or its properties cannot be read
+     */
+    private List<String> getFields(String dataType) throws MacroExecutionException
+    {
+        Source source = new Source(SOURCE);
+        source.setParameter(CLASS_NAME_PARAMETER, dataType);
+        try {
+            return this.liveDataSourceManager.get(source)
+                .orElseThrow(() -> new MacroExecutionException(
+                    String.format("The [%s] Live Data source is not available.", SOURCE)))
+                .getProperties().get().stream()
+                .map(LiveDataPropertyDescriptor::getId)
+                .filter(id -> id != null && !id.startsWith(METADATA_PREFIX) && !id.startsWith(INTERNAL_PREFIX))
+                .toList();
+        } catch (LiveDataException e) {
+            throw new MacroExecutionException(String.format("Failed to read the fields of [%s].", dataType), e);
+        }
+    }
+
+    /**
+     * @param parameters the macro parameters
+     * @return the source parameters, as the query string {@link LiveDataRendererParameters} expects
+     */
+    private String getSourceParameters(RecordsMacroParameters parameters)
+    {
+        Map<String, String> sourceParameters = new LinkedHashMap<>();
+        sourceParameters.put(CLASS_NAME_PARAMETER,
+            this.entityReferenceSerializer.serialize(parameters.getDataType()));
+        sourceParameters.put(TRANSLATION_PREFIX_PARAMETER, DOC_TRANSLATION_PREFIX);
+
+        return sourceParameters.entrySet().stream()
+            .map(entry -> encode(entry.getKey()) + '=' + encode(entry.getValue()))
+            .collect(Collectors.joining("&"));
+    }
+
+    /**
+     * @param value the value to encode
+     * @return the value, URL-encoded, since the receiving end URL-decodes each source parameter
+     */
+    private String encode(String value)
+    {
+        return URLEncoder.encode(StringUtils.defaultString(value), StandardCharsets.UTF_8);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsColumns.java
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsColumns.java
@@ -1,0 +1,46 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.records.macro;
+
+import org.xwiki.stability.Unstable;
+
+/**
+ * Marker type selecting this module's field picker for a macro parameter.
+ * <p>
+ * The parameter it is declared on stays a comma-separated {@link String}; this type exists only to name the HTML
+ * displayer, since {@code DefaultTemplateHTMLDisplayer} resolves
+ * {@code templates/html_displayer/<simple type name in lower case>/edit.vm} — here
+ * {@code templates/html_displayer/recordscolumns/edit.vm}.
+ * <p>
+ * The widget it selects is a suggester whose candidate list depends on the value of the sibling {@code class}
+ * parameter. The macro editor offers no declarative way to express that dependency: a displayer receives its own
+ * type, default value and attributes and nothing else. What makes it work anyway is that the suggest widget's data
+ * source is a callback invoked on each keystroke rather than a URL fixed when this template is rendered, so it can
+ * read the {@code class} input at query time. See the {@code xwiki-platform-records-webjar} module for the
+ * implementation, and note that the coupling is to the input <em>named after the parameter</em>, which is the same
+ * contract the macro editor itself relies on to assemble a macro call.
+ *
+ * @version $Id$
+ * @since 18.8.0RC1
+ */
+@Unstable
+public interface RecordsColumns
+{
+}

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsDataType.java
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsDataType.java
@@ -1,0 +1,43 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.records.macro;
+
+import org.xwiki.stability.Unstable;
+
+/**
+ * Marker type selecting the XClass picker for a macro parameter.
+ * <p>
+ * The parameter it is declared on stays a {@link org.xwiki.model.reference.DocumentReference}; this type exists only
+ * to name the HTML displayer, since {@code DefaultTemplateHTMLDisplayer} resolves
+ * {@code templates/html_displayer/<simple type name in lower case>/edit.vm} — here
+ * {@code templates/html_displayer/recordsdatatype/edit.vm}, which delegates to the {@code #classPicker} Velocity
+ * macro.
+ * <p>
+ * That picker is the one the object and class editors use: it lists the XClasses the user may view, grouped by
+ * space, by reference. It is a stopgap, not the picker this macro should end up with — searching on a human-readable
+ * name, showing the entry count and hiding technical classes are the subject of a separate proposal.
+ *
+ * @version $Id$
+ * @since 18.8.0RC1
+ */
+@Unstable
+public interface RecordsDataType
+{
+}

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsFilters.java
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsFilters.java
@@ -1,0 +1,49 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.records.macro;
+
+import org.xwiki.stability.Unstable;
+
+/**
+ * Marker type selecting this module's filter picker for a macro parameter.
+ * <p>
+ * The parameter it is declared on stays a query string; this type exists only to name the HTML displayer, since
+ * {@code DefaultTemplateHTMLDisplayer} resolves
+ * {@code templates/html_displayer/<simple type name in lower case>/edit.vm} — here
+ * {@code templates/html_displayer/recordsfilters/edit.vm}.
+ * <p>
+ * The widget it selects holds one item per {@code field=value} constraint, which is what the renderer parses the
+ * query string into. Its suggestions come in two steps, since only the author knows which field they mean: the
+ * fields until a {@code =} is typed, then that field's values. Those values are not invented here — the Live Data
+ * properties resource reports a {@code filter.searchURL} for every property whose values are enumerable, and that
+ * is the same URL the Live Data filter row queries, so the dialog offers what a reader would be offered in the
+ * rendered table. A property without one is filtered by typing, which is why this is the only picker of this
+ * dialog that accepts free text.
+ * <p>
+ * Like {@link RecordsColumns}, the candidate list depends on the value of the sibling {@code class} parameter, and
+ * is read from the browser at query time for the reasons given there.
+ *
+ * @version $Id$
+ * @since 18.8.0RC1
+ */
+@Unstable
+public interface RecordsFilters
+{
+}

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsLayouts.java
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsLayouts.java
@@ -1,0 +1,49 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.records.macro;
+
+import org.xwiki.stability.Unstable;
+
+/**
+ * Marker type selecting the layout picker for a macro parameter.
+ * <p>
+ * The parameter it is declared on stays a {@link String} holding a Live Data layout identifier; this type exists
+ * only to name the HTML displayer, since {@code DefaultTemplateHTMLDisplayer} resolves
+ * {@code templates/html_displayer/<simple type name in lower case>/edit.vm} — here
+ * {@code templates/html_displayer/recordslayouts/edit.vm}.
+ * <p>
+ * The widget it selects is a pair of radio buttons naming the two layouts this macro offers, {@code table} and
+ * {@code cards}. The choice is deliberately closed: Live Data accepts a comma-separated list of any registered
+ * layout, but the layouts an author can reasonably pick for a table of records are these two, and a free-text list
+ * asks them to know identifiers the dialog is in a position to name. An author who needs anything else — a third
+ * layout, or a switcher between several — reaches for the {@code liveData} macro, which is the unconstrained
+ * surface.
+ * <p>
+ * Radio buttons work here without any JavaScript of their own because the macro editor already handles them: it
+ * collects the inputs whose {@code name} matches the parameter id, and when the first of them is a radio it keeps
+ * the whole group and checks the one whose value matches the current parameter value.
+ *
+ * @version $Id$
+ * @since 18.8.0RC1
+ */
+@Unstable
+public interface RecordsLayouts
+{
+}

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsMacroParameters.java
@@ -1,0 +1,256 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.records.macro;
+
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.properties.annotation.PropertyAdvanced;
+import org.xwiki.properties.annotation.PropertyDescription;
+import org.xwiki.properties.annotation.PropertyDisplayType;
+import org.xwiki.properties.annotation.PropertyGroup;
+import org.xwiki.properties.annotation.PropertyId;
+import org.xwiki.properties.annotation.PropertyMandatory;
+import org.xwiki.properties.annotation.PropertyName;
+import org.xwiki.properties.annotation.PropertyOrder;
+import org.xwiki.stability.Unstable;
+
+/**
+ * Parameters of the {@code records} macro.
+ * <p>
+ * The annotations are what the WYSIWYG macro dialog is built from, and the layout they produce is not a free choice.
+ * {@code MacroDescriptorUIFactory} renders the mandatory nodes flat, above the tab strip, and turns the optional
+ * groups into the tabs. {@code class} is mandatory and carries no group, so it is that flat field; the
+ * {@code columns}, {@code filterSort}, {@code display} and {@code advanced} groups become the tabs, in that order.
+ * <p>
+ * Leaving {@code class} ungrouped is a choice rather than a requirement: a group holding a mandatory parameter is
+ * itself mandatory and would be rendered in the same place, as a titled panel. It is ungrouped because it is
+ * currently alone there, and a panel headed <em>Data</em> wrapping a single field labelled <em>Data type</em> is
+ * redundant. It belongs in a group again once {@code location} joins it, since the two parameters that decide which
+ * rows the table has do belong together.
+ * <p>
+ * Every <em>optional</em> parameter, by contrast, must carry an explicit group. An ungrouped optional parameter is
+ * added to the framework's own {@code defaultOptionalGroup}, and because {@code MacroDescriptorUIFactory} pins that
+ * group at order {@code 0} while {@code DefaultBeanDescriptor} keeps an {@link PropertyOrder} value only when it is
+ * strictly positive, no Java macro can move it: it would show up as the <em>first</em> tab, ahead of
+ * {@code Columns}. Leaving it childless is the only way to get the intended order. A mandatory parameter never
+ * reaches that branch, which is why {@code class} is exempt.
+ * <p>
+ * Two parameters the design calls for are deliberately absent from this first increment. {@code location}, which
+ * scopes the table to one part of the page tree, needs an exact prefix predicate that the {@code liveTable} source
+ * cannot express, so it waits on the results page this module will ship. {@code editable} cannot be honoured
+ * without harm: it maps onto the per-property {@code editable} flag of the Live Data <em>configuration</em> rather
+ * than onto a macro parameter, and {@code LiveDataRenderer} treats a configuration as trusted only when it is blank
+ * or the author holds script right. Since the {@code liveTable} property types already allow editing, suppressing
+ * it is the default path, so honouring the parameter would silently downgrade the content trust of every table
+ * authored by someone without script right and get the link displayers sanitized away.
+ * <p>
+ * The display types are what select the parameter widgets. {@link RecordsDataType} names the XClass picker of the
+ * object and class editors, and {@link RecordsColumns} names this module's own field picker; both resolve to a
+ * template under {@code templates/html_displayer}. Everything else relies on the displayer the Java type already
+ * has: {@code int} and {@link String} render text inputs.
+ *
+ * @version $Id$
+ * @since 18.8.0RC1
+ */
+@Unstable
+public class RecordsMacroParameters
+{
+    private DocumentReference dataType;
+
+    private String properties;
+
+    private String filters;
+
+    private String sort;
+
+    private String layouts = "table";
+
+    private int limit = 15;
+
+    private String description;
+
+    private String id;
+
+    /**
+     * @return the data type whose entries are listed
+     */
+    public DocumentReference getDataType()
+    {
+        return this.dataType;
+    }
+
+    /**
+     * @param dataType the data type whose entries are listed
+     */
+    @PropertyId("class")
+    @PropertyDisplayType(RecordsDataType.class)
+    @PropertyName("Data type")
+    @PropertyDescription("The data type whose entries are listed.")
+    @PropertyMandatory
+    @PropertyOrder(1)
+    public void setDataType(DocumentReference dataType)
+    {
+        this.dataType = dataType;
+    }
+
+    /**
+     * @return the columns to display, in the order given
+     */
+    public String getProperties()
+    {
+        return this.properties;
+    }
+
+    /**
+     * @param properties the columns to display, in the order given
+     */
+    @PropertyDisplayType(RecordsColumns.class)
+    @PropertyName("Columns")
+    @PropertyDescription("The columns to display, separated by commas, in the order given. Entry metadata such as "
+        + "doc.title and the fields of the data type can be mixed. Leave empty to display every field.")
+    @PropertyGroup("columns")
+    @PropertyOrder(2)
+    public void setProperties(String properties)
+    {
+        this.properties = properties;
+    }
+
+    /**
+     * @return the filters applied before readers see the table
+     */
+    public String getFilters()
+    {
+        return this.filters;
+    }
+
+    /**
+     * @param filters the filters applied before readers see the table
+     */
+    @PropertyName("Filters")
+    @PropertyDescription("Filters applied before readers see the table, as a query string, for example "
+        + "status=Active&client=Acme. The operator is the one the field's type defines.")
+    @PropertyGroup("filterSort")
+    @PropertyOrder(3)
+    public void setFilters(String filters)
+    {
+        this.filters = filters;
+    }
+
+    /**
+     * @return the columns the table is sorted on when the page opens
+     */
+    public String getSort()
+    {
+        return this.sort;
+    }
+
+    /**
+     * @param sort the columns the table is sorted on when the page opens
+     */
+    @PropertyName("Sort")
+    @PropertyDescription("The columns the table is sorted on when the page opens, separated by commas. Each name may "
+        + "be followed by :asc or :desc.")
+    @PropertyGroup("filterSort")
+    @PropertyOrder(4)
+    public void setSort(String sort)
+    {
+        this.sort = sort;
+    }
+
+    /**
+     * @return the layouts readers can switch between
+     */
+    public String getLayouts()
+    {
+        return this.layouts;
+    }
+
+    /**
+     * @param layouts the layouts readers can switch between
+     */
+    @PropertyName("Layouts")
+    @PropertyDescription("The layouts readers can switch between, separated by commas. The first one is shown first.")
+    @PropertyGroup("display")
+    @PropertyOrder(5)
+    public void setLayouts(String layouts)
+    {
+        this.layouts = layouts;
+    }
+
+    /**
+     * @return how many entries are shown before paging
+     */
+    public int getLimit()
+    {
+        return this.limit;
+    }
+
+    /**
+     * @param limit how many entries are shown before paging
+     */
+    @PropertyName("Entries per page")
+    @PropertyDescription("How many entries are shown before paging.")
+    @PropertyGroup("display")
+    @PropertyOrder(6)
+    public void setLimit(int limit)
+    {
+        this.limit = limit;
+    }
+
+    /**
+     * @return the description announced to assistive technology
+     */
+    public String getDescription()
+    {
+        return this.description;
+    }
+
+    /**
+     * @param description the description announced to assistive technology
+     */
+    @PropertyName("Description")
+    @PropertyDescription("Describes what the table lists. Announced to assistive technology.")
+    @PropertyGroup("display")
+    @PropertyOrder(7)
+    public void setDescription(String description)
+    {
+        this.description = description;
+    }
+
+    /**
+     * @return the identifier of this table
+     */
+    public String getId()
+    {
+        return this.id;
+    }
+
+    /**
+     * @param id the identifier of this table
+     */
+    @PropertyName("Table identifier")
+    @PropertyDescription("Identifier for this table, needed only when one page holds more than one.")
+    @PropertyGroup("advanced")
+    @PropertyAdvanced
+    @PropertyOrder(8)
+    public void setId(String id)
+    {
+        this.id = id;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsMacroParameters.java
@@ -51,9 +51,12 @@ import org.xwiki.stability.Unstable;
  * {@code Columns}. Leaving it childless is the only way to get the intended order. A mandatory parameter never
  * reaches that branch, which is why {@code class} is exempt.
  * <p>
- * Two parameters the design calls for are deliberately absent from this first increment. {@code location}, which
- * scopes the table to one part of the page tree, needs an exact prefix predicate that the {@code liveTable} source
- * cannot express, so it waits on the results page this module will ship. {@code editable} cannot be honoured
+ * Three parameters the design calls for are deliberately absent from this first increment. {@code limit}, which
+ * decides how many entries a page holds, is left out until there is a reason to override Live Data's own default of
+ * fifteen: the reader can already change the page size from the pagination controls, so the parameter would only
+ * pick the starting point. {@code location}, which scopes the table to one part of the page tree, needs an exact
+ * prefix predicate that the {@code liveTable} source cannot express, so it waits on the results page this module
+ * will ship. {@code editable} cannot be honoured
  * without harm: it maps onto the per-property {@code editable} flag of the Live Data <em>configuration</em> rather
  * than onto a macro parameter, and {@code LiveDataRenderer} treats a configuration as trusted only when it is blank
  * or the author holds script right. Since the {@code liveTable} property types already allow editing, suppressing
@@ -61,9 +64,9 @@ import org.xwiki.stability.Unstable;
  * authored by someone without script right and get the link displayers sanitized away.
  * <p>
  * The display types are what select the parameter widgets. {@link RecordsDataType} names the XClass picker of the
- * object and class editors, and {@link RecordsColumns} names this module's own field picker; both resolve to a
- * template under {@code templates/html_displayer}. Everything else relies on the displayer the Java type already
- * has: {@code int} and {@link String} render text inputs.
+ * object and class editors, {@link RecordsColumns} names this module's own field picker and {@link RecordsLayouts}
+ * names its layout radio group; all three resolve to a template under {@code templates/html_displayer}. Everything
+ * else relies on the displayer the Java type already has: a {@link String} renders a text input.
  *
  * @version $Id$
  * @since 18.8.0RC1
@@ -80,8 +83,6 @@ public class RecordsMacroParameters
     private String sort;
 
     private String layouts = "table";
-
-    private int limit = 15;
 
     private String description;
 
@@ -175,7 +176,7 @@ public class RecordsMacroParameters
     }
 
     /**
-     * @return the layouts readers can switch between
+     * @return the layout the entries are displayed in
      */
     public String getLayouts()
     {
@@ -183,35 +184,16 @@ public class RecordsMacroParameters
     }
 
     /**
-     * @param layouts the layouts readers can switch between
+     * @param layouts the layout the entries are displayed in
      */
-    @PropertyName("Layouts")
-    @PropertyDescription("The layouts readers can switch between, separated by commas. The first one is shown first.")
+    @PropertyDisplayType(RecordsLayouts.class)
+    @PropertyName("Layout")
+    @PropertyDescription("How the entries are laid out.")
     @PropertyGroup("display")
     @PropertyOrder(5)
     public void setLayouts(String layouts)
     {
         this.layouts = layouts;
-    }
-
-    /**
-     * @return how many entries are shown before paging
-     */
-    public int getLimit()
-    {
-        return this.limit;
-    }
-
-    /**
-     * @param limit how many entries are shown before paging
-     */
-    @PropertyName("Entries per page")
-    @PropertyDescription("How many entries are shown before paging.")
-    @PropertyGroup("display")
-    @PropertyOrder(6)
-    public void setLimit(int limit)
-    {
-        this.limit = limit;
     }
 
     /**
@@ -229,7 +211,7 @@ public class RecordsMacroParameters
     @PropertyDescription("Describes what the table lists. Shown above the table, and used as its accessible "
         + "description.")
     @PropertyGroup("display")
-    @PropertyOrder(7)
+    @PropertyOrder(6)
     public void setDescription(String description)
     {
         this.description = description;
@@ -250,7 +232,7 @@ public class RecordsMacroParameters
     @PropertyDescription("Identifier for this table, needed only when one page holds more than one.")
     @PropertyGroup("advanced")
     @PropertyAdvanced
-    @PropertyOrder(8)
+    @PropertyOrder(7)
     public void setId(String id)
     {
         this.id = id;

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsMacroParameters.java
@@ -64,10 +64,10 @@ import org.xwiki.stability.Unstable;
  * authored by someone without script right and get the link displayers sanitized away.
  * <p>
  * The display types are what select the parameter widgets. {@link RecordsDataType} names the XClass picker of the
- * object and class editors, {@link RecordsColumns} names this module's own field picker, {@link RecordsSort} its
- * sort picker and {@link RecordsLayouts} its layout radio group; all four resolve to a template under
- * {@code templates/html_displayer}. Everything else relies on the displayer the Java type already has: a
- * {@link String} renders a text input.
+ * object and class editors, {@link RecordsColumns} names this module's own field picker, {@link RecordsFilters}
+ * its filter picker, {@link RecordsSort} its sort picker and {@link RecordsLayouts} its layout radio group; all
+ * five resolve to a template under {@code templates/html_displayer}. Everything else relies on the displayer the
+ * Java type already has: a {@link String} renders a text input.
  *
  * @version $Id$
  * @since 18.8.0RC1
@@ -145,9 +145,10 @@ public class RecordsMacroParameters
     /**
      * @param filters the filters applied before readers see the table
      */
+    @PropertyDisplayType(RecordsFilters.class)
     @PropertyName("Filters")
-    @PropertyDescription("Filters applied before readers see the table, as a query string, for example "
-        + "status=Active&client=Acme. The operator is the one the field's type defines.")
+    @PropertyDescription("Filters applied before readers see the table. The operator is the one the field's type "
+        + "defines.")
     @PropertyGroup("filterSort")
     @PropertyOrder(3)
     public void setFilters(String filters)

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsMacroParameters.java
@@ -64,9 +64,10 @@ import org.xwiki.stability.Unstable;
  * authored by someone without script right and get the link displayers sanitized away.
  * <p>
  * The display types are what select the parameter widgets. {@link RecordsDataType} names the XClass picker of the
- * object and class editors, {@link RecordsColumns} names this module's own field picker and {@link RecordsLayouts}
- * names its layout radio group; all three resolve to a template under {@code templates/html_displayer}. Everything
- * else relies on the displayer the Java type already has: a {@link String} renders a text input.
+ * object and class editors, {@link RecordsColumns} names this module's own field picker, {@link RecordsSort} its
+ * sort picker and {@link RecordsLayouts} its layout radio group; all four resolve to a template under
+ * {@code templates/html_displayer}. Everything else relies on the displayer the Java type already has: a
+ * {@link String} renders a text input.
  *
  * @version $Id$
  * @since 18.8.0RC1
@@ -165,9 +166,9 @@ public class RecordsMacroParameters
     /**
      * @param sort the columns the table is sorted on when the page opens
      */
+    @PropertyDisplayType(RecordsSort.class)
     @PropertyName("Sort")
-    @PropertyDescription("The columns the table is sorted on when the page opens, separated by commas. Each name may "
-        + "be followed by :asc or :desc.")
+    @PropertyDescription("The columns the table is sorted on when the page opens, in the order they apply.")
     @PropertyGroup("filterSort")
     @PropertyOrder(4)
     public void setSort(String sort)

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsMacroParameters.java
@@ -123,7 +123,8 @@ public class RecordsMacroParameters
     @PropertyDisplayType(RecordsColumns.class)
     @PropertyName("Columns")
     @PropertyDescription("The columns to display, separated by commas, in the order given. Entry metadata such as "
-        + "doc.title and the fields of the data type can be mixed. Leave empty to display every field.")
+        + "doc.title and the fields of the data type can be mixed. Leave empty to display the entry title followed "
+        + "by every field.")
     @PropertyGroup("columns")
     @PropertyOrder(2)
     public void setProperties(String properties)

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsMacroParameters.java
@@ -215,7 +215,7 @@ public class RecordsMacroParameters
     }
 
     /**
-     * @return the description announced to assistive technology
+     * @return the description shown above the table
      */
     public String getDescription()
     {
@@ -223,10 +223,11 @@ public class RecordsMacroParameters
     }
 
     /**
-     * @param description the description announced to assistive technology
+     * @param description the description shown above the table, which is also its accessible description
      */
     @PropertyName("Description")
-    @PropertyDescription("Describes what the table lists. Announced to assistive technology.")
+    @PropertyDescription("Describes what the table lists. Shown above the table, and used as its accessible "
+        + "description.")
     @PropertyGroup("display")
     @PropertyOrder(7)
     public void setDescription(String description)

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsSort.java
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/java/org/xwiki/records/macro/RecordsSort.java
@@ -1,0 +1,49 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.records.macro;
+
+import org.xwiki.stability.Unstable;
+
+/**
+ * Marker type selecting this module's sort picker for a macro parameter.
+ * <p>
+ * The parameter it is declared on stays a comma-separated {@link String}; this type exists only to name the HTML
+ * displayer, since {@code DefaultTemplateHTMLDisplayer} resolves
+ * {@code templates/html_displayer/<simple type name in lower case>/edit.vm} — here
+ * {@code templates/html_displayer/recordssort/edit.vm}.
+ * <p>
+ * The widget it selects offers each field of the data type twice, once ascending and once descending, so that a
+ * criterion is picked rather than typed. It is a suggester rather than the platform's {@code sortPicker} widget
+ * ({@code uicomponents/widgets/sortPicker.js}), which edits a single criterion through a field select and an order
+ * select: this parameter holds an ordered <em>list</em> of criteria, and the suggester's drag-and-drop plugin is
+ * what lets that order be authored. The platform widget would also need its field select filled from the sibling
+ * {@code class} parameter, which is the same client-side work as this picker, so choosing it would buy the harder
+ * half and still lose the list.
+ * <p>
+ * Like {@link RecordsColumns}, the candidate list depends on the value of the sibling {@code class} parameter, and
+ * is read from the browser at query time for the reasons given there.
+ *
+ * @version $Id$
+ * @since 18.8.0RC1
+ */
+@Unstable
+public interface RecordsSort
+{
+}

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/ApplicationResources.properties
@@ -40,11 +40,8 @@ rendering.macro.records.parameter.filters.description=Filters applied before rea
 rendering.macro.records.parameter.sort.name=Sort
 rendering.macro.records.parameter.sort.description=The columns the table is sorted on when the page opens, separated \
   by commas. Each name may be followed by :asc or :desc.
-rendering.macro.records.parameter.layouts.name=Layouts
-rendering.macro.records.parameter.layouts.description=The layouts readers can switch between, separated by commas. \
-  The first one is shown first.
-rendering.macro.records.parameter.limit.name=Entries per page
-rendering.macro.records.parameter.limit.description=How many entries are shown before paging.
+rendering.macro.records.parameter.layouts.name=Layout
+rendering.macro.records.parameter.layouts.description=How the entries are laid out.
 rendering.macro.records.parameter.description.name=Description
 rendering.macro.records.parameter.description.description=Describes what the table lists. Shown above the table, \
   and used as its accessible description.

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/ApplicationResources.properties
@@ -46,8 +46,8 @@ rendering.macro.records.parameter.layouts.description=The layouts readers can sw
 rendering.macro.records.parameter.limit.name=Entries per page
 rendering.macro.records.parameter.limit.description=How many entries are shown before paging.
 rendering.macro.records.parameter.description.name=Description
-rendering.macro.records.parameter.description.description=Describes what the table lists. Announced to assistive \
-  technology.
+rendering.macro.records.parameter.description.description=Describes what the table lists. Shown above the table, \
+  and used as its accessible description.
 rendering.macro.records.parameter.id.name=Table identifier
 rendering.macro.records.parameter.id.description=Identifier for this table, needed only when one page holds more \
   than one.

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/ApplicationResources.properties
@@ -32,8 +32,8 @@ rendering.macro.records.parameter.class.name=Data type
 rendering.macro.records.parameter.class.description=The data type whose entries are listed.
 rendering.macro.records.parameter.properties.name=Columns
 rendering.macro.records.parameter.properties.description=The columns to display, in the order given. Entry metadata \
-  and the fields of the data type can be mixed. Leave empty to display every field.
-rendering.macro.records.parameter.properties.placeholder=Every field
+  and the fields of the data type can be mixed. Leave empty to display the entry title followed by every field.
+rendering.macro.records.parameter.properties.placeholder=Title and every field
 rendering.macro.records.parameter.filters.name=Filters
 rendering.macro.records.parameter.filters.description=Filters applied before readers see the table, as a query \
   string, for example status=Active&client=Acme. The operator is the one the field's type defines.

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/ApplicationResources.properties
@@ -1,0 +1,53 @@
+# ---------------------------------------------------------------------------
+# See the NOTICE file distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+# ---------------------------------------------------------------------------
+rendering.macro.records.name=Records
+rendering.macro.records.description=Displays a collection of entries of the same data type, as a table readers can \
+  sort and filter.
+
+# The tabs, in this order. Without these keys they would read as the raw group ids. There is no key for the
+# mandatory class parameter: it carries no group, so it is rendered as a bare field above the tab strip.
+rendering.macro.records.group.columns.name=Columns
+rendering.macro.records.group.filterSort.name=Filter & sort
+rendering.macro.records.group.display.name=Display
+rendering.macro.records.group.advanced.name=Advanced
+
+rendering.macro.records.parameter.class.name=Data type
+rendering.macro.records.parameter.class.description=The data type whose entries are listed.
+rendering.macro.records.parameter.properties.name=Columns
+rendering.macro.records.parameter.properties.description=The columns to display, in the order given. Entry metadata \
+  and the fields of the data type can be mixed. Leave empty to display every field.
+rendering.macro.records.parameter.properties.placeholder=Every field
+rendering.macro.records.parameter.filters.name=Filters
+rendering.macro.records.parameter.filters.description=Filters applied before readers see the table, as a query \
+  string, for example status=Active&client=Acme. The operator is the one the field's type defines.
+rendering.macro.records.parameter.sort.name=Sort
+rendering.macro.records.parameter.sort.description=The columns the table is sorted on when the page opens, separated \
+  by commas. Each name may be followed by :asc or :desc.
+rendering.macro.records.parameter.layouts.name=Layouts
+rendering.macro.records.parameter.layouts.description=The layouts readers can switch between, separated by commas. \
+  The first one is shown first.
+rendering.macro.records.parameter.limit.name=Entries per page
+rendering.macro.records.parameter.limit.description=How many entries are shown before paging.
+rendering.macro.records.parameter.description.name=Description
+rendering.macro.records.parameter.description.description=Describes what the table lists. Announced to assistive \
+  technology.
+rendering.macro.records.parameter.id.name=Table identifier
+rendering.macro.records.parameter.id.description=Identifier for this table, needed only when one page holds more \
+  than one.

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/ApplicationResources.properties
@@ -35,8 +35,9 @@ rendering.macro.records.parameter.properties.description=The columns to display,
   and the fields of the data type can be mixed. Leave empty to display the entry title followed by every field.
 rendering.macro.records.parameter.properties.placeholder=Title and every field
 rendering.macro.records.parameter.filters.name=Filters
-rendering.macro.records.parameter.filters.description=Filters applied before readers see the table, as a query \
-  string, for example status=Active&client=Acme. The operator is the one the field's type defines.
+rendering.macro.records.parameter.filters.description=Filters applied before readers see the table. The operator \
+  is the one the field's type defines.
+rendering.macro.records.parameter.filters.placeholder=Every entry
 rendering.macro.records.parameter.sort.name=Sort
 rendering.macro.records.parameter.sort.description=The columns the table is sorted on when the page opens, in the \
   order they apply.

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/ApplicationResources.properties
@@ -38,8 +38,9 @@ rendering.macro.records.parameter.filters.name=Filters
 rendering.macro.records.parameter.filters.description=Filters applied before readers see the table, as a query \
   string, for example status=Active&client=Acme. The operator is the one the field's type defines.
 rendering.macro.records.parameter.sort.name=Sort
-rendering.macro.records.parameter.sort.description=The columns the table is sorted on when the page opens, separated \
-  by commas. Each name may be followed by :asc or :desc.
+rendering.macro.records.parameter.sort.description=The columns the table is sorted on when the page opens, in the \
+  order they apply.
+rendering.macro.records.parameter.sort.placeholder=The order the data type returns
 rendering.macro.records.parameter.layouts.name=Layout
 rendering.macro.records.parameter.layouts.description=How the entries are laid out.
 rendering.macro.records.parameter.description.name=Description

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/META-INF/components.txt
@@ -1,0 +1,1 @@
+org.xwiki.records.internal.macro.RecordsMacro

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/templates/html_displayer/recordscolumns/edit.vm
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/templates/html_displayer/recordscolumns/edit.vm
@@ -1,0 +1,50 @@
+## ---------------------------------------------------------------------------
+## See the NOTICE file distributed with this work for additional
+## information regarding copyright ownership.
+##
+## This is free software; you can redistribute it and/or modify it
+## under the terms of the GNU Lesser General Public License as
+## published by the Free Software Foundation; either version 2.1 of
+## the License, or (at your option) any later version.
+##
+## This software is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public
+## License along with this software; if not, write to the Free
+## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+## ---------------------------------------------------------------------------
+## Displays the field picker used for the columns of a Records table.
+##
+## The candidates depend on the value of the sibling class parameter, which no displayer can be told about: the macro
+## editor renders each parameter from its own type, default value and attributes alone. The picker therefore reads
+## that input from the browser when the author opens the dropdown, which is why the logic lives in JavaScript rather
+## than here. See the xwiki-platform-records-webjar module.
+##
+## This template only has to produce an input the suggest widget can enhance and the macro editor can read back. The
+## editor collects parameter values by serializing the inputs of the modal and matching their names against
+## parameter ids, so the name attribute it hands over is passed through untouched.
+#set ($parameters = {})
+#set ($discard = $parameters.putAll($displayer.parameters))
+## Note the absence of the xwiki-selectize class. xwiki.selectize.js auto-enhances every element carrying it on
+## xwiki:dom:updated, with default settings and therefore without the load callback this picker is built on, and
+## $.fn.xwikiSelectize skips an element that is already enhanced. Owning the enhancement means keeping that class
+## off and marking the element with our own instead.
+#set ($discard = $parameters.put('class', "$!parameters.get('class') suggest-records-fields"))
+#set ($discard = $parameters.put('multiple', 'multiple'))
+#if ("$!displayer.value" != '')
+  #set ($discard = $parameters.put('value', "$displayer.value"))
+#end
+#set ($discard = $parameters.putIfAbsent('placeholder',
+  $services.localization.render('rendering.macro.records.parameter.properties.placeholder')))
+## Loads the picker. This is deliberately a classic script rather than a module one: the macro editor injects this
+## template with jQuery, which refuses to fetch a type="module" script by src and evaluates every other script as a
+## classic one, so a module script here would never run. The bundle is built free of imports and exports for that
+## reason, and it declares jquery and xwiki-selectize as RequireJS dependencies so that it shares the page's
+## instances rather than bundling its own.
+<script src="$escapetool.xml($services.webjars.url(
+  'org.xwiki.platform:xwiki-platform-records-webjar', 'index.es.js'))"></script>
+#suggestInput($parameters)

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/templates/html_displayer/recordsdatatype/edit.vm
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/templates/html_displayer/recordsdatatype/edit.vm
@@ -1,0 +1,32 @@
+## ---------------------------------------------------------------------------
+## See the NOTICE file distributed with this work for additional
+## information regarding copyright ownership.
+##
+## This is free software; you can redistribute it and/or modify it
+## under the terms of the GNU Lesser General Public License as
+## published by the Free Software Foundation; either version 2.1 of
+## the License, or (at your option) any later version.
+##
+## This software is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public
+## License along with this software; if not, write to the Free
+## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+## ---------------------------------------------------------------------------
+## Displays the XClass picker used by the object and class editors. The value handed over by the macro editor is a
+## document reference, so it is serialized before being given to the picker, which resolves it back with
+## $services.model.resolveDocument in #classPicker_displayOptions.
+#set ($parameters = {})
+#set ($discard = $parameters.putAll($displayer.parameters))
+#if ("$!displayer.value" != '')
+  #if ($displayer.value.type)
+    #set ($parameters.value = $services.model.serialize($displayer.value, 'default'))
+  #else
+    #set ($parameters.value = "$displayer.value")
+  #end
+#end
+#classPicker($parameters)

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/templates/html_displayer/recordsfilters/edit.vm
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/templates/html_displayer/recordsfilters/edit.vm
@@ -1,0 +1,42 @@
+## ---------------------------------------------------------------------------
+## See the NOTICE file distributed with this work for additional
+## information regarding copyright ownership.
+##
+## This is free software; you can redistribute it and/or modify it
+## under the terms of the GNU Lesser General Public License as
+## published by the Free Software Foundation; either version 2.1 of
+## the License, or (at your option) any later version.
+##
+## This software is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public
+## License along with this software; if not, write to the Free
+## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+## ---------------------------------------------------------------------------
+## Displays the filter picker of a Records table: one item per field=value constraint.
+##
+## Everything this template does mirrors the columns picker, and for the same reasons: the candidates depend on the
+## sibling class parameter, which no displayer can be told about, so they are loaded by the browser; the element is
+## marked with a class of ours rather than xwiki-selectize, so that this module owns the enhancement; and the
+## bundle is loaded as a classic script, since the macro editor injects this template with jQuery. See
+## templates/html_displayer/recordscolumns/edit.vm for the long form of each.
+##
+## Unlike the other two pickers, this one separates its items with & rather than with a comma, since that is how
+## the parameter separates its constraints. The widget is told so in JavaScript, along with everything else that
+## is behaviour rather than markup.
+#set ($parameters = {})
+#set ($discard = $parameters.putAll($displayer.parameters))
+#set ($discard = $parameters.put('class', "$!parameters.get('class') suggest-records-filters"))
+#set ($discard = $parameters.put('multiple', 'multiple'))
+#if ("$!displayer.value" != '')
+  #set ($discard = $parameters.put('value', "$displayer.value"))
+#end
+#set ($discard = $parameters.putIfAbsent('placeholder',
+  $services.localization.render('rendering.macro.records.parameter.filters.placeholder')))
+<script src="$escapetool.xml($services.webjars.url(
+  'org.xwiki.platform:xwiki-platform-records-webjar', 'index.es.js'))"></script>
+#suggestInput($parameters)

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/templates/html_displayer/recordslayouts/edit.vm
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/templates/html_displayer/recordslayouts/edit.vm
@@ -1,0 +1,42 @@
+## ---------------------------------------------------------------------------
+## See the NOTICE file distributed with this work for additional
+## information regarding copyright ownership.
+##
+## This is free software; you can redistribute it and/or modify it
+## under the terms of the GNU Lesser General Public License as
+## published by the Free Software Foundation; either version 2.1 of
+## the License, or (at your option) any later version.
+##
+## This software is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public
+## License along with this software; if not, write to the Free
+## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+## ---------------------------------------------------------------------------
+## Displays the layout picker of a Records table: one radio button per layout the macro offers.
+##
+## The macro editor collects the inputs whose name matches the parameter id, and when the first of them is a radio it
+## keeps the group and checks the one whose value matches the parameter value, so the group needs no JavaScript of
+## its own. It also puts the computed id on the first input and points the parameter label at it, which is why no id
+## is set here: each radio carries its own label instead, wrapping the input so that it needs no id to be associated
+## with it.
+##
+## The labels are Live Data's own layout names, already translated, rather than keys of this module: they name the
+## same thing the reader sees, and there is no reason for the dialog to call it something else.
+#set ($layouts = ['table', 'cards'])
+#foreach ($layout in $layouts)
+  <div class="radio">
+    <label>
+      <input type="radio" value="$escapetool.xml($layout)"#if ($layout == "$!displayer.value") checked#end
+        #foreach ($parameter in $displayer.parameters.entrySet())
+          $escapetool.xml($parameter.key)="$!escapetool.xml($parameter.value)"
+        #end
+      />
+      $escapetool.xml($services.localization.render("liveData.layout.$layout"))
+    </label>
+  </div>
+#end

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/templates/html_displayer/recordssort/edit.vm
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/main/resources/templates/html_displayer/recordssort/edit.vm
@@ -1,0 +1,38 @@
+## ---------------------------------------------------------------------------
+## See the NOTICE file distributed with this work for additional
+## information regarding copyright ownership.
+##
+## This is free software; you can redistribute it and/or modify it
+## under the terms of the GNU Lesser General Public License as
+## published by the Free Software Foundation; either version 2.1 of
+## the License, or (at your option) any later version.
+##
+## This software is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public
+## License along with this software; if not, write to the Free
+## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+## ---------------------------------------------------------------------------
+## Displays the sort picker of a Records table: the fields of the data type, each offered ascending and descending.
+##
+## Everything this template does mirrors the columns picker, and for the same reasons: the candidates depend on the
+## sibling class parameter, which no displayer can be told about, so they are loaded by the browser; the element is
+## marked with a class of ours rather than xwiki-selectize, so that this module owns the enhancement; and the
+## bundle is loaded as a classic script, since the macro editor injects this template with jQuery. See
+## templates/html_displayer/recordscolumns/edit.vm for the long form of each.
+#set ($parameters = {})
+#set ($discard = $parameters.putAll($displayer.parameters))
+#set ($discard = $parameters.put('class', "$!parameters.get('class') suggest-records-sort"))
+#set ($discard = $parameters.put('multiple', 'multiple'))
+#if ("$!displayer.value" != '')
+  #set ($discard = $parameters.put('value', "$displayer.value"))
+#end
+#set ($discard = $parameters.putIfAbsent('placeholder',
+  $services.localization.render('rendering.macro.records.parameter.sort.placeholder')))
+<script src="$escapetool.xml($services.webjars.url(
+  'org.xwiki.platform:xwiki-platform-records-webjar', 'index.es.js'))"></script>
+#suggestInput($parameters)

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/test/java/org/xwiki/records/internal/macro/RecordsMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/test/java/org/xwiki/records/internal/macro/RecordsMacroTest.java
@@ -1,0 +1,343 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.records.internal.macro;
+
+import java.util.List;
+import java.util.Optional;
+
+import javax.inject.Named;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.xwiki.livedata.LiveDataException;
+import org.xwiki.livedata.LiveDataPropertyDescriptor;
+import org.xwiki.livedata.LiveDataPropertyDescriptorStore;
+import org.xwiki.livedata.LiveDataQuery.Source;
+import org.xwiki.livedata.LiveDataSource;
+import org.xwiki.livedata.LiveDataSourceManager;
+import org.xwiki.livedata.internal.LiveDataRenderer;
+import org.xwiki.livedata.internal.LiveDataRendererParameters;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.records.macro.RecordsMacroParameters;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.block.GroupBlock;
+import org.xwiki.rendering.macro.MacroExecutionException;
+import org.xwiki.rendering.transformation.MacroTransformationContext;
+import org.xwiki.rendering.transformation.TransformationContext;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link RecordsMacro}.
+ * <p>
+ * The macro is a translation layer onto Live Data, so these tests are about the translation: they assert what the
+ * macro hands to {@link LiveDataRenderer} rather than what the rendered table looks like, which is Live Data's own
+ * concern and is covered by its own tests.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+class RecordsMacroTest
+{
+    private static final DocumentReference DATA_TYPE =
+        new DocumentReference("xwiki", List.of("Clients", "Code"), "ProjectClass");
+
+    private static final String SERIALIZED_DATA_TYPE = "Clients.Code.ProjectClass";
+
+    @InjectMockComponents
+    private RecordsMacro macro;
+
+    @MockComponent
+    private LiveDataRenderer liveDataRenderer;
+
+    @MockComponent
+    private LiveDataSourceManager liveDataSourceManager;
+
+    @Mock
+    private LiveDataSource liveDataSource;
+
+    @Mock
+    private LiveDataPropertyDescriptorStore propertyStore;
+
+    @MockComponent
+    @Named("compactwiki")
+    private EntityReferenceSerializer<String> entityReferenceSerializer;
+
+    private final Block renderedBlock = new GroupBlock(List.of());
+
+    private MacroTransformationContext context;
+
+    @BeforeEach
+    void beforeEach() throws Exception
+    {
+        this.context = new MacroTransformationContext(new TransformationContext());
+        when(this.entityReferenceSerializer.serialize(DATA_TYPE)).thenReturn(SERIALIZED_DATA_TYPE);
+        when(this.liveDataSourceManager.get(any(Source.class))).thenReturn(Optional.of(this.liveDataSource));
+        when(this.liveDataSource.getProperties()).thenReturn(this.propertyStore);
+        // What the liveTable property store reports: the entry metadata, the data type's fields, and the Live Data
+        // pseudo-columns, all in one list.
+        when(this.propertyStore.get()).thenReturn(List.of(
+            descriptor("doc.title"), descriptor("doc.location"),
+            descriptor("_actions"), descriptor("_avatar"),
+            descriptor("first_name"), descriptor("last_name"), descriptor("email")));
+        when(this.liveDataRenderer.execute(any(LiveDataRendererParameters.class), eq((String) null), anyBoolean()))
+            .thenReturn(this.renderedBlock);
+    }
+
+    @Test
+    void executeReturnsWhatLiveDataRendered() throws Exception
+    {
+        List<Block> blocks = this.macro.execute(newParameters(), null, this.context);
+
+        assertEquals(1, blocks.size());
+        assertSame(this.renderedBlock, blocks.get(0));
+    }
+
+    @Test
+    void executeMapsEveryParameterOntoLiveData() throws Exception
+    {
+        RecordsMacroParameters parameters = newParameters();
+        parameters.setProperties("doc.title,status,budget");
+        parameters.setFilters("status=Active&client=Acme");
+        parameters.setSort("budget:desc");
+        parameters.setLayouts("table,cards");
+        parameters.setLimit(25);
+        parameters.setDescription("Acme projects, most recent first");
+        parameters.setId("projects");
+
+        LiveDataRendererParameters liveDataParameters = execute(parameters);
+
+        assertEquals("liveTable", liveDataParameters.getSource());
+        assertEquals("doc.title,status,budget", liveDataParameters.getProperties());
+        assertEquals("status=Active&client=Acme", liveDataParameters.getFilters());
+        assertEquals("budget:desc", liveDataParameters.getSort());
+        assertEquals("table,cards", liveDataParameters.getLayouts());
+        assertEquals(25, liveDataParameters.getLimit());
+        assertEquals("Acme projects, most recent first", liveDataParameters.getDescription());
+        assertEquals("projects", liveDataParameters.getId());
+    }
+
+    @Test
+    void executePassesTheDataTypeAsASourceParameter() throws Exception
+    {
+        LiveDataRendererParameters liveDataParameters = execute(newParameters());
+
+        assertEquals("className=Clients.Code.ProjectClass&translationPrefix=platform.index.",
+            liveDataParameters.getSourceParameters());
+    }
+
+    @Test
+    void executeUrlEncodesTheSourceParameters() throws Exception
+    {
+        // A class reference is unlikely to hold these, but the receiving end URL-decodes every source parameter, so
+        // a value that is not encoded here would be silently truncated at the first separator.
+        when(this.entityReferenceSerializer.serialize(DATA_TYPE)).thenReturn("Space.A&B=C");
+
+        LiveDataRendererParameters liveDataParameters = execute(newParameters());
+
+        assertEquals("className=Space.A%26B%3DC&translationPrefix=platform.index.",
+            liveDataParameters.getSourceParameters());
+    }
+
+    @Test
+    void executeDisplaysEveryFieldOfTheDataTypeWhenNoColumnIsGiven() throws Exception
+    {
+        // The liveTable source needs an explicit column list: an absent one yields a table with no columns rather
+        // than one with every column, which is the opposite of the parameter's documented default.
+        LiveDataRendererParameters liveDataParameters = execute(newParameters());
+
+        assertEquals("first_name,last_name,email", liveDataParameters.getProperties());
+    }
+
+    @Test
+    void executeLeavesTheEntryMetadataOutOfTheDefaultColumns() throws Exception
+    {
+        // doc.* columns are offered to the author but are not part of "every field of this data type", and the
+        // pseudo-columns are affordances rather than data.
+        String properties = execute(newParameters()).getProperties();
+
+        assertFalse(properties.contains("doc."));
+        assertFalse(properties.contains("_actions"));
+        assertFalse(properties.contains("_avatar"));
+    }
+
+    @Test
+    void executeKeepsTheAuthoredColumnsAndDoesNotQueryTheDataType() throws Exception
+    {
+        RecordsMacroParameters parameters = newParameters();
+        parameters.setProperties("doc.title,email");
+
+        assertEquals("doc.title,email", execute(parameters).getProperties());
+        verify(this.propertyStore, never()).get();
+    }
+
+    @Test
+    void executeReportsADataTypeWhoseFieldsCannotBeRead() throws Exception
+    {
+        when(this.propertyStore.get()).thenThrow(new LiveDataException("no such class"));
+
+        MacroExecutionException exception = assertThrows(MacroExecutionException.class,
+            () -> this.macro.execute(newParameters(), null, this.context));
+
+        assertEquals("Failed to read the fields of [Clients.Code.ProjectClass].", exception.getMessage());
+    }
+
+    @Test
+    void executeReportsAMissingLiveTableSource()
+    {
+        when(this.liveDataSourceManager.get(any(Source.class))).thenReturn(Optional.empty());
+
+        MacroExecutionException exception = assertThrows(MacroExecutionException.class,
+            () -> this.macro.execute(newParameters(), null, this.context));
+
+        assertEquals("The [liveTable] Live Data source is not available.", exception.getMessage());
+    }
+
+    @Test
+    void executeLeavesTheParametersLiveDataDefaultsAlone() throws Exception
+    {
+        // The macro must not invent values for what the author left empty, otherwise a Records table and a liveData
+        // macro with the same parameters would not behave the same way.
+        LiveDataRendererParameters liveDataParameters = execute(newParameters());
+
+        assertNull(liveDataParameters.getFilters());
+        assertNull(liveDataParameters.getSort());
+        assertNull(liveDataParameters.getId());
+        assertNull(liveDataParameters.getDescription());
+        assertNull(liveDataParameters.getOffset());
+    }
+
+    @Test
+    void executeAppliesTheParameterDefaults() throws Exception
+    {
+        LiveDataRendererParameters liveDataParameters = execute(newParameters());
+
+        assertEquals("table", liveDataParameters.getLayouts());
+        assertEquals(15, liveDataParameters.getLimit());
+    }
+
+    @Test
+    void executePassesNoAdvancedConfigurationSoThatTheContentStaysTrusted() throws Exception
+    {
+        this.macro.execute(newParameters(), null, this.context);
+
+        // LiveDataRenderer only treats the content as trusted when the advanced configuration is blank or the author
+        // holds script right. Passing one here would downgrade every table authored without that right.
+        verify(this.liveDataRenderer).execute(any(LiveDataRendererParameters.class), eq((String) null), eq(false));
+    }
+
+    @Test
+    void executePropagatesTheRestrictedFlag() throws Exception
+    {
+        TransformationContext transformationContext = new TransformationContext();
+        transformationContext.setRestricted(true);
+
+        this.macro.execute(newParameters(), null, new MacroTransformationContext(transformationContext));
+
+        verify(this.liveDataRenderer).execute(any(LiveDataRendererParameters.class), eq((String) null), eq(true));
+    }
+
+    @Test
+    void executeRejectsAMissingDataType()
+    {
+        MacroExecutionException exception =
+            assertThrows(MacroExecutionException.class,
+                () -> this.macro.execute(new RecordsMacroParameters(), null, this.context));
+
+        assertEquals("The [class] parameter is mandatory.", exception.getMessage());
+    }
+
+    @Test
+    void executeWrapsALiveDataFailure() throws Exception
+    {
+        LiveDataException cause = new LiveDataException("no such source");
+        when(this.liveDataRenderer.execute(any(LiveDataRendererParameters.class), eq((String) null), anyBoolean()))
+            .thenThrow(cause);
+
+        MacroExecutionException exception = assertThrows(MacroExecutionException.class,
+            () -> this.macro.execute(newParameters(), null, this.context));
+
+        assertEquals("Failed to render the Records macro.", exception.getMessage());
+        assertSame(cause, exception.getCause());
+    }
+
+    @Test
+    void theMacroRendersABlockAndIsolatesItsExecution()
+    {
+        // The table is a block, so it cannot be rendered inline, and it must not leak its Live Data configuration
+        // into the surrounding transformation.
+        assertFalse(this.macro.supportsInlineMode());
+        assertTrue(this.macro.isExecutionIsolated(newParameters(), null));
+    }
+
+    /**
+     * @param id the property identifier
+     * @return a property descriptor carrying just that identifier
+     */
+    private static LiveDataPropertyDescriptor descriptor(String id)
+    {
+        LiveDataPropertyDescriptor descriptor = new LiveDataPropertyDescriptor();
+        descriptor.setId(id);
+        return descriptor;
+    }
+
+    /**
+     * @return parameters holding only the mandatory data type, so that a test states just what it is about
+     */
+    private RecordsMacroParameters newParameters()
+    {
+        RecordsMacroParameters parameters = new RecordsMacroParameters();
+        parameters.setDataType(DATA_TYPE);
+        return parameters;
+    }
+
+    /**
+     * Executes the macro and captures what it handed to the renderer.
+     *
+     * @param parameters the macro parameters
+     * @return the Live Data parameters the macro built
+     */
+    private LiveDataRendererParameters execute(RecordsMacroParameters parameters) throws Exception
+    {
+        this.macro.execute(parameters, null, this.context);
+
+        ArgumentCaptor<LiveDataRendererParameters> captor =
+            ArgumentCaptor.forClass(LiveDataRendererParameters.class);
+        verify(this.liveDataRenderer).execute(captor.capture(), eq((String) null), anyBoolean());
+        return captor.getValue();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/test/java/org/xwiki/records/internal/macro/RecordsMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/test/java/org/xwiki/records/internal/macro/RecordsMacroTest.java
@@ -41,9 +41,11 @@ import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.records.macro.RecordsMacroParameters;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.GroupBlock;
+import org.xwiki.rendering.block.XDOM;
 import org.xwiki.rendering.macro.MacroExecutionException;
 import org.xwiki.rendering.transformation.MacroTransformationContext;
 import org.xwiki.rendering.transformation.TransformationContext;
+import org.xwiki.rendering.util.IdGenerator;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
@@ -57,6 +59,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -105,6 +108,8 @@ class RecordsMacroTest
     void beforeEach() throws Exception
     {
         this.context = new MacroTransformationContext(new TransformationContext());
+        // The document's generator: shared by every id the page builds, headings included.
+        this.context.setXDOM(new XDOM(List.of(), new IdGenerator()));
         when(this.entityReferenceSerializer.serialize(DATA_TYPE)).thenReturn(SERIALIZED_DATA_TYPE);
         when(this.liveDataSourceManager.get(any(Source.class))).thenReturn(Optional.of(this.liveDataSource));
         when(this.liveDataSource.getProperties()).thenReturn(this.propertyStore);
@@ -244,15 +249,80 @@ class RecordsMacroTest
     }
 
     @Test
+    void executeGeneratesAnIdentifierWhenTheAuthorSuppliedNone() throws Exception
+    {
+        // Live Data builds the table description's element id from it, so an absent one is not an option.
+        assertEquals("records", execute(newParameters()).getId());
+    }
+
+    @Test
+    void executeSuffixesTheGeneratedIdentifierOfEveryFurtherTableOnThePage() throws Exception
+    {
+        assertEquals("records", executeOn(this.context, newParameters()).getId());
+        assertEquals("records-1", executeOn(this.context, newParameters()).getId());
+        assertEquals("records-2", executeOn(this.context, newParameters()).getId());
+    }
+
+    @Test
+    void executeKeepsAnAuthoredIdentifierThatIsAlreadyUnique() throws Exception
+    {
+        RecordsMacroParameters parameters = newParameters();
+        parameters.setId("projects");
+
+        assertEquals("projects", execute(parameters).getId());
+    }
+
+    @Test
+    void executeSuffixesAnAuthoredIdentifierAnotherTableAlreadyUses() throws Exception
+    {
+        RecordsMacroParameters first = newParameters();
+        first.setId("projects");
+        RecordsMacroParameters second = newParameters();
+        second.setId("projects");
+
+        assertEquals("projects", executeOn(this.context, first).getId());
+        assertEquals("projects-1", executeOn(this.context, second).getId());
+    }
+
+    @Test
+    void executeIsNotConfusedByAnIdentifierStartingWithADigit() throws Exception
+    {
+        // The generator takes the first character of an id as its prefix and rejects a non-letter, so this would
+        // otherwise fail rather than render.
+        RecordsMacroParameters parameters = newParameters();
+        parameters.setId("2026projects");
+
+        assertEquals("records2026projects", execute(parameters).getId());
+    }
+
+    @Test
+    void executeDoesNotCollideWithAnIdentifierThePageAlreadyUsed() throws Exception
+    {
+        // A heading rendered before the macro takes its id from the same generator.
+        this.context.getXDOM().getIdGenerator().generateUniqueId("records", "");
+
+        assertEquals("records-1", execute(newParameters()).getId());
+    }
+
+    @Test
+    void executeCopesWithNoDocumentToBeUniqueAgainst() throws Exception
+    {
+        // A macro executed outside a document has no XDOM, and must still hand Live Data an id.
+        MacroTransformationContext bare = new MacroTransformationContext(new TransformationContext());
+
+        assertEquals("records", executeOn(bare, newParameters()).getId());
+    }
+
+    @Test
     void executeLeavesTheParametersLiveDataDefaultsAlone() throws Exception
     {
         // The macro must not invent values for what the author left empty, otherwise a Records table and a liveData
-        // macro with the same parameters would not behave the same way.
+        // macro with the same parameters would not behave the same way. The identifier is the exception, and has
+        // its own tests: Live Data needs one whether the author supplied it or not.
         LiveDataRendererParameters liveDataParameters = execute(newParameters());
 
         assertNull(liveDataParameters.getFilters());
         assertNull(liveDataParameters.getSort());
-        assertNull(liveDataParameters.getId());
         assertNull(liveDataParameters.getDescription());
         assertNull(liveDataParameters.getOffset());
     }
@@ -282,7 +352,9 @@ class RecordsMacroTest
         TransformationContext transformationContext = new TransformationContext();
         transformationContext.setRestricted(true);
 
-        this.macro.execute(newParameters(), null, new MacroTransformationContext(transformationContext));
+        MacroTransformationContext restrictedContext = new MacroTransformationContext(transformationContext);
+        restrictedContext.setXDOM(new XDOM(List.of(), new IdGenerator()));
+        this.macro.execute(newParameters(), null, restrictedContext);
 
         verify(this.liveDataRenderer).execute(any(LiveDataRendererParameters.class), eq((String) null), eq(true));
     }
@@ -349,11 +421,27 @@ class RecordsMacroTest
      */
     private LiveDataRendererParameters execute(RecordsMacroParameters parameters) throws Exception
     {
-        this.macro.execute(parameters, null, this.context);
+        return executeOn(this.context, parameters);
+    }
+
+    /**
+     * Executes the macro in a given context and captures what it handed to the renderer.
+     *
+     * Several tests execute the macro more than once in the same context, to exercise what a page holding more than
+     * one table produces, so the captured value is the last one.
+     *
+     * @param context the transformation context to execute in
+     * @param parameters the macro parameters
+     * @return the Live Data parameters the macro built
+     */
+    private LiveDataRendererParameters executeOn(MacroTransformationContext context,
+        RecordsMacroParameters parameters) throws Exception
+    {
+        this.macro.execute(parameters, null, context);
 
         ArgumentCaptor<LiveDataRendererParameters> captor =
             ArgumentCaptor.forClass(LiveDataRendererParameters.class);
-        verify(this.liveDataRenderer).execute(captor.capture(), eq((String) null), anyBoolean());
+        verify(this.liveDataRenderer, atLeastOnce()).execute(captor.capture(), eq((String) null), anyBoolean());
         return captor.getValue();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/test/java/org/xwiki/records/internal/macro/RecordsMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/test/java/org/xwiki/records/internal/macro/RecordsMacroTest.java
@@ -174,25 +174,41 @@ class RecordsMacroTest
     }
 
     @Test
-    void executeDisplaysEveryFieldOfTheDataTypeWhenNoColumnIsGiven() throws Exception
+    void executeDisplaysTheTitleAndEveryFieldWhenNoColumnIsGiven() throws Exception
     {
         // The liveTable source needs an explicit column list: an absent one yields a table with no columns rather
         // than one with every column, which is the opposite of the parameter's documented default.
         LiveDataRendererParameters liveDataParameters = execute(newParameters());
 
-        assertEquals("first_name,last_name,email", liveDataParameters.getProperties());
+        assertEquals("doc.title,first_name,last_name,email", liveDataParameters.getProperties());
     }
 
     @Test
-    void executeLeavesTheEntryMetadataOutOfTheDefaultColumns() throws Exception
+    void executeOpensTheDefaultColumnsWithTheEntryTitle() throws Exception
     {
-        // doc.* columns are offered to the author but are not part of "every field of this data type", and the
+        // Without it a reader cannot tell one entry from another, nor reach the page an entry lives in.
+        assertTrue(execute(newParameters()).getProperties().startsWith("doc.title,"));
+    }
+
+    @Test
+    void executeLeavesTheOtherMetadataAndThePseudoColumnsOutOfTheDefault() throws Exception
+    {
+        // The title is the only piece of entry metadata the default wants; the rest is the author's to add. The
         // pseudo-columns are affordances rather than data.
         String properties = execute(newParameters()).getProperties();
 
-        assertFalse(properties.contains("doc."));
+        assertFalse(properties.contains("doc.location"));
         assertFalse(properties.contains("_actions"));
         assertFalse(properties.contains("_avatar"));
+    }
+
+    @Test
+    void executeStillIdentifiesTheEntriesOfADataTypeWithoutFields() throws Exception
+    {
+        // A data type with no field of its own still gets a table a reader can use, rather than no columns at all.
+        when(this.propertyStore.get()).thenReturn(List.of(descriptor("doc.title"), descriptor("_actions")));
+
+        assertEquals("doc.title", execute(newParameters()).getProperties());
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/test/java/org/xwiki/records/internal/macro/RecordsMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-macro/src/test/java/org/xwiki/records/internal/macro/RecordsMacroTest.java
@@ -139,8 +139,7 @@ class RecordsMacroTest
         parameters.setProperties("doc.title,status,budget");
         parameters.setFilters("status=Active&client=Acme");
         parameters.setSort("budget:desc");
-        parameters.setLayouts("table,cards");
-        parameters.setLimit(25);
+        parameters.setLayouts("cards");
         parameters.setDescription("Acme projects, most recent first");
         parameters.setId("projects");
 
@@ -150,8 +149,7 @@ class RecordsMacroTest
         assertEquals("doc.title,status,budget", liveDataParameters.getProperties());
         assertEquals("status=Active&client=Acme", liveDataParameters.getFilters());
         assertEquals("budget:desc", liveDataParameters.getSort());
-        assertEquals("table,cards", liveDataParameters.getLayouts());
-        assertEquals(25, liveDataParameters.getLimit());
+        assertEquals("cards", liveDataParameters.getLayouts());
         assertEquals("Acme projects, most recent first", liveDataParameters.getDescription());
         assertEquals("projects", liveDataParameters.getId());
     }
@@ -325,6 +323,8 @@ class RecordsMacroTest
         assertNull(liveDataParameters.getSort());
         assertNull(liveDataParameters.getDescription());
         assertNull(liveDataParameters.getOffset());
+        // The page size is deliberately not a macro parameter, so it stays Live Data's own default.
+        assertNull(liveDataParameters.getLimit());
     }
 
     @Test
@@ -333,7 +333,6 @@ class RecordsMacroTest
         LiveDataRendererParameters liveDataParameters = execute(newParameters());
 
         assertEquals("table", liveDataParameters.getLayouts());
-        assertEquals(15, liveDataParameters.getLimit());
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.platform</groupId>
+    <artifactId>xwiki-platform-records</artifactId>
+    <version>18.8.0-SNAPSHOT</version>
+  </parent>
+  <packaging>webjar-node</packaging>
+  <artifactId>xwiki-platform-records-webjar</artifactId>
+  <name>XWiki Platform - Records - WebJar</name>
+  <description>The field picker used by the Records macro parameter dialog.</description>
+  <properties>
+    <!-- Name to display by the Extension Manager -->
+    <xwiki.extension.name>Records WebJar</xwiki.extension.name>
+    <!-- Category for the Extension Manager -->
+    <xwiki.extension.category>webjar</xwiki.extension.category>
+  </properties>
+  <dependencies>
+    <!-- Requires xwiki-platform-node to be built first to get access to the bundled javascript packages. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-node</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.webjars</groupId>
+      <artifactId>requirejs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.webjars</groupId>
+      <artifactId>jquery</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/eslint.config.ts
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/eslint.config.ts
@@ -1,0 +1,23 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import config from "@xwiki/platform-tool-eslintconfig";
+
+export default config;

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/package.json
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/package.json
@@ -1,0 +1,31 @@
+{
+  "private": true,
+  "name": "xwiki-platform-records-webjar",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "run-p type-check \"build-only {@}\" --",
+    "build-only": "vite build",
+    "dev": "vite",
+    "format": "prettier --write src/",
+    "lint": "eslint .",
+    "test:unit": "vitest --run --passWithNoTests",
+    "type-check": "tsc --build"
+  },
+  "devDependencies": {
+    "@types/jquery": "catalog:",
+    "@types/jsdom": "catalog:",
+    "@types/node": "catalog:",
+    "@types/requirejs": "catalog:",
+    "@xwiki/platform-tool-eslintconfig": "workspace:*",
+    "@xwiki/platform-tool-tsconfig": "workspace:*",
+    "@xwiki/platform-tool-viteconfig": "workspace:*",
+    "eslint": "catalog:",
+    "jsdom": "catalog:",
+    "npm-run-all": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/__tests__/dialog.test.ts
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/__tests__/dialog.test.ts
@@ -1,0 +1,175 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import {
+  DERIVED_PARAMETERS,
+  findDataTypeInput,
+  findScope,
+  hasValue,
+  resetDerivedParameters,
+  setTabsVisible,
+} from "../dialog";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Builds the shape the macro editor produces: the mandatory field, then the tab strip and its panes holding the
+ * parameters derived from it.
+ *
+ * @param dataType - the value of the data type input
+ * @param derived - the values of the derived parameters
+ * @returns the dialog's form
+ */
+function givenDialog(
+  dataType: string,
+  derived: Partial<Record<string, string>> = {},
+): HTMLFormElement {
+  document.body.innerHTML = `
+    <form>
+      <div class="macro-parameter-field">
+        <select name="class"><option value="">none</option>
+          <option value="${dataType}" selected>${dataType}</option></select>
+      </div>
+      <ul class="nav nav-tabs macro-tabs"><li>Columns</li></ul>
+      <div class="tab-content">
+        <input name="properties" value="${derived.properties ?? ""}" />
+        <input name="filters" value="${derived.filters ?? ""}" />
+        <input name="sort" value="${derived.sort ?? ""}" />
+      </div>
+    </form>`;
+  return document.querySelector("form")!;
+}
+
+describe("findScope", () => {
+  it("scopes lookups to the enclosing form, so two dialogs cannot read each other", () => {
+    document.body.innerHTML = `
+      <form id="a"><input name="class" value="A.Class" /><span class="p"></span></form>
+      <form id="b"><input name="class" value="B.Class" /></form>`;
+    const marker = document.querySelector("#a .p")!;
+    const scope = findScope(marker);
+    expect(findDataTypeInput(scope)!.value).toBe("A.Class");
+  });
+
+  it("falls back to the document when the field is not in a form", () => {
+    document.body.innerHTML = `<input name="class" value="Loose" /><span class="p"></span>`;
+    const scope = findScope(document.querySelector(".p")!);
+    expect(findDataTypeInput(scope)!.value).toBe("Loose");
+  });
+});
+
+describe("findDataTypeInput", () => {
+  it("returns null when the dialog has no data type field", () => {
+    document.body.innerHTML = `<form><input name="properties" /></form>`;
+    expect(findDataTypeInput(document.querySelector("form")!)).toBeNull();
+  });
+});
+
+describe("setTabsVisible", () => {
+  it("hides the tab strip and its panes together", () => {
+    const form = givenDialog("Some.Class");
+    setTabsVisible(form, false);
+    expect(form.querySelector<HTMLElement>(".macro-tabs")!.hidden).toBe(true);
+    expect(form.querySelector<HTMLElement>(".tab-content")!.hidden).toBe(true);
+  });
+
+  it("shows them again", () => {
+    const form = givenDialog("Some.Class");
+    setTabsVisible(form, false);
+    setTabsVisible(form, true);
+    expect(form.querySelector<HTMLElement>(".macro-tabs")!.hidden).toBe(false);
+    expect(form.querySelector<HTMLElement>(".tab-content")!.hidden).toBe(false);
+  });
+
+  it("does not touch another dialog's tabs", () => {
+    document.body.innerHTML = `
+      <form id="a"><ul class="macro-tabs"></ul></form>
+      <form id="b"><ul class="macro-tabs"></ul></form>`;
+    setTabsVisible(document.querySelector("#a")!, false);
+    expect(document.querySelector<HTMLElement>("#a .macro-tabs")!.hidden).toBe(
+      true,
+    );
+    expect(document.querySelector<HTMLElement>("#b .macro-tabs")!.hidden).toBe(
+      false,
+    );
+  });
+});
+
+describe("resetDerivedParameters", () => {
+  it("clears every parameter derived from the data type", () => {
+    const form = givenDialog("Some.Class", {
+      properties: "doc.title,status",
+      filters: "status=Active",
+      sort: "doc.title:asc",
+    });
+    resetDerivedParameters(form);
+    DERIVED_PARAMETERS.forEach((name) => {
+      expect(
+        form.querySelector<HTMLInputElement>(`[name="${name}"]`)!.value,
+      ).toBe("");
+    });
+  });
+
+  it("reports which parameters actually held a value", () => {
+    const form = givenDialog("Some.Class", {
+      properties: "doc.title",
+      sort: "doc.title:asc",
+    });
+    expect(resetDerivedParameters(form).sort()).toEqual(["properties", "sort"]);
+  });
+
+  it("reports nothing when there was nothing to lose", () => {
+    expect(resetDerivedParameters(givenDialog("Some.Class"))).toEqual([]);
+  });
+
+  it("leaves the data type itself alone", () => {
+    const form = givenDialog("Some.Class", { properties: "doc.title" });
+    resetDerivedParameters(form);
+    expect(findDataTypeInput(form)!.value).toBe("Some.Class");
+  });
+
+  it("clears an enhanced widget through its own API rather than the element", () => {
+    const form = givenDialog("Some.Class");
+    const element = form.querySelector('[name="properties"]')!;
+    const calls: string[] = [];
+    Object.assign(element, {
+      selectize: {
+        clear: () => calls.push("clear"),
+        clearOptions: () => calls.push("clearOptions"),
+      },
+    });
+    resetDerivedParameters(form);
+    // Both matter: clear drops the selection, clearOptions drops the previous type's candidates.
+    expect(calls).toEqual(["clear", "clearOptions"]);
+  });
+});
+
+describe("hasValue", () => {
+  it("ignores a placeholder option, which is not a value", () => {
+    document.body.innerHTML = `<select name="properties"><option value="" selected>Every field</option></select>`;
+    expect(hasValue(document.querySelector("select")!)).toBe(false);
+  });
+
+  it("sees a real selection", () => {
+    document.body.innerHTML = `
+      <select name="properties" multiple>
+        <option value="" >Every field</option><option value="doc.title" selected>Title</option>
+      </select>`;
+    expect(hasValue(document.querySelector("select")!)).toBe(true);
+  });
+});

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/__tests__/fieldPicker.test.ts
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/__tests__/fieldPicker.test.ts
@@ -1,0 +1,267 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import {
+  FIELDS_GROUP,
+  METADATA_GROUP,
+  asDescriptors,
+  findDataType,
+  loadOptions,
+  propertiesUrl,
+  toOptions,
+} from "../fieldPicker";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { JsonFetcher, PropertyDescriptor } from "../fieldPicker";
+import type { Mock } from "vitest";
+
+/**
+ * Builds a macro dialog holding a data type input and a field picker, as the macro editor renders it.
+ *
+ * @param dataType - the value of the data type input
+ * @returns the field picker element
+ */
+function givenDialog(dataType: string): Element {
+  document.body.innerHTML = `
+    <form>
+      <input name="class" value="${dataType}" />
+      <select name="properties" class="suggest-records-fields" multiple></select>
+    </form>`;
+  return document.querySelector(".suggest-records-fields")!;
+}
+
+const DESCRIPTORS: PropertyDescriptor[] = [
+  { id: "doc.title", name: "Title", type: "String" },
+  { id: "status", name: "Status", type: "StaticList" },
+  { id: "budget", name: "Budget", type: "Number" },
+];
+
+describe("findDataType", () => {
+  it("reads the value of the sibling class parameter", () => {
+    expect(findDataType(givenDialog("Clients.Code.ProjectClass"))).toBe(
+      "Clients.Code.ProjectClass",
+    );
+  });
+
+  it("returns null when no data type is picked yet", () => {
+    expect(findDataType(givenDialog(""))).toBeNull();
+  });
+
+  it("returns null when the class input holds only whitespace", () => {
+    expect(findDataType(givenDialog("   "))).toBeNull();
+  });
+
+  it("does not read the class input of another dialog", () => {
+    document.body.innerHTML = `
+      <form id="other"><input name="class" value="Other.Class" /></form>
+      <form id="mine">
+        <input name="class" value="Mine.Class" />
+        <select class="suggest-records-fields"></select>
+      </form>`;
+    const picker = document.querySelector("#mine .suggest-records-fields")!;
+    expect(findDataType(picker)).toBe("Mine.Class");
+  });
+
+  it("falls back to the document when the picker is not inside a form", () => {
+    document.body.innerHTML = `
+      <input name="class" value="Loose.Class" />
+      <select class="suggest-records-fields"></select>`;
+    const picker = document.querySelector(".suggest-records-fields")!;
+    expect(findDataType(picker)).toBe("Loose.Class");
+  });
+});
+
+describe("propertiesUrl", () => {
+  it("asks the Live Data properties resource for the given data type", () => {
+    expect(propertiesUrl("/xwiki", "Clients.Code.ProjectClass")).toBe(
+      "/xwiki/rest/liveData/sources/liveTable/properties" +
+        "?sourceParams.className=Clients.Code.ProjectClass&media=json",
+    );
+  });
+
+  it("encodes a reference holding characters that are special in a query string", () => {
+    const url = propertiesUrl("/xwiki", "Space.A&B=C");
+    expect(url).toContain("sourceParams.className=Space.A%26B%3DC");
+    expect(url).toContain("media=json");
+  });
+});
+
+describe("toOptions", () => {
+  it("separates the entry metadata from the data type's own fields", () => {
+    const options = toOptions(DESCRIPTORS);
+    expect(options).toEqual([
+      {
+        value: "doc.title",
+        label: "Title",
+        hint: "String",
+        optgroup: METADATA_GROUP,
+      },
+      {
+        value: "status",
+        label: "Status",
+        hint: "StaticList",
+        optgroup: FIELDS_GROUP,
+      },
+      {
+        value: "budget",
+        label: "Budget",
+        hint: "Number",
+        optgroup: FIELDS_GROUP,
+      },
+    ]);
+  });
+
+  it("falls back to the identifier when a property has no translated name", () => {
+    const options = toOptions([{ id: "internalField" }]);
+    expect(options[0]).toMatchObject({
+      value: "internalField",
+      label: "internalField",
+      optgroup: FIELDS_GROUP,
+    });
+    expect(options[0].hint).toBeUndefined();
+  });
+
+  it("matches the query against the label", () => {
+    expect(toOptions(DESCRIPTORS, "stat").map((o) => o.value)).toEqual([
+      "status",
+    ]);
+  });
+
+  it("matches the query against the identifier, so doc.title is reachable by typing doc", () => {
+    expect(toOptions(DESCRIPTORS, "doc").map((o) => o.value)).toEqual([
+      "doc.title",
+    ]);
+  });
+
+  it("ignores the case and the surrounding spaces of the query", () => {
+    expect(toOptions(DESCRIPTORS, "  BUDGET ").map((o) => o.value)).toEqual([
+      "budget",
+    ]);
+  });
+
+  it("offers everything when the query is empty", () => {
+    expect(toOptions(DESCRIPTORS, "")).toHaveLength(3);
+  });
+
+  it("hides the Live Data pseudo-columns", () => {
+    // The resource reports these next to the real fields; they are affordances, not data.
+    const descriptors = [
+      { id: "_actions" },
+      { id: "_avatar" },
+      { id: "_images" },
+      { id: "_attachments" },
+      { id: "first_name", name: "First Name" },
+    ] as PropertyDescriptor[];
+    expect(toOptions(descriptors).map((o) => o.value)).toEqual(["first_name"]);
+  });
+
+  it("falls back to the identifier when the resource sends a null name", () => {
+    // doc.* descriptors really do come back with name: null.
+    const descriptors = [
+      { id: "doc.title", name: null, type: "String" },
+    ] as unknown as PropertyDescriptor[];
+    expect(toOptions(descriptors)[0]).toMatchObject({
+      value: "doc.title",
+      label: "doc.title",
+      optgroup: METADATA_GROUP,
+    });
+  });
+
+  it("skips descriptors without a usable identifier", () => {
+    const descriptors = [{ id: "" }, { id: "kept" }] as PropertyDescriptor[];
+    expect(toOptions(descriptors).map((o) => o.value)).toEqual(["kept"]);
+  });
+});
+
+describe("asDescriptors", () => {
+  it("reads the descriptors out of the resource's envelope", () => {
+    // The shape the properties resource actually answers with.
+    const payload = {
+      links: [{ href: "..." }, { href: "..." }],
+      properties: [{ id: "doc.title" }, { id: "first_name" }],
+    };
+    expect(asDescriptors(payload).map((d) => d.id)).toEqual([
+      "doc.title",
+      "first_name",
+    ]);
+  });
+
+  it("accepts a bare array too", () => {
+    expect(asDescriptors([{ id: "a" }, { id: "b" }])).toHaveLength(2);
+  });
+
+  it("drops entries that are not property descriptors", () => {
+    expect(
+      asDescriptors([{ id: "a" }, null, 42, "b", { name: "no id" }]),
+    ).toEqual([{ id: "a" }]);
+  });
+
+  it("yields nothing when the payload holds no properties", () => {
+    expect(asDescriptors({ links: [] })).toEqual([]);
+    expect(asDescriptors({ properties: "not an array" })).toEqual([]);
+    expect(asDescriptors(null)).toEqual([]);
+    expect(asDescriptors(undefined)).toEqual([]);
+  });
+});
+
+describe("loadOptions", () => {
+  let fetchJson: Mock<JsonFetcher>;
+
+  beforeEach(() => {
+    fetchJson = vi.fn<JsonFetcher>();
+    // Answer in the shape the resource really uses.
+    fetchJson.mockResolvedValue({ links: [], properties: DESCRIPTORS });
+  });
+
+  it("loads the columns of the selected data type", async () => {
+    const picker = givenDialog("Clients.Code.ProjectClass");
+    const options = await loadOptions(picker, "", "/xwiki", fetchJson);
+
+    expect(fetchJson).toHaveBeenCalledWith(
+      propertiesUrl("/xwiki", "Clients.Code.ProjectClass"),
+    );
+    expect(options.map((option) => option.value)).toEqual([
+      "doc.title",
+      "status",
+      "budget",
+    ]);
+  });
+
+  it("offers nothing, without requesting anything, while no data type is picked", async () => {
+    const options = await loadOptions(givenDialog(""), "", "/xwiki", fetchJson);
+
+    expect(options).toEqual([]);
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it("applies the query to what it loaded", async () => {
+    const picker = givenDialog("Clients.Code.ProjectClass");
+    const options = await loadOptions(picker, "budget", "/xwiki", fetchJson);
+    expect(options.map((option) => option.value)).toEqual(["budget"]);
+  });
+
+  it("propagates a failure of the properties resource to its caller", async () => {
+    const picker = givenDialog("Clients.Code.ProjectClass");
+    fetchJson.mockRejectedValue(new Error("HTTP 500"));
+
+    await expect(loadOptions(picker, "", "/xwiki", fetchJson)).rejects.toThrow(
+      "HTTP 500",
+    );
+  });
+});

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/__tests__/filterPicker.test.ts
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/__tests__/filterPicker.test.ts
@@ -1,0 +1,214 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import { FIELDS_GROUP, METADATA_GROUP } from "../fieldPicker";
+import {
+  asValues,
+  encodeConstraint,
+  isIncomplete,
+  resolveFilterOption,
+  splitConstraint,
+  toFieldOptions,
+  toValueOptions,
+  valuesUrl,
+} from "../filterPicker";
+import { describe, expect, it } from "vitest";
+import type { PropertyDescriptor } from "../fieldPicker";
+
+const STATUS: PropertyDescriptor = {
+  id: "status",
+  name: "Status",
+  type: "StaticList",
+  filter: { searchURL: "/xwiki/rest/.../status/values?fp={encodedQuery}" },
+};
+
+const DESCRIPTORS: PropertyDescriptor[] = [
+  STATUS,
+  { id: "doc.title", name: "Title", type: "String" },
+  { id: "_actions", name: "Actions" },
+];
+
+describe("splitConstraint", () => {
+  it("splits a constraint on its first separator", () => {
+    expect(splitConstraint("status=Active")).toEqual({
+      field: "status",
+      value: "Active",
+    });
+  });
+
+  it("returns null while no value separator has been typed", () => {
+    expect(splitConstraint("stat")).toBeNull();
+  });
+
+  it("decodes the value", () => {
+    expect(splitConstraint("client=Acme%20%26%20Co")).toEqual({
+      field: "client",
+      value: "Acme & Co",
+    });
+  });
+
+  it("keeps a value that is not valid percent-encoding", () => {
+    // decodeURIComponent throws on a bare %, and a keystroke handler must not.
+    expect(splitConstraint("discount=100%")).toEqual({
+      field: "discount",
+      value: "100%",
+    });
+  });
+
+  it("reads an empty value as empty rather than as no constraint", () => {
+    expect(splitConstraint("status=")).toEqual({ field: "status", value: "" });
+  });
+});
+
+describe("encodeConstraint", () => {
+  it("encodes what the parameter's own separators would otherwise swallow", () => {
+    // The renderer splits on & and on the first =, then URL-decodes, so an unencoded value holding either would
+    // be read as a second constraint.
+    expect(encodeConstraint("client", "Acme & Co")).toBe(
+      "client=Acme%20%26%20Co",
+    );
+    expect(encodeConstraint("formula", "a=b")).toBe("formula=a%3Db");
+  });
+});
+
+describe("toFieldOptions", () => {
+  it("offers the fields as constraints waiting for a value", () => {
+    expect(toFieldOptions(DESCRIPTORS, "status")).toEqual([
+      {
+        value: "status=",
+        label: "Status =",
+        hint: "StaticList",
+        optgroup: FIELDS_GROUP,
+      },
+    ]);
+  });
+
+  it("groups the entry metadata apart", () => {
+    expect(toFieldOptions(DESCRIPTORS, "title")[0].optgroup).toBe(
+      METADATA_GROUP,
+    );
+  });
+
+  it("leaves out the Live Data pseudo-columns", () => {
+    expect(
+      toFieldOptions(DESCRIPTORS).some((option) =>
+        option.value.startsWith("_actions"),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isIncomplete", () => {
+  it("tells a field waiting for its value from a usable constraint", () => {
+    expect(isIncomplete("status=")).toBe(true);
+    expect(isIncomplete("status=Active")).toBe(false);
+  });
+});
+
+describe("valuesUrl", () => {
+  it("puts the typed text where the placeholder is, encoded", () => {
+    expect(
+      valuesUrl(
+        "/xwiki/rest/values?fp={encodedQuery}",
+        "on hold",
+        "http://wiki/xwiki/bin/view/Space/Page",
+      ),
+    ).toBe("http://wiki/xwiki/rest/values?fp=on%20hold");
+  });
+
+  it("resolves a search URL that is only a query string", () => {
+    // The user and group suggester is reported as '?xpage=uorgsuggest&...', relative to the current page.
+    expect(
+      valuesUrl(
+        "?xpage=uorgsuggest&input={encodedQuery}",
+        "ad",
+        "http://wiki/xwiki/bin/view/Space/Page",
+      ),
+    ).toBe("http://wiki/xwiki/bin/view/Space/Page?xpage=uorgsuggest&input=ad");
+  });
+});
+
+describe("asValues", () => {
+  it("reads the class property values resource", () => {
+    expect(
+      asValues({ propertyValues: [{ value: "Text" }, { value: "Wysiwyg" }] }),
+    ).toEqual(["Text", "Wysiwyg"]);
+  });
+
+  it("reads a bare array, as the user suggester answers", () => {
+    expect(asValues([{ id: "XWiki.Admin" }, "XWiki.Guest"])).toEqual([
+      "XWiki.Admin",
+      "XWiki.Guest",
+    ]);
+  });
+
+  it("yields nothing for a shape it does not know", () => {
+    expect(asValues({ unexpected: true })).toEqual([]);
+    expect(asValues(null)).toEqual([]);
+  });
+});
+
+describe("toValueOptions", () => {
+  it("builds one encoded constraint per value", () => {
+    expect(toValueOptions(["Active", "On hold"], STATUS)).toEqual([
+      {
+        value: "status=Active",
+        label: "Status = Active",
+        hint: "StaticList",
+        optgroup: FIELDS_GROUP,
+      },
+      {
+        value: "status=On%20hold",
+        label: "Status = On hold",
+        hint: "StaticList",
+        optgroup: FIELDS_GROUP,
+      },
+    ]);
+  });
+
+  it("narrows the values to what was typed after the separator", () => {
+    expect(
+      toValueOptions(["Active", "On hold"], STATUS, "hold").map((o) => o.value),
+    ).toEqual(["status=On%20hold"]);
+  });
+});
+
+describe("resolveFilterOption", () => {
+  it("shows a stored constraint with its field name and decoded value", () => {
+    expect(resolveFilterOption(DESCRIPTORS, "status=On%20hold")).toEqual({
+      value: "status=On%20hold",
+      label: "Status = On hold",
+      hint: "StaticList",
+      optgroup: FIELDS_GROUP,
+    });
+  });
+
+  it("keeps a constraint naming a field the data type no longer has", () => {
+    expect(resolveFilterOption(DESCRIPTORS, "gone=1")).toEqual(
+      expect.objectContaining({ value: "gone=1", label: "gone=1" }),
+    );
+  });
+
+  it("keeps something that is not a constraint at all", () => {
+    expect(resolveFilterOption(DESCRIPTORS, "nonsense")).toEqual(
+      expect.objectContaining({ value: "nonsense", label: "nonsense" }),
+    );
+  });
+});

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/__tests__/sortPicker.test.ts
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/__tests__/sortPicker.test.ts
@@ -70,6 +70,20 @@ describe("toSortOptions", () => {
   it("offers nothing when the data type has no field", () => {
     expect(toSortOptions([])).toEqual([]);
   });
+
+  it("stops offering a field that is already sorted on", () => {
+    // Both directions go, not just the one picked: sorting a field twice says nothing the first criterion did not
+    // already say.
+    expect(
+      toSortOptions(DESCRIPTORS, "", ["budget:asc"]).map((o) => o.value),
+    ).toEqual(["doc.title:asc", "doc.title:desc"]);
+  });
+
+  it("recognises a used field whose criterion names no direction", () => {
+    expect(
+      toSortOptions(DESCRIPTORS, "", ["budget"]).map((o) => o.value),
+    ).toEqual(["doc.title:asc", "doc.title:desc"]);
+  });
 });
 
 describe("resolveSortOption", () => {

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/__tests__/sortPicker.test.ts
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/__tests__/sortPicker.test.ts
@@ -1,0 +1,110 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import { FIELDS_GROUP, METADATA_GROUP } from "../fieldPicker";
+import { resolveSortOption, toSortOptions } from "../sortPicker";
+import { describe, expect, it } from "vitest";
+import type { PropertyDescriptor } from "../fieldPicker";
+
+const DESCRIPTORS: PropertyDescriptor[] = [
+  { id: "doc.title", name: "Title", type: "String" },
+  { id: "budget", name: "Budget", type: "Number" },
+  { id: "_actions", name: "Actions" },
+];
+
+describe("toSortOptions", () => {
+  it("offers each field ascending and descending", () => {
+    expect(toSortOptions(DESCRIPTORS, "budget")).toEqual([
+      {
+        value: "budget:asc",
+        label: "Budget (ascending)",
+        hint: "Number",
+        optgroup: FIELDS_GROUP,
+      },
+      {
+        value: "budget:desc",
+        label: "Budget (descending)",
+        hint: "Number",
+        optgroup: FIELDS_GROUP,
+      },
+    ]);
+  });
+
+  it("groups the entry metadata apart from the fields", () => {
+    expect(
+      toSortOptions(DESCRIPTORS, "title").map((option) => option.optgroup),
+    ).toEqual([METADATA_GROUP, METADATA_GROUP]);
+  });
+
+  it("leaves out the Live Data pseudo-columns", () => {
+    expect(
+      toSortOptions(DESCRIPTORS).some((option) =>
+        option.value.startsWith("_actions"),
+      ),
+    ).toBe(false);
+  });
+
+  it("matches on the stored value as well as on the label", () => {
+    expect(toSortOptions(DESCRIPTORS, "budget:desc")).toEqual([
+      expect.objectContaining({ value: "budget:desc" }),
+    ]);
+  });
+
+  it("offers nothing when the data type has no field", () => {
+    expect(toSortOptions([])).toEqual([]);
+  });
+});
+
+describe("resolveSortOption", () => {
+  it("shows a stored criterion with its field name and direction", () => {
+    expect(resolveSortOption(DESCRIPTORS, "budget:desc")).toEqual({
+      value: "budget:desc",
+      label: "Budget (descending)",
+      hint: "Number",
+      optgroup: FIELDS_GROUP,
+    });
+  });
+
+  it("keeps a criterion that names no direction, and says so", () => {
+    expect(resolveSortOption(DESCRIPTORS, "budget")).toEqual(
+      expect.objectContaining({
+        value: "budget",
+        label: "Budget (default order)",
+      }),
+    );
+  });
+
+  it("keeps a criterion naming a field the data type no longer has", () => {
+    // The suggester refuses free text, so an option whose value is not exactly the stored one would drop what the
+    // author wrote the next time the dialog opens.
+    expect(resolveSortOption(DESCRIPTORS, "gone:asc")).toEqual(
+      expect.objectContaining({ value: "gone:asc", label: "gone:asc" }),
+    );
+  });
+
+  it("keeps a criterion whose direction is not one Live Data defines", () => {
+    expect(resolveSortOption(DESCRIPTORS, "budget:sideways")).toEqual(
+      expect.objectContaining({
+        value: "budget:sideways",
+        label: "Budget (default order)",
+      }),
+    );
+  });
+});

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/dialog.ts
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/dialog.ts
@@ -1,0 +1,164 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+/**
+ * The parts of the Records macro dialog that react to the data type.
+ *
+ * Everything here is plain DOM work kept apart from the RequireJS and jQuery wiring in the entry point, so that it
+ * can be tested. The dialog's shape is not ours: {@link https://github.com/xwiki/xwiki-platform} builds it from the
+ * macro descriptor, and the two things this module needs from it are stable — the tab strip and its panes are
+ * `.macro-tabs` and `.tab-content` siblings of the mandatory fields, and every parameter field is an input named
+ * after its parameter.
+ */
+
+import { DATA_TYPE_PARAMETER } from "./fieldPicker";
+
+/**
+ * The parameters whose value is derived from the data type.
+ *
+ * Their candidates are that data type's fields, so none of them survives a change of data type: a column, a filter
+ * or a sort naming a field the new type does not have would render a table the author cannot explain.
+ */
+const DERIVED_PARAMETERS: readonly string[] = ["properties", "filters", "sort"];
+
+/**
+ * A Tom Select instance, as the suggest widget exposes it on the enhanced element.
+ */
+interface Enhanced {
+  selectize?: {
+    clear: (silent?: boolean) => void;
+    clearOptions: () => void;
+  };
+}
+
+/**
+ * Returns the form the dialog's fields live in, which scopes every lookup to one dialog.
+ *
+ * @param element - any element inside the dialog
+ * @returns the enclosing form, or the document when the field is not in one
+ */
+function findScope(element: Element): ParentNode {
+  return element.closest("form") ?? element.ownerDocument;
+}
+
+/**
+ * Returns the data type input of a dialog.
+ *
+ * @param scope - the dialog's form
+ * @returns the input, or null when the dialog has none
+ */
+function findDataTypeInput(
+  scope: ParentNode,
+): HTMLInputElement | HTMLSelectElement | null {
+  const field = scope.querySelector(`[name="${DATA_TYPE_PARAMETER}"]`);
+  return field instanceof HTMLInputElement || field instanceof HTMLSelectElement
+    ? field
+    : null;
+}
+
+/**
+ * Shows or hides the tab strip and its panes.
+ *
+ * Hiding rather than disabling is deliberate: the macro editor has no disabled state for a group, so the choice is
+ * between a tab that is reachable but has nothing to offer and no tab at all. Until a data type is picked, every
+ * tab is derived from it, so there is nothing to show.
+ *
+ * @param scope - the dialog's form
+ * @param visible - whether the tabs should be shown
+ */
+function setTabsVisible(scope: ParentNode, visible: boolean): void {
+  scope.querySelectorAll(".macro-tabs, .tab-content").forEach((element) => {
+    if (element instanceof HTMLElement) {
+      element.hidden = !visible;
+    }
+  });
+}
+
+/**
+ * Clears the parameters derived from the data type, back to their defaults.
+ *
+ * The default of all three is empty: every field, no filter, no sort. An enhanced widget is cleared through its own
+ * API rather than by resetting the underlying element, so that what the author sees matches what will be saved.
+ *
+ * @param scope - the dialog's form
+ * @returns the names of the parameters that actually held a value
+ */
+function resetDerivedParameters(scope: ParentNode): string[] {
+  const reset: string[] = [];
+  DERIVED_PARAMETERS.forEach((name) => {
+    scope.querySelectorAll(`[name="${name}"]`).forEach((element) => {
+      if (resetField(element)) {
+        reset.push(name);
+      }
+    });
+  });
+  return [...new Set(reset)];
+}
+
+/**
+ * Clears one parameter field.
+ *
+ * @param element - the field to clear
+ * @returns whether it held a value before being cleared
+ */
+function resetField(element: Element): boolean {
+  const held = hasValue(element);
+  const enhanced = (element as unknown as Enhanced).selectize;
+  if (enhanced) {
+    enhanced.clear(true);
+    enhanced.clearOptions();
+  } else if (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement
+  ) {
+    element.value = "";
+  } else if (element instanceof HTMLSelectElement) {
+    element.selectedIndex = -1;
+  }
+  return held;
+}
+
+/**
+ * @param element - a parameter field
+ * @returns whether the field holds anything
+ */
+function hasValue(element: Element): boolean {
+  if (element instanceof HTMLSelectElement) {
+    return Array.from(element.selectedOptions).some(
+      (option) => option.value !== "",
+    );
+  }
+  if (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement
+  ) {
+    return element.value !== "";
+  }
+  return false;
+}
+
+export {
+  DERIVED_PARAMETERS,
+  findDataTypeInput,
+  findScope,
+  hasValue,
+  resetDerivedParameters,
+  setTabsVisible,
+};

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/fieldPicker.ts
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/fieldPicker.ts
@@ -56,6 +56,16 @@ interface PropertyDescriptor {
    * way.
    */
   type?: string;
+  /**
+   * How the property is filtered, when the source says so.
+   */
+  filter?: {
+    /**
+     * The URL suggesting the property's values, with an `{encodedQuery}` placeholder. Reported for the properties
+     * whose values are enumerable, and used by the filter picker exactly as the Live Data filter row uses it.
+     */
+    searchURL?: string;
+  };
 }
 
 /**

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/fieldPicker.ts
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/fieldPicker.ts
@@ -163,28 +163,15 @@ function toOptions(
   descriptors: PropertyDescriptor[],
   query = "",
 ): FieldOption[] {
-  const normalizedQuery = query.trim().toLowerCase();
   return descriptors
-    .filter(
-      (descriptor) =>
-        typeof descriptor?.id === "string" &&
-        descriptor.id !== "" &&
-        !descriptor.id.startsWith(INTERNAL_PREFIX),
-    )
+    .filter(isCandidate)
     .map((descriptor) => ({
       value: descriptor.id,
       label: descriptor.name ?? descriptor.id,
       hint: descriptor.type,
-      optgroup: descriptor.id.startsWith(METADATA_PREFIX)
-        ? METADATA_GROUP
-        : FIELDS_GROUP,
+      optgroup: groupOf(descriptor),
     }))
-    .filter(
-      (option) =>
-        normalizedQuery === "" ||
-        option.label.toLowerCase().includes(normalizedQuery) ||
-        option.value.toLowerCase().includes(normalizedQuery),
-    );
+    .filter((option) => matches(option, query));
 }
 
 /**
@@ -210,12 +197,75 @@ async function loadOptions(
   contextPath: string,
   fetchJson: JsonFetcher,
 ): Promise<FieldOption[]> {
+  return toOptions(
+    await loadDescriptors(element, contextPath, fetchJson),
+    query,
+  );
+}
+
+/**
+ * Loads the property descriptors of the data type currently selected.
+ *
+ * This is the step every picker of this dialog shares: which data type is selected is read from the sibling
+ * parameter, and the answer is the same list of descriptors whether the picker turns them into columns, into sort
+ * criteria or into filter constraints.
+ *
+ * @param element - the picker element
+ * @param contextPath - the wiki context path
+ * @param fetchJson - fetches and parses the properties resource
+ * @returns the descriptors of the selected data type, empty when no data type is selected
+ */
+async function loadDescriptors(
+  element: Element,
+  contextPath: string,
+  fetchJson: JsonFetcher,
+): Promise<PropertyDescriptor[]> {
   const dataType = findDataType(element);
   if (dataType === null) {
     return [];
   }
-  const payload = await fetchJson(propertiesUrl(contextPath, dataType));
-  return toOptions(asDescriptors(payload), query);
+  return asDescriptors(await fetchJson(propertiesUrl(contextPath, dataType)));
+}
+
+/**
+ * Whether a property descriptor names something an author can pick.
+ *
+ * @param descriptor - the descriptor to check
+ * @returns false for the Live Data pseudo-columns and for anything without an identifier
+ */
+function isCandidate(descriptor: PropertyDescriptor): boolean {
+  return (
+    typeof descriptor?.id === "string" &&
+    descriptor.id !== "" &&
+    !descriptor.id.startsWith(INTERNAL_PREFIX)
+  );
+}
+
+/**
+ * @param descriptor - a property descriptor
+ * @returns the group it is listed under
+ */
+function groupOf(descriptor: PropertyDescriptor): string {
+  return descriptor.id.startsWith(METADATA_PREFIX)
+    ? METADATA_GROUP
+    : FIELDS_GROUP;
+}
+
+/**
+ * @param option - an option to test
+ * @param query - the text the author typed
+ * @returns whether the option matches, on either what is shown or what is stored
+ */
+function matches(
+  option: { label: string; value: string },
+  query: string,
+): boolean {
+  const normalized = query.trim().toLowerCase();
+  return (
+    normalized === "" ||
+    option.label.toLowerCase().includes(normalized) ||
+    option.value.toLowerCase().includes(normalized)
+  );
 }
 
 /**
@@ -255,7 +305,11 @@ export {
   METADATA_PREFIX,
   asDescriptors,
   findDataType,
+  groupOf,
+  isCandidate,
+  loadDescriptors,
   loadOptions,
+  matches,
   propertiesUrl,
   toOptions,
 };

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/fieldPicker.ts
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/fieldPicker.ts
@@ -1,0 +1,262 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+/**
+ * The field picker of the Records macro dialog.
+ *
+ * The candidate columns of a Records table are the fields of the data type the author picked in the sibling
+ * `class` parameter, plus the entry metadata. The macro editor has no declarative way to express that dependency:
+ * it builds every parameter widget by handing a displayer its own type, default value and attributes, and nothing
+ * else, and it caches the resulting templates per macro id, so a template can never be rendered against the
+ * current values.
+ *
+ * What makes an assisted widget possible anyway is that a suggester's data source is a callback invoked on each
+ * keystroke rather than a URL fixed at render time. {@link findDataType} therefore reads the `class` input when the
+ * author opens the dropdown, not when the template was rendered.
+ *
+ * That coupling is to the input *named after the parameter*. It is worth being explicit about why that is
+ * acceptable: it is the same contract the macro editor itself relies on, since it assembles a macro call by
+ * scraping the modal's inputs and matching their names against parameter ids. It cannot be renamed without
+ * breaking every macro. This module deliberately does not reach for anything else in the editor's DOM.
+ */
+
+/**
+ * The part of a Live Data property descriptor this picker needs.
+ *
+ * @see https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/Features/LiveData/
+ */
+interface PropertyDescriptor {
+  /**
+   * The property identifier, which is what the `properties` macro parameter holds.
+   */
+  id: string;
+  /**
+   * The human readable name, already translated by the property store.
+   */
+  name?: string;
+  /**
+   * The property type, shown as a hint because two fields with the same name do not necessarily filter the same
+   * way.
+   */
+  type?: string;
+}
+
+/**
+ * One entry of the picker's dropdown.
+ */
+interface FieldOption {
+  /**
+   * The value stored in the macro parameter.
+   */
+  value: string;
+  /**
+   * The label shown to the author.
+   */
+  label: string;
+  /**
+   * The hint shown next to the label, if the property declares a type.
+   */
+  hint?: string;
+  /**
+   * The group this option is listed under.
+   */
+  optgroup: string;
+}
+
+/**
+ * The identifier prefix of the entry metadata properties, as opposed to the data type's own fields.
+ */
+const METADATA_PREFIX = "doc.";
+
+/**
+ * The identifier prefix of the Live Data pseudo-columns.
+ *
+ * The properties resource reports `_actions`, `_avatar`, `_images` and `_attachments` alongside the real ones.
+ * They are rendering affordances rather than data, they carry no type, and offering them as columns would put
+ * columns in the table that the data type does not have.
+ */
+const INTERNAL_PREFIX = "_";
+
+/**
+ * The group the entry metadata properties are listed under.
+ */
+const METADATA_GROUP = "metadata";
+
+/**
+ * The group the data type's own fields are listed under.
+ */
+const FIELDS_GROUP = "fields";
+
+/**
+ * The name of the macro parameter holding the data type.
+ */
+const DATA_TYPE_PARAMETER = "class";
+
+/**
+ * Reads the data type the author currently has selected.
+ *
+ * The lookup is scoped to the enclosing form when there is one, so that two macro dialogs open at once cannot read
+ * each other's value.
+ *
+ * @param element - the picker element, used as the starting point of the lookup
+ * @returns the serialized data type reference, or `null` when the author has not picked one yet
+ */
+function findDataType(element: Element): string | null {
+  const scope: ParentNode = element.closest("form") ?? element.ownerDocument;
+  const field = scope.querySelector(`[name="${DATA_TYPE_PARAMETER}"]`);
+  if (
+    !(field instanceof HTMLInputElement || field instanceof HTMLSelectElement)
+  ) {
+    return null;
+  }
+  const value = field.value.trim();
+  return value === "" ? null : value;
+}
+
+/**
+ * Builds the URL of the Live Data properties resource for a data type.
+ *
+ * No new backend is needed for this picker: the resource already reports every property of an XClass with its
+ * translated name, its type and its sortable and filterable flags. The `sourceParams.` prefix is how the Live Data
+ * REST resources pass parameters through to their source.
+ *
+ * @param contextPath - the wiki context path, as `XWiki.contextPath` gives it
+ * @param dataType - the serialized reference of the data type
+ * @returns the URL to fetch the property descriptors from
+ */
+function propertiesUrl(contextPath: string, dataType: string): string {
+  const parameters = new URLSearchParams({
+    "sourceParams.className": dataType,
+    media: "json",
+  });
+  return `${contextPath}/rest/liveData/sources/liveTable/properties?${parameters.toString()}`;
+}
+
+/**
+ * Turns property descriptors into dropdown options.
+ *
+ * The two groups matter: the entry metadata and the data type's own fields are different things, and authors look
+ * for them separately.
+ *
+ * @param descriptors - the property descriptors reported by the Live Data properties resource
+ * @param query - the text the author typed, matched against both the label and the identifier
+ * @returns the options to offer, metadata last so that the data type's own fields come first
+ */
+function toOptions(
+  descriptors: PropertyDescriptor[],
+  query = "",
+): FieldOption[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  return descriptors
+    .filter(
+      (descriptor) =>
+        typeof descriptor?.id === "string" &&
+        descriptor.id !== "" &&
+        !descriptor.id.startsWith(INTERNAL_PREFIX),
+    )
+    .map((descriptor) => ({
+      value: descriptor.id,
+      label: descriptor.name ?? descriptor.id,
+      hint: descriptor.type,
+      optgroup: descriptor.id.startsWith(METADATA_PREFIX)
+        ? METADATA_GROUP
+        : FIELDS_GROUP,
+    }))
+    .filter(
+      (option) =>
+        normalizedQuery === "" ||
+        option.label.toLowerCase().includes(normalizedQuery) ||
+        option.value.toLowerCase().includes(normalizedQuery),
+    );
+}
+
+/**
+ * Fetches a JSON document.
+ */
+type JsonFetcher = (url: string) => Promise<unknown>;
+
+/**
+ * Loads the candidate columns of the data type currently selected.
+ *
+ * Returns an empty list rather than throwing when no data type is selected: that is not an error, it is the state
+ * the dialog opens in, and the widget says so in place.
+ *
+ * @param element - the picker element
+ * @param query - the text the author typed
+ * @param contextPath - the wiki context path
+ * @param fetchJson - fetches and parses the properties resource
+ * @returns the options to offer, empty when there is no data type or the resource reports none
+ */
+async function loadOptions(
+  element: Element,
+  query: string,
+  contextPath: string,
+  fetchJson: JsonFetcher,
+): Promise<FieldOption[]> {
+  const dataType = findDataType(element);
+  if (dataType === null) {
+    return [];
+  }
+  const payload = await fetchJson(propertiesUrl(contextPath, dataType));
+  return toOptions(asDescriptors(payload), query);
+}
+
+/**
+ * Reads the property descriptors out of what the REST resource returned.
+ *
+ * The resource answers with an envelope, `{ links, properties }`, and the descriptors are its `properties` entry.
+ * A bare array is accepted too, so that the picker keeps working if the resource is ever simplified. Anything else
+ * yields no option rather than an exception inside a keystroke handler.
+ *
+ * @param payload - the parsed response body
+ * @returns the property descriptors it holds, possibly none
+ */
+function asDescriptors(payload: unknown): PropertyDescriptor[] {
+  let candidates: unknown[];
+  if (Array.isArray(payload)) {
+    candidates = payload;
+  } else if (
+    typeof payload === "object" &&
+    payload !== null &&
+    Array.isArray((payload as { properties?: unknown }).properties)
+  ) {
+    candidates = (payload as { properties: unknown[] }).properties;
+  } else {
+    return [];
+  }
+  return candidates.filter(
+    (item): item is PropertyDescriptor =>
+      typeof item === "object" && item !== null && "id" in item,
+  );
+}
+
+export {
+  DATA_TYPE_PARAMETER,
+  FIELDS_GROUP,
+  INTERNAL_PREFIX,
+  METADATA_GROUP,
+  METADATA_PREFIX,
+  asDescriptors,
+  findDataType,
+  loadOptions,
+  propertiesUrl,
+  toOptions,
+};
+export type { FieldOption, JsonFetcher, PropertyDescriptor };

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/filterPicker.ts
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/filterPicker.ts
@@ -1,0 +1,270 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+/**
+ * The filter picker of the Records macro dialog.
+ *
+ * The `filters` parameter is a query string, `status=Active&client=Acme`, which the renderer parses by splitting on
+ * `&`, then on the first `=`, and URL-decoding both halves; a field named twice becomes two constraints on that
+ * field. So one filter is one `field=value` pair, which is what makes a multiple-value suggester with `&` as its
+ * delimiter the natural widget: each selected item is one constraint.
+ *
+ * Two consequences of that encoding drive this module. A suggested value is percent-encoded, because the renderer
+ * decodes it and a value holding `&` or `=` would otherwise be read as another constraint. And the same field may
+ * legitimately appear more than once, which works because an item's value is the whole pair rather than the field.
+ *
+ * The candidate values come from the property descriptor itself: the Live Data properties resource reports a
+ * `filter.searchURL` for the properties that have one, with an `{encodedQuery}` placeholder. That is the very URL
+ * the Live Data filter row uses to suggest values, so this picker suggests exactly what a reader would be offered
+ * in the rendered table.
+ */
+
+import { groupOf, isCandidate, matches } from "./fieldPicker";
+import type { FieldOption, PropertyDescriptor } from "./fieldPicker";
+
+/**
+ * Separates a field from its value in one constraint.
+ */
+const VALUE_SEPARATOR = "=";
+
+/**
+ * Separates the constraints in the parameter, and therefore the widget's delimiter.
+ */
+const FILTER_SEPARATOR = "&";
+
+/**
+ * The placeholder a `filter.searchURL` carries where the typed text goes.
+ */
+const QUERY_PLACEHOLDER = "{encodedQuery}";
+
+/**
+ * One constraint, split into its two halves.
+ */
+interface Constraint {
+  /**
+   * The field identifier, as authored.
+   */
+  field: string;
+  /**
+   * The value, decoded.
+   */
+  value: string;
+}
+
+/**
+ * Splits a constraint into its field and its value.
+ *
+ * @param text - one constraint, or the text the author is typing
+ * @returns the two halves, or null when no value separator has been typed yet
+ */
+function splitConstraint(text: string): Constraint | null {
+  const separator = text.indexOf(VALUE_SEPARATOR);
+  if (separator === -1) {
+    return null;
+  }
+  return {
+    field: text.slice(0, separator),
+    value: decode(text.slice(separator + 1)),
+  };
+}
+
+/**
+ * Decodes the value half of a constraint, tolerating one that is not valid percent-encoding.
+ *
+ * An author may type a bare `%` in a value, which {@link decodeURIComponent} refuses. Showing what they typed is
+ * better than failing inside a keystroke handler.
+ *
+ * @param value - the value as it appears in the parameter
+ * @returns the decoded value, or the value unchanged when it cannot be decoded
+ */
+function decode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Builds one constraint, encoded as the parameter needs it.
+ *
+ * @param field - the field identifier
+ * @param value - the value, decoded
+ * @returns the constraint to store
+ */
+function encodeConstraint(field: string, value: string): string {
+  return `${field}${VALUE_SEPARATOR}${encodeURIComponent(value)}`;
+}
+
+/**
+ * Offers the fields that can be filtered on, as constraints waiting for a value.
+ *
+ * The value of each is `field=`, which is not a usable constraint on its own; the dialog turns picking one back
+ * into typing, so that the author continues with the value and the value suggestions appear.
+ *
+ * @param descriptors - the property descriptors of the data type
+ * @param query - the text the author typed
+ * @returns one option per matching field
+ */
+function toFieldOptions(
+  descriptors: PropertyDescriptor[],
+  query = "",
+): FieldOption[] {
+  return descriptors
+    .filter(isCandidate)
+    .map((descriptor) => ({
+      value: `${descriptor.id}${VALUE_SEPARATOR}`,
+      label: `${descriptor.name ?? descriptor.id} ${VALUE_SEPARATOR}`,
+      hint: descriptor.type,
+      optgroup: groupOf(descriptor),
+    }))
+    .filter((option) => matches(option, query));
+}
+
+/**
+ * Whether an option is a field waiting for its value rather than a usable constraint.
+ *
+ * @param value - an option value
+ * @returns true when the value names a field but no value
+ */
+function isIncomplete(value: string): boolean {
+  return value.endsWith(VALUE_SEPARATOR);
+}
+
+/**
+ * Builds the URL suggesting the values of one field.
+ *
+ * @param searchURL - the `filter.searchURL` of the property descriptor, holding the query placeholder
+ * @param query - the text the author typed after the value separator
+ * @param base - the URL relative ones are resolved against, since a `searchURL` may be a bare query string
+ * @returns the URL to fetch the candidate values from
+ */
+function valuesUrl(searchURL: string, query: string, base: string): string {
+  const url = searchURL
+    .split(QUERY_PLACEHOLDER)
+    .join(encodeURIComponent(query));
+  return new URL(url, base).toString();
+}
+
+/**
+ * Reads the candidate values out of what a value resource returned.
+ *
+ * Two shapes are accepted, because the descriptors point at two different resources: the class property values
+ * resource answers `{propertyValues: [{value}]}`, while the user and group suggester answers a bare array. Anything
+ * else yields no value rather than an exception inside a keystroke handler.
+ *
+ * @param payload - the parsed response body
+ * @returns the values it holds, possibly none
+ */
+function asValues(payload: unknown): string[] {
+  const candidates = Array.isArray(payload)
+    ? payload
+    : ((payload as { propertyValues?: unknown })?.propertyValues ?? []);
+  if (!Array.isArray(candidates)) {
+    return [];
+  }
+  return candidates
+    .map((candidate) => {
+      if (typeof candidate === "string") {
+        return candidate;
+      }
+      const value = (candidate as { value?: unknown; id?: unknown })?.value;
+      const id = (candidate as { id?: unknown })?.id;
+      return typeof value === "string"
+        ? value
+        : typeof id === "string"
+          ? id
+          : null;
+    })
+    .filter((value): value is string => value !== null && value !== "");
+}
+
+/**
+ * Turns the candidate values of a field into constraints.
+ *
+ * @param values - the candidate values
+ * @param descriptor - the field they belong to
+ * @param query - the text typed after the value separator, matched against the value
+ * @returns one option per matching value
+ */
+function toValueOptions(
+  values: string[],
+  descriptor: PropertyDescriptor,
+  query = "",
+): FieldOption[] {
+  const name = descriptor.name ?? descriptor.id;
+  return values
+    .map((value) => ({
+      value: encodeConstraint(descriptor.id, value),
+      label: `${name} ${VALUE_SEPARATOR} ${value}`,
+      hint: descriptor.type,
+      optgroup: groupOf(descriptor),
+    }))
+    .filter(
+      (option) =>
+        query.trim() === "" ||
+        option.label.toLowerCase().includes(query.trim().toLowerCase()),
+    );
+}
+
+/**
+ * Resolves one stored constraint into the option that shows it back.
+ *
+ * As for the sort picker, this is not a search: a constraint on a field the data type no longer has, or one whose
+ * value no resource suggests, is still what the author wrote, and an option whose value differs from the stored
+ * one would lose it when the dialog reopens.
+ *
+ * @param descriptors - the property descriptors of the data type
+ * @param value - one constraint, as stored in the parameter
+ * @returns the option showing that constraint
+ */
+function resolveFilterOption(
+  descriptors: PropertyDescriptor[],
+  value: string,
+): FieldOption {
+  const constraint = splitConstraint(value);
+  const descriptor = descriptors
+    .filter(isCandidate)
+    .find((candidate) => candidate.id === constraint?.field);
+  if (constraint === null || descriptor === undefined) {
+    return { value, label: value, optgroup: "fields" };
+  }
+  return {
+    value,
+    label: `${descriptor.name ?? descriptor.id} ${VALUE_SEPARATOR} ${constraint.value}`,
+    hint: descriptor.type,
+    optgroup: groupOf(descriptor),
+  };
+}
+
+export {
+  FILTER_SEPARATOR,
+  QUERY_PLACEHOLDER,
+  VALUE_SEPARATOR,
+  asValues,
+  encodeConstraint,
+  isIncomplete,
+  resolveFilterOption,
+  splitConstraint,
+  toFieldOptions,
+  toValueOptions,
+  valuesUrl,
+};
+export type { Constraint };

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/index.ts
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/index.ts
@@ -24,8 +24,9 @@ import {
   resetDerivedParameters,
   setTabsVisible,
 } from "./dialog";
-import { loadOptions } from "./fieldPicker";
-import type { FieldOption } from "./fieldPicker";
+import { loadDescriptors, loadOptions } from "./fieldPicker";
+import { resolveSortOption, toSortOptions } from "./sortPicker";
+import type { FieldOption, JsonFetcher } from "./fieldPicker";
 
 /**
  * Wires the Records macro dialog: the field picker, and the two behaviours that depend on the data type.
@@ -42,9 +43,14 @@ import type { FieldOption } from "./fieldPicker";
  */
 
 /**
- * The CSS class the displayer template marks its field inputs with.
+ * The CSS class the columns displayer template marks its input with.
  */
 const PICKER_SELECTOR = ".suggest-records-fields";
+
+/**
+ * The CSS class the sort displayer template marks its input with.
+ */
+const SORT_SELECTOR = ".suggest-records-sort";
 
 /**
  * Marks a dialog as already wired, since `xwiki:dom:updated` fires more than once per dialog.
@@ -82,7 +88,7 @@ interface PickerSettings {
 }
 
 /**
- * Builds the suggest widget settings for one field input.
+ * Builds the suggest widget settings for one picker input.
  *
  * `persist` is off and the options are cleared whenever the data type changes, because the widget would otherwise
  * keep offering the previous data type's columns: the suggest widget caches what it has loaded, and the author
@@ -98,26 +104,25 @@ interface PickerSettings {
  */
 function createSettings(
   element: Element,
-  fetchJson: (url: string) => Promise<unknown>,
+  fetchJson: JsonFetcher,
+  offer: Offer = columnsOffer,
 ): PickerSettings {
-  const load = (query: string, callback: (options: FieldOption[]) => void) => {
-    // A failure to reach the properties resource must not break the keystroke handler: the dropdown simply has
-    // nothing to offer, which is the same state as "no data type picked yet".
-    void (async () => {
-      try {
-        callback(
-          await loadOptions(element, query, XWiki.contextPath, fetchJson),
-        );
-      } catch {
-        callback([]);
-      }
-    })();
-  };
+  // A failure to reach the properties resource must not break the keystroke handler: the dropdown simply has
+  // nothing to offer, which is the same state as "no data type picked yet".
+  const guard =
+    (produce: (query: string) => Promise<FieldOption[]>) =>
+    (query: string, callback: (options: FieldOption[]) => void) => {
+      void (async () => {
+        try {
+          callback(await produce(query));
+        } catch {
+          callback([]);
+        }
+      })();
+    };
   return {
-    load,
-    // The saved value is a list of identifiers, and an identifier is all the picker needs to show it back, so the
-    // selected values resolve through the same request as the suggestions.
-    loadSelected: (value, callback) => load(value, callback),
+    load: guard((query) => offer.load(element, query, fetchJson)),
+    loadSelected: guard((value) => offer.resolve(element, value, fetchJson)),
     optgroups: [
       { value: "fields", label: "Fields" },
       { value: "metadata", label: "Entry metadata" },
@@ -126,7 +131,8 @@ function createSettings(
     labelField: "label",
     valueField: "value",
     searchField: ["label", "value"],
-    // Column order is authored, so the selected items must be reorderable.
+    // Both the column order and the order of the sort criteria are authored, so the selected items must be
+    // reorderable.
     plugins: ["drag_drop", "remove_button"],
     persist: false,
     // A column the data type does not have would render an empty column, so free text is refused.
@@ -138,6 +144,50 @@ function createSettings(
     hidePlaceholder: true,
   };
 }
+
+/**
+ * What one picker offers: the options for a query, and the option that shows a stored value back.
+ */
+interface Offer {
+  load: (
+    element: Element,
+    query: string,
+    fetchJson: JsonFetcher,
+  ) => Promise<FieldOption[]>;
+  resolve: (
+    element: Element,
+    value: string,
+    fetchJson: JsonFetcher,
+  ) => Promise<FieldOption[]>;
+}
+
+/**
+ * The columns picker: one option per field, and a stored value is an identifier the same request resolves.
+ */
+const columnsOffer: Offer = {
+  load: (element, query, fetchJson) =>
+    loadOptions(element, query, XWiki.contextPath, fetchJson),
+  resolve: (element, value, fetchJson) =>
+    loadOptions(element, value, XWiki.contextPath, fetchJson),
+};
+
+/**
+ * The sort picker: two options per field, one per direction, and a stored criterion is resolved exactly rather
+ * than searched, for the reason given on {@link resolveSortOption}.
+ */
+const sortOffer: Offer = {
+  load: async (element, query, fetchJson) =>
+    toSortOptions(
+      await loadDescriptors(element, XWiki.contextPath, fetchJson),
+      query,
+    ),
+  resolve: async (element, value, fetchJson) => [
+    resolveSortOption(
+      await loadDescriptors(element, XWiki.contextPath, fetchJson),
+      value,
+    ),
+  ],
+};
 
 /**
  * Fetches and parses a JSON document.
@@ -158,8 +208,11 @@ async function fetchJson(url: string): Promise<unknown> {
 /**
  * Wires one Records dialog.
  *
+ * The columns picker is what identifies the dialog as a Records one, and it is also where the data type is
+ * watched from, so that the warning and the reset happen once per dialog rather than once per picker.
+ *
  * @param $ - the page's jQuery instance
- * @param picker - the field picker element, which identifies the dialog as a Records one
+ * @param picker - the columns picker element
  */
 function wire($: JQueryStatic, picker: Element): void {
   const $picker = $(picker);
@@ -167,6 +220,9 @@ function wire($: JQueryStatic, picker: Element): void {
   const dataTypeInput = findDataTypeInput(scope);
 
   $picker.xwikiSelectize(createSettings(picker, fetchJson));
+  scope.querySelectorAll(SORT_SELECTOR).forEach((sort) => {
+    $(sort).xwikiSelectize(createSettings(sort, fetchJson, sortOffer));
+  });
 
   // The tabs are all derived from the data type, so there is nothing to show until one is picked.
   setTabsVisible(scope, dataTypeInput !== null && dataTypeInput.value !== "");

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/index.ts
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/index.ts
@@ -78,6 +78,7 @@ interface PickerSettings {
   plugins: string[];
   persist: boolean;
   create: boolean;
+  hidePlaceholder: boolean;
 }
 
 /**
@@ -86,6 +87,10 @@ interface PickerSettings {
  * `persist` is off and the options are cleared whenever the data type changes, because the widget would otherwise
  * keep offering the previous data type's columns: the suggest widget caches what it has loaded, and the author
  * changing their mind about the data type is exactly the case that must not silently keep stale fields.
+ *
+ * `hidePlaceholder` is set for the reason given below: it is not the widget's default for a multiple-value field,
+ * and every such field in the platform has carried the placeholder alongside its items since Tom Select replaced
+ * Selectize.
  *
  * @param element - the field input being enhanced
  * @param fetchJson - fetches and parses the Live Data properties resource
@@ -126,6 +131,11 @@ function createSettings(
     persist: false,
     // A column the data type does not have would render an empty column, so free text is refused.
     create: false,
+    // The suggest widget is backed by Tom Select, whose `hidePlaceholder` defaults to `mode !==
+    // 'multi'`, so a multiple-value field keeps its placeholder next to the selected items. Here that
+    // placeholder names the default column list, so leaving it visible would tell the author the table
+    // shows the title and every field while they are looking at the columns they just picked.
+    hidePlaceholder: true,
   };
 }
 

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/index.ts
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/index.ts
@@ -102,15 +102,24 @@ interface PickerSettings {
   hidePlaceholder: boolean;
   delimiter?: string;
   onItemAdd?: (this: Suggester, value: string) => void;
+  onItemRemove?: (this: Suggester, value: string) => void;
 }
 
 /**
  * The part of the suggest widget's API this module drives.
  */
 interface Suggester {
+  /**
+   * The values currently selected.
+   */
+  items: string[];
   removeItem: (value: string, silent?: boolean) => void;
   setTextboxValue: (value: string) => void;
   refreshOptions: (triggerDropdown?: boolean) => void;
+  /**
+   * Drops every option that is not backing a selected item, and clears the search cache with them.
+   */
+  clearOptions: () => void;
 }
 
 /**
@@ -135,19 +144,29 @@ function createSettings(
 ): PickerSettings {
   // A failure to reach the properties resource must not break the keystroke handler: the dropdown simply has
   // nothing to offer, which is the same state as "no data type picked yet".
-  const guard =
-    (produce: (query: string) => Promise<FieldOption[]>) =>
-    (query: string, callback: (options: FieldOption[]) => void) => {
+  const guard = (
+    produce: (query: string, selected: string[]) => Promise<FieldOption[]>,
+  ) =>
+    // Not an arrow function: the widget calls this with itself as `this`, which is how a picker knows what is
+    // already selected.
+    function (
+      this: Suggester | undefined,
+      query: string,
+      callback: (options: FieldOption[]) => void,
+    ) {
+      const selected = this?.items ?? [];
       void (async () => {
         try {
-          callback(await produce(query));
+          callback(await produce(query, selected));
         } catch {
           callback([]);
         }
       })();
     };
   return {
-    load: guard((query) => offer.load(element, query, fetchJson)),
+    load: guard((query, selected) =>
+      offer.load(element, query, fetchJson, selected),
+    ),
     loadSelected: guard((value) => offer.resolve(element, value, fetchJson)),
     optgroups: [
       { value: "fields", label: "Fields" },
@@ -180,6 +199,7 @@ interface Offer {
     element: Element,
     query: string,
     fetchJson: JsonFetcher,
+    selected: string[],
   ) => Promise<FieldOption[]>;
   resolve: (
     element: Element,
@@ -203,14 +223,16 @@ const columnsOffer: Offer = {
 };
 
 /**
- * The sort picker: two options per field, one per direction, and a stored criterion is resolved exactly rather
- * than searched, for the reason given on {@link resolveSortOption}.
+ * The sort picker: two options per field, one per direction, minus the fields already sorted on, since sorting a
+ * field twice adds nothing. A stored criterion is resolved exactly rather than searched, for the reason given on
+ * {@link resolveSortOption}.
  */
 const sortOffer: Offer = {
-  load: async (element, query, fetchJson) =>
+  load: async (element, query, fetchJson, selected) =>
     toSortOptions(
       await loadDescriptors(element, XWiki.contextPath, fetchJson),
       query,
+      selected,
     ),
   resolve: async (element, value, fetchJson) => [
     resolveSortOption(
@@ -218,6 +240,17 @@ const sortOffer: Offer = {
       value,
     ),
   ],
+  settings: {
+    // A field that has just been used, or has just been freed, changes what should be offered. The widget caches
+    // what it has loaded per query and keeps the options it has already seen, so both are dropped here: what
+    // survives is the options backing the selected criteria, and the next dropdown loads the rest afresh.
+    onItemAdd() {
+      this.clearOptions();
+    },
+    onItemRemove() {
+      this.clearOptions();
+    },
+  },
 };
 
 /**

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/index.ts
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/index.ts
@@ -1,0 +1,228 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import {
+  findDataTypeInput,
+  findScope,
+  resetDerivedParameters,
+  setTabsVisible,
+} from "./dialog";
+import { loadOptions } from "./fieldPicker";
+import type { FieldOption } from "./fieldPicker";
+
+/**
+ * Wires the Records macro dialog: the field picker, and the two behaviours that depend on the data type.
+ *
+ * jQuery and the suggest widget are taken as RequireJS dependencies rather than imported, so that they stay the
+ * single instances the rest of the page already uses and nothing is bundled twice. That is also why this module
+ * registers itself with `define` and then requires itself.
+ *
+ * The bundle deliberately exports nothing. The macro editor builds each parameter field in a detached element and
+ * only then appends it to the dialog, and jQuery evaluates a field's scripts at that append: a classic script runs,
+ * a `type="module"` one is skipped outright, and ES syntax in a classic one fails to parse. Keeping this module
+ * free of imports and exports leaves the emitted bundle valid as a classic script, which is what the displayer
+ * template loads it as.
+ */
+
+/**
+ * The CSS class the displayer template marks its field inputs with.
+ */
+const PICKER_SELECTOR = ".suggest-records-fields";
+
+/**
+ * Marks a dialog as already wired, since `xwiki:dom:updated` fires more than once per dialog.
+ */
+const WIRED_FLAG = "recordsDialogWired";
+
+/**
+ * What the author is warned with before a change of data type discards their configuration.
+ *
+ * Kept in English here rather than read from a translation bundle because a webjar has no access to one; the
+ * message belongs in the macro's bundle once the picker gets a proper in-dialog error channel.
+ */
+const RESET_WARNING =
+  "Changing the data type resets the columns, the filters and the sort, " +
+  "because they name fields of the data type you are leaving.\n\nChange it anyway?";
+
+/**
+ * The suggest widget settings this picker needs.
+ */
+interface PickerSettings {
+  load: (query: string, callback: (options: FieldOption[]) => void) => void;
+  loadSelected: (
+    value: string,
+    callback: (options: FieldOption[]) => void,
+  ) => void;
+  optgroups: { value: string; label: string }[];
+  optgroupField: string;
+  labelField: string;
+  valueField: string;
+  searchField: string[];
+  plugins: string[];
+  persist: boolean;
+  create: boolean;
+}
+
+/**
+ * Builds the suggest widget settings for one field input.
+ *
+ * `persist` is off and the options are cleared whenever the data type changes, because the widget would otherwise
+ * keep offering the previous data type's columns: the suggest widget caches what it has loaded, and the author
+ * changing their mind about the data type is exactly the case that must not silently keep stale fields.
+ *
+ * @param element - the field input being enhanced
+ * @param fetchJson - fetches and parses the Live Data properties resource
+ * @returns the settings to hand to the suggest widget
+ */
+function createSettings(
+  element: Element,
+  fetchJson: (url: string) => Promise<unknown>,
+): PickerSettings {
+  const load = (query: string, callback: (options: FieldOption[]) => void) => {
+    // A failure to reach the properties resource must not break the keystroke handler: the dropdown simply has
+    // nothing to offer, which is the same state as "no data type picked yet".
+    void (async () => {
+      try {
+        callback(
+          await loadOptions(element, query, XWiki.contextPath, fetchJson),
+        );
+      } catch {
+        callback([]);
+      }
+    })();
+  };
+  return {
+    load,
+    // The saved value is a list of identifiers, and an identifier is all the picker needs to show it back, so the
+    // selected values resolve through the same request as the suggestions.
+    loadSelected: (value, callback) => load(value, callback),
+    optgroups: [
+      { value: "fields", label: "Fields" },
+      { value: "metadata", label: "Entry metadata" },
+    ],
+    optgroupField: "optgroup",
+    labelField: "label",
+    valueField: "value",
+    searchField: ["label", "value"],
+    // Column order is authored, so the selected items must be reorderable.
+    plugins: ["drag_drop", "remove_button"],
+    persist: false,
+    // A column the data type does not have would render an empty column, so free text is refused.
+    create: false,
+  };
+}
+
+/**
+ * Fetches and parses a JSON document.
+ *
+ * @param url - the URL to fetch
+ * @returns the parsed body
+ */
+async function fetchJson(url: string): Promise<unknown> {
+  const response = await fetch(url, {
+    headers: { Accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to load [${url}]: ${response.status}`);
+  }
+  return response.json();
+}
+
+/**
+ * Wires one Records dialog.
+ *
+ * @param $ - the page's jQuery instance
+ * @param picker - the field picker element, which identifies the dialog as a Records one
+ */
+function wire($: JQueryStatic, picker: Element): void {
+  const $picker = $(picker);
+  const scope = findScope(picker);
+  const dataTypeInput = findDataTypeInput(scope);
+
+  $picker.xwikiSelectize(createSettings(picker, fetchJson));
+
+  // The tabs are all derived from the data type, so there is nothing to show until one is picked.
+  setTabsVisible(scope, dataTypeInput !== null && dataTypeInput.value !== "");
+  if (dataTypeInput === null) {
+    return;
+  }
+
+  let previous = dataTypeInput.value;
+  $(dataTypeInput).on("change", () => {
+    const current = dataTypeInput.value;
+    if (current === previous) {
+      return;
+    }
+    // Only warn when there is something to lose: the first choice discards nothing.
+    if (previous !== "" && !window.confirm(RESET_WARNING)) {
+      revert(dataTypeInput, previous);
+      return;
+    }
+    resetDerivedParameters(scope);
+    setTabsVisible(scope, current !== "");
+    previous = current;
+  });
+}
+
+/**
+ * Puts the data type field back on the value the author declined to leave.
+ *
+ * The enhanced widget holds its own copy of the value, so setting the element's is not enough. It is told
+ * silently, since restoring a value the author never actually left is not a change worth notifying.
+ *
+ * @param dataTypeInput - the data type field
+ * @param value - the value to restore
+ */
+function revert(
+  dataTypeInput: HTMLInputElement | HTMLSelectElement,
+  value: string,
+): void {
+  dataTypeInput.value = value;
+  const enhanced = (
+    dataTypeInput as unknown as {
+      selectize?: { setValue: (value: string, silent?: boolean) => void };
+    }
+  ).selectize;
+  enhanced?.setValue(value, true);
+}
+
+define("xwiki-records-fields", ["jquery", "xwiki-selectize"], function (
+  $: JQueryStatic,
+) {
+  const initialize = (event?: unknown, data?: { elements?: Element[] }) => {
+    const roots: ParentNode[] = data?.elements ?? [document];
+    roots.forEach((root) => {
+      root.querySelectorAll(PICKER_SELECTOR).forEach((picker) => {
+        const $picker = $(picker);
+        if ($picker.data(WIRED_FLAG) === true) {
+          return;
+        }
+        $picker.data(WIRED_FLAG, true);
+        wire($, picker);
+      });
+    });
+  };
+  $(document).on("xwiki:dom:loaded xwiki:dom:updated", initialize);
+  initialize();
+});
+
+// Kick the module off, since `define` on its own only registers it. The `requirejs` alias is used rather than
+// `require` so that this reads as the AMD loader it is rather than as a CommonJS import.
+requirejs(["xwiki-records-fields"], () => {});

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/index.ts
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/index.ts
@@ -25,6 +25,16 @@ import {
   setTabsVisible,
 } from "./dialog";
 import { loadDescriptors, loadOptions } from "./fieldPicker";
+import {
+  FILTER_SEPARATOR,
+  asValues,
+  isIncomplete,
+  resolveFilterOption,
+  splitConstraint,
+  toFieldOptions,
+  toValueOptions,
+  valuesUrl,
+} from "./filterPicker";
 import { resolveSortOption, toSortOptions } from "./sortPicker";
 import type { FieldOption, JsonFetcher } from "./fieldPicker";
 
@@ -51,6 +61,11 @@ const PICKER_SELECTOR = ".suggest-records-fields";
  * The CSS class the sort displayer template marks its input with.
  */
 const SORT_SELECTOR = ".suggest-records-sort";
+
+/**
+ * The CSS class the filters displayer template marks its input with.
+ */
+const FILTERS_SELECTOR = ".suggest-records-filters";
 
 /**
  * Marks a dialog as already wired, since `xwiki:dom:updated` fires more than once per dialog.
@@ -85,6 +100,17 @@ interface PickerSettings {
   persist: boolean;
   create: boolean;
   hidePlaceholder: boolean;
+  delimiter?: string;
+  onItemAdd?: (this: Suggester, value: string) => void;
+}
+
+/**
+ * The part of the suggest widget's API this module drives.
+ */
+interface Suggester {
+  removeItem: (value: string, silent?: boolean) => void;
+  setTextboxValue: (value: string) => void;
+  refreshOptions: (triggerDropdown?: boolean) => void;
 }
 
 /**
@@ -142,6 +168,7 @@ function createSettings(
     // placeholder names the default column list, so leaving it visible would tell the author the table
     // shows the title and every field while they are looking at the columns they just picked.
     hidePlaceholder: true,
+    ...offer.settings,
   };
 }
 
@@ -159,6 +186,10 @@ interface Offer {
     value: string,
     fetchJson: JsonFetcher,
   ) => Promise<FieldOption[]>;
+  /**
+   * What this picker needs on top of the settings every picker shares.
+   */
+  settings?: Partial<PickerSettings>;
 }
 
 /**
@@ -190,6 +221,65 @@ const sortOffer: Offer = {
 };
 
 /**
+ * The filters picker: one item per `field=value` constraint.
+ *
+ * The suggestions come in two steps, because a constraint has two halves and only the author knows the first one.
+ * Until a value separator is typed the dropdown offers the fields; once one is typed, it offers that field's
+ * values when the source reports a way to suggest them, and otherwise stays out of the way so the author can type
+ * a value freely. That is also why this is the one picker accepting free text.
+ */
+const filtersOffer: Offer = {
+  load: async (element, query, fetchJson) => {
+    const descriptors = await loadDescriptors(
+      element,
+      XWiki.contextPath,
+      fetchJson,
+    );
+    const constraint = splitConstraint(query);
+    if (constraint === null) {
+      return toFieldOptions(descriptors, query);
+    }
+    const descriptor = descriptors.find(
+      (candidate) => candidate.id === constraint.field,
+    );
+    const searchURL = descriptor?.filter?.searchURL;
+    if (descriptor === undefined || searchURL === undefined) {
+      return [];
+    }
+    const values = asValues(
+      await fetchJson(
+        valuesUrl(searchURL, constraint.value, window.location.href),
+      ),
+    );
+    return toValueOptions(values, descriptor, constraint.value);
+  },
+  resolve: async (element, value, fetchJson) => [
+    resolveFilterOption(
+      await loadDescriptors(element, XWiki.contextPath, fetchJson),
+      value,
+    ),
+  ],
+  settings: {
+    // One item is one constraint, and the parameter separates them the way a query string does.
+    delimiter: FILTER_SEPARATOR,
+    // Most properties have no value suggester, so a value has to be typeable.
+    create: true,
+    // Filters apply together, so unlike columns and sort criteria their order carries no meaning.
+    plugins: ["remove_button"],
+    // Picking a field is picking half a constraint. Rather than leaving `status=` behind as an item that filters
+    // on the empty value, put it back in the text box: the author carries on with the value, and typing the
+    // separator is what brings up that field's values.
+    onItemAdd(value) {
+      if (isIncomplete(value)) {
+        this.removeItem(value, true);
+        this.setTextboxValue(value);
+        this.refreshOptions(true);
+      }
+    },
+  },
+};
+
+/**
  * Fetches and parses a JSON document.
  *
  * @param url - the URL to fetch
@@ -206,6 +296,33 @@ async function fetchJson(url: string): Promise<unknown> {
 }
 
 /**
+ * Enhances the three pickers of one dialog.
+ *
+ * They differ only in what they offer, which is what {@link Offer} carries: the settings they share — the widget,
+ * the failure handling, the placeholder behaviour — are built once in {@link createSettings}.
+ *
+ * @param $ - the page's jQuery instance
+ * @param picker - the columns picker element
+ * @param scope - the dialog's form
+ */
+function enhancePickers(
+  $: JQueryStatic,
+  picker: Element,
+  scope: ParentNode,
+): void {
+  $(picker).xwikiSelectize(createSettings(picker, fetchJson));
+  const others: [string, Offer][] = [
+    [SORT_SELECTOR, sortOffer],
+    [FILTERS_SELECTOR, filtersOffer],
+  ];
+  others.forEach(([selector, offer]) => {
+    scope.querySelectorAll(selector).forEach((element) => {
+      $(element).xwikiSelectize(createSettings(element, fetchJson, offer));
+    });
+  });
+}
+
+/**
  * Wires one Records dialog.
  *
  * The columns picker is what identifies the dialog as a Records one, and it is also where the data type is
@@ -215,14 +332,10 @@ async function fetchJson(url: string): Promise<unknown> {
  * @param picker - the columns picker element
  */
 function wire($: JQueryStatic, picker: Element): void {
-  const $picker = $(picker);
   const scope = findScope(picker);
   const dataTypeInput = findDataTypeInput(scope);
 
-  $picker.xwikiSelectize(createSettings(picker, fetchJson));
-  scope.querySelectorAll(SORT_SELECTOR).forEach((sort) => {
-    $(sort).xwikiSelectize(createSettings(sort, fetchJson, sortOffer));
-  });
+  enhancePickers($, picker, scope);
 
   // The tabs are all derived from the data type, so there is nothing to show until one is picked.
   setTabsVisible(scope, dataTypeInput !== null && dataTypeInput.value !== "");

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/sortPicker.ts
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/sortPicker.ts
@@ -28,7 +28,9 @@
  * suggester with the drag-and-drop plugin already gives.
  *
  * Each candidate field therefore yields two options rather than one, so that picking a criterion is a single
- * choice and the direction never has to be typed.
+ * choice and the direction never has to be typed. A field already used is then dropped from what is offered:
+ * sorting on the same field twice says nothing the first criterion did not already say, and offering both
+ * directions of a field that is already sorted invites reading the pair as a choice when it is not one.
  */
 
 import { groupOf, isCandidate, matches } from "./fieldPicker";
@@ -56,18 +58,31 @@ const DIRECTIONS: readonly { value: string; label: string }[] = [
 const DEFAULT_DIRECTION_LABEL = "default order";
 
 /**
+ * @param criterion - one criterion, with or without a direction
+ * @returns the field it sorts on
+ */
+function fieldOf(criterion: string): string {
+  const separator = criterion.indexOf(DIRECTION_SEPARATOR);
+  return separator === -1 ? criterion : criterion.slice(0, separator);
+}
+
+/**
  * Builds the sort criteria offered for a data type.
  *
  * @param descriptors - the property descriptors of the data type
  * @param query - the text the author typed, matched against both the label and the stored value
- * @returns two options per candidate field, ascending first
+ * @param selected - the criteria already picked, whose fields are not offered again
+ * @returns two options per candidate field still available, ascending first
  */
 function toSortOptions(
   descriptors: PropertyDescriptor[],
   query = "",
+  selected: readonly string[] = [],
 ): FieldOption[] {
+  const used = new Set(selected.map(fieldOf));
   return descriptors
     .filter(isCandidate)
+    .filter((descriptor) => !used.has(descriptor.id))
     .flatMap((descriptor) =>
       DIRECTIONS.map((direction) => ({
         value: `${descriptor.id}${DIRECTION_SEPARATOR}${direction.value}`,
@@ -96,7 +111,7 @@ function resolveSortOption(
   value: string,
 ): FieldOption {
   const separator = value.indexOf(DIRECTION_SEPARATOR);
-  const field = separator === -1 ? value : value.slice(0, separator);
+  const field = fieldOf(value);
   const direction = separator === -1 ? "" : value.slice(separator + 1);
   const descriptor = descriptors
     .filter(isCandidate)
@@ -119,6 +134,7 @@ function resolveSortOption(
 export {
   DEFAULT_DIRECTION_LABEL,
   DIRECTIONS,
+  fieldOf,
   resolveSortOption,
   toSortOptions,
 };

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/sortPicker.ts
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/sortPicker.ts
@@ -1,0 +1,124 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+/**
+ * The sort picker of the Records macro dialog.
+ *
+ * The `sort` parameter is a comma-separated list of `field` or `field:asc` / `field:desc` criteria, in the order
+ * they apply. That is Live Data's own encoding, and it is what makes a suggester the right widget rather than the
+ * platform's `sortPicker` (`uicomponents/widgets/sortPicker.js`): that one edits a single criterion through two
+ * selects, whereas this parameter holds a list whose order matters, which is exactly what a multiple-value
+ * suggester with the drag-and-drop plugin already gives.
+ *
+ * Each candidate field therefore yields two options rather than one, so that picking a criterion is a single
+ * choice and the direction never has to be typed.
+ */
+
+import { groupOf, isCandidate, matches } from "./fieldPicker";
+import type { FieldOption, PropertyDescriptor } from "./fieldPicker";
+
+/**
+ * Separates a field from its direction in one criterion.
+ */
+const DIRECTION_SEPARATOR = ":";
+
+/**
+ * The directions Live Data understands, with the label each is offered under.
+ *
+ * English rather than translated for the same reason as the rest of this webjar: a webjar has no access to a
+ * translation bundle, and these belong in the macro's bundle once the dialog has a way to reach one.
+ */
+const DIRECTIONS: readonly { value: string; label: string }[] = [
+  { value: "asc", label: "ascending" },
+  { value: "desc", label: "descending" },
+];
+
+/**
+ * How a criterion that names no direction is labelled, since Live Data then applies the source's own order.
+ */
+const DEFAULT_DIRECTION_LABEL = "default order";
+
+/**
+ * Builds the sort criteria offered for a data type.
+ *
+ * @param descriptors - the property descriptors of the data type
+ * @param query - the text the author typed, matched against both the label and the stored value
+ * @returns two options per candidate field, ascending first
+ */
+function toSortOptions(
+  descriptors: PropertyDescriptor[],
+  query = "",
+): FieldOption[] {
+  return descriptors
+    .filter(isCandidate)
+    .flatMap((descriptor) =>
+      DIRECTIONS.map((direction) => ({
+        value: `${descriptor.id}${DIRECTION_SEPARATOR}${direction.value}`,
+        label: `${descriptor.name ?? descriptor.id} (${direction.label})`,
+        hint: descriptor.type,
+        optgroup: groupOf(descriptor),
+      })),
+    )
+    .filter((option) => matches(option, query));
+}
+
+/**
+ * Resolves one stored criterion into the option that shows it back.
+ *
+ * This is deliberately not {@link toSortOptions} with the value as the query. A saved criterion may name no
+ * direction, and it may name a field the data type no longer has; in both cases the suggester is told to refuse
+ * free text, so an option whose value is not exactly the stored one would silently drop the author's criterion
+ * when the dialog reopens. Resolving the exact value keeps what was authored.
+ *
+ * @param descriptors - the property descriptors of the data type
+ * @param value - one criterion, as stored in the parameter
+ * @returns the option showing that criterion
+ */
+function resolveSortOption(
+  descriptors: PropertyDescriptor[],
+  value: string,
+): FieldOption {
+  const separator = value.indexOf(DIRECTION_SEPARATOR);
+  const field = separator === -1 ? value : value.slice(0, separator);
+  const direction = separator === -1 ? "" : value.slice(separator + 1);
+  const descriptor = descriptors
+    .filter(isCandidate)
+    .find((candidate) => candidate.id === field);
+  const directionLabel =
+    DIRECTIONS.find((candidate) => candidate.value === direction)?.label ??
+    DEFAULT_DIRECTION_LABEL;
+  return {
+    value,
+    // A field the data type does not have is shown as it was authored: the dialog is not the place to decide that
+    // a criterion is stale, and dropping it would lose it on the next save.
+    label: descriptor
+      ? `${descriptor.name ?? descriptor.id} (${directionLabel})`
+      : value,
+    hint: descriptor?.type,
+    optgroup: descriptor ? groupOf(descriptor) : "fields",
+  };
+}
+
+export {
+  DEFAULT_DIRECTION_LABEL,
+  DIRECTIONS,
+  resolveSortOption,
+  toSortOptions,
+};

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/xwiki.d.ts
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/src/xwiki.d.ts
@@ -1,0 +1,35 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+export {};
+
+declare global {
+  const XWiki: {
+    contextPath: string;
+    currentWiki: string;
+  };
+
+  /**
+   * The suggest widget's jQuery plugin, declared by `uicomponents/suggest/xwiki.selectize.js`, which the displayer
+   * template imports. It ships no type definitions of its own.
+   */
+  interface JQuery {
+    xwikiSelectize(settings: unknown): JQuery;
+  }
+}

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/tsconfig.app.json
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/tsconfig.app.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@xwiki/platform-tool-tsconfig/tsconfig.json",
+  "compilerOptions": {
+    "types": [
+      "requirejs",
+      "jquery"
+    ],
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/*"]
+}

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/tsconfig.json
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    },
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.vitest.json"
+    }
+  ]
+}

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/tsconfig.node.json
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@xwiki/platform-tool-tsconfig/tsconfig.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "isolatedDeclarations": false
+  },
+  "include": ["vite.config.ts", "vitest.config.ts"]
+}

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/tsconfig.vitest.json
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/tsconfig.vitest.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",
+    "isolatedDeclarations": false,
+    "types": ["requirejs", "jquery", "node", "jsdom"]
+  },
+  "include": ["src/**/__tests__/*"],
+  "exclude": []
+}

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/vite.config.ts
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/vite.config.ts
@@ -1,0 +1,23 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import { generateWebjarNodeConfig } from "@xwiki/platform-tool-viteconfig";
+
+export default generateWebjarNodeConfig(import.meta.url);

--- a/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/vitest.config.ts
+++ b/xwiki-platform-core/xwiki-platform-records/xwiki-platform-records-webjar/src/main/node/vitest.config.ts
@@ -1,0 +1,34 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import viteConfig from "./vite.config";
+import { configDefaults, defineConfig, mergeConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      environment: "jsdom",
+      exclude: [...configDefaults.exclude, "e2e/**"],
+      root: fileURLToPath(new URL("./", import.meta.url)),
+    },
+  }),
+);


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24831

Design proposal: https://design.xwiki.org/xwiki/bin/view/Proposal/XObjectsDisplayMacro
Forum thread: https://forum.xwiki.org/t/xobjects-listing-macro/18806

# Changes

## Description

* Adds `xwiki-platform-records`, with two modules: `xwiki-platform-records-macro` (the `{{records}}`
  macro) and `xwiki-platform-records-webjar` (the parameter pickers its dialog uses).
* `{{records}}` lists the entries of one data type (an XClass) as a Live Data table. The macro maps
  its parameters onto a `LiveDataRendererParameters` and delegates the rendering to Live Data, so
  readers get sorting, filtering, pagination and the layout switch for free.
* The point of the macro is the **dialog**, not the syntax: every parameter is picked rather than
  typed, so an author never has to know the name of a field, the `field:direction` sort syntax or
  the `field=value&field=value` filter syntax.
  * **Data type** (mandatory) — a page picker over the wiki's XClasses.
  * **Columns** — a multi-value picker over the data type's fields and the entry metadata
    (`doc.title`, `doc.date`, …), the two offered as separate groups, free text refused.
  * **Sort** — two candidates per field, "Pages (ascending)" / "Pages (descending)"; a field
    already used disappears from the list **in both directions**, since a second criterion on the
    same field does nothing.
  * **Filters** — one item per `field=value`, suggested in two steps: the fields until `=` is
    typed, then that field's own values, read from the property descriptor's `filter.searchURL` —
    the same URL that feeds Live Data's filter row, so the dialog offers what a reader is offered.
    Free text stays allowed, for the values no descriptor can enumerate.
  * **Layout** — two radio buttons, table or cards, reusing Live Data's own translations.
  * **Description** and **Table identifier** — plain text, the latter needed only when one page
    holds more than one table.
* The parameters are grouped into four tabs (Columns / Filter & sort / Display / Advanced) through
  `@PropertyGroup`, so the dialog stays short.

## Clarifications

* **Why a new macro rather than parameters on `{{liveData}}`.** `{{liveData}}` is a general-purpose
  rendering of a Live Data *source*; this one has a single audience — someone listing the entries of
  a data type — and its whole value is that its parameters can be suggested from that data type.
  Almost every parameter here is a picker whose candidates come from the `class` chosen in the
  sibling field, which a generic Live Data macro cannot offer.
* **No `limit` parameter.** An unset limit is Live Data's own default of fifteen, and the reader
  changes the page size from the pagination controls anyway, so the parameter only picked a starting
  point. `LiveDataRendererParameters.limit` is an `Integer`; leaving it null is how you say "default".
* **Why not the platform's `sortPicker`** (`uicomponents/widgets/sortPicker.js`, used by the
  `documents` macro): it edits a *single* criterion through two selects, while `sort` is an ordered
  list, and its field select would still have to be filled from the sibling `class` — the same
  client-side work, for the harder half of the problem and without the list.
* **The one-field-one-criterion rule is enforced in the dialog only.** `sort="pages:asc,pages:desc"`
  written by hand is accepted and the second criterion silently does nothing. Whether that (and the
  wiki-syntax audience generally) deserves server-side validation is an open question — feedback
  welcome.
* A few strings in the webjar ("ascending", "descending", "default order") are still hard-coded in
  English: the webjar has no access to a translation bundle. They belong in the macro's bundle once
  the dialog can reach one.
* The macro API is annotated `@Unstable`.

# Screenshots & Video

Each example is shown with the wiki syntax it corresponds to. Through the dialog series the syntax is the call built so far, so a parameter can be followed from the field that sets it to the text it produces.

## What a reader sees

No parameter but the data type: the entry title followed by every field.

```
{{records class="Records.BookClass"/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/01-render-default.png" width="900" alt="No parameter but the data type: the entry title followed by every field.">

Chosen columns, in the order given, mixing entry metadata and fields.

```
{{records class="Records.BookClass" properties="doc.title,author,status,pages,released"/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/02-render-columns.png" width="900" alt="Chosen columns, in the order given, mixing entry metadata and fields.">

A filter, a sort criterion and a description.

```
{{records class="Records.BookClass" properties="doc.title,author,status,genre,pages" filters="status=published" sort="pages:desc" description="The published books, longest first."/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/03-render-filtered-sorted.png" width="900" alt="A filter, a sort criterion and a description.">

The same list in the cards layout.

```
{{records class="Records.BookClass" properties="doc.title,author,genre,pages" layouts="cards"/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/04-render-cards.png" width="900" alt="The same list in the cards layout.">

Two tables on one page, told apart by the `id` parameter.

```
= Published =

{{records class="Records.BookClass" properties="doc.title,author,pages" filters="status=published" id="published"/}}

= Drafts =

{{records class="Records.BookClass" properties="doc.title,author,pages" filters="status=draft" id="drafts"/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/05-render-two-tables.png" width="900" alt="Two tables on one page, told apart by the `id` parameter.">

A filter that matches nothing.

```
{{records class="Records.BookClass" filters="status=retired"/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/06-render-empty.png" width="900" alt="A filter that matches nothing.">

## Inserting the macro

The macro in the macro selector.

*Nothing is written yet.*

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/10-select-macro.png" width="900" alt="The macro in the macro selector.">

On insert only the mandatory parameter is asked for; the rest appears once a data type is chosen.

*Nothing is written yet.*

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/11-dialog-mandatory-only.png" width="900" alt="On insert only the mandatory parameter is asked for; the rest appears once a data type is chosen.">

Data type: a page picker over the wiki's XClasses.

*Nothing is written yet.*

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/12-datatype-suggestions.png" width="900" alt="Data type: a page picker over the wiki's XClasses.">

Once a data type is set, the four parameter tabs appear.

```
{{records class="Records.BookClass"/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/13-datatype-chosen.png" width="900" alt="Once a data type is set, the four parameter tabs appear.">

## Columns

Columns, empty: the placeholder says what an empty value does.

```
{{records class="Records.BookClass"/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/14-columns-placeholder.png" width="900" alt="Columns, empty: the placeholder says what an empty value does.">

Columns: entry metadata and the data type's fields, as two groups, each with its type.

```
{{records class="Records.BookClass"/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/15-columns-suggestions.png" width="900" alt="Columns: entry metadata and the data type's fields, as two groups, each with its type.">

Columns picked; the placeholder is gone and the items can be reordered by dragging.

```
{{records class="Records.BookClass" properties="doc.title,author,status,pages"/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/16-columns-picked.png" width="900" alt="Columns picked; the placeholder is gone and the items can be reordered by dragging.">

## Sort

Sort: two candidates per field, ascending and descending.

```
{{records class="Records.BookClass" properties="doc.title,author,status,pages"/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/17-sort-suggestions.png" width="900" alt="Sort: two candidates per field, ascending and descending.">

A field already sorted on is no longer offered, in either direction.

```
{{records class="Records.BookClass" properties="doc.title,author,status,pages" sort="pages:desc"/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/18-sort-field-not-offered-twice.png" width="900" alt="A field already sorted on is no longer offered, in either direction.">

## Filters

Filters, first step: the fields.

```
{{records class="Records.BookClass" properties="doc.title,author,status,pages" sort="pages:desc"/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/19-filters-field-suggestions.png" width="900" alt="Filters, first step: the fields.">

Filters, second step: once `=` is typed, that field's own values.

```
{{records class="Records.BookClass" properties="doc.title,author,status,pages" sort="pages:desc"/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/20-filters-value-suggestions.png" width="900" alt="Filters, second step: once `=` is typed, that field's own values.">

The filter as a single item, `Status = published`.

```
{{records class="Records.BookClass" properties="doc.title,author,status,pages" filters="status=published" sort="pages:desc"/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/21-filters-picked.png" width="900" alt="The filter as a single item, `Status = published`.">

## Display and Advanced

Layout is a closed choice of two, defaulting to table — which is why no `layouts` parameter is written.

```
{{records class="Records.BookClass" properties="doc.title,author,status,pages" filters="status=published" sort="pages:desc"/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/22-display-layout-radios.png" width="900" alt="Layout is a closed choice of two, defaulting to table — which is why no `layouts` parameter is written.">

The description shown above the table, and used as its accessible description.

```
{{records class="Records.BookClass" properties="doc.title,author,status,pages" filters="status=published" sort="pages:desc" description="The published books, longest first."/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/23-display-description.png" width="900" alt="The description shown above the table, and used as its accessible description.">

The table identifier, needed only when one page holds more than one table.

```
{{records class="Records.BookClass" properties="doc.title,author,status,pages" filters="status=published" sort="pages:desc" description="The published books, longest first." id="published-books"/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/24-advanced-table-identifier.png" width="900" alt="The table identifier, needed only when one page holds more than one table.">

## Reopening the dialog on an existing macro

Reopening the dialog on a macro already in the page: the stored columns come back as items.

```
{{records class="Records.BookClass" properties="doc.title,author,status,genre,pages" filters="status=published" sort="pages:desc" description="The published books, longest first."/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/25-reopened-columns.png" width="900" alt="Reopening the dialog on a macro already in the page: the stored columns come back as items.">

`filters="status=published"` and `sort="pages:desc"` resolved back into items, not raw text.

```
{{records class="Records.BookClass" properties="doc.title,author,status,genre,pages" filters="status=published" sort="pages:desc" description="The published books, longest first."/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/26-reopened-filter-sort.png" width="900" alt="`filters='status=published'` and `sort='pages:desc'` resolved back into items, not raw text.">

The stored layout and description.

```
{{records class="Records.BookClass" properties="doc.title,author,status,genre,pages" filters="status=published" sort="pages:desc" description="The published books, longest first."/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/27-reopened-display.png" width="900" alt="The stored layout and description.">

The Advanced tab of the reopened dialog.

```
{{records class="Records.BookClass" properties="doc.title,author,status,genre,pages" filters="status=published" sort="pages:desc" description="The published books, longest first."/}}
```

<img src="https://raw.githubusercontent.com/manuelleduc/xwiki-platform/screenshots/XWIKI-24831/28-reopened-advanced.png" width="900" alt="The Advanced tab of the reopened dialog.">

# Executed Tests

* `mvn -B -ntp clean install -Pquality` on `xwiki-platform-core/xwiki-platform-records` — green,
  including Checkstyle, Revapi, Spoon, the license check and the JaCoCo gate (the macro module is at
  an instruction ratio of 1.00).
* Unit tests: `RecordsMacroTest` (Java, the parameter-to-Live-Data mapping) and 68 vitest tests
  across `dialog`, `fieldPicker`, `filterPicker` and `sortPicker` (the picker logic).
* Manually exercised in a browser against a standalone 18.8.0-SNAPSHOT instance, over a data type
  with a String, two StaticList, a Number, a Date, a Users and a TextArea field: the insert flow,
  each of the three pickers, the layout radios, and the round-trip of reopening the dialog on a
  macro already in the page. The screenshots above are that session.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * (none — new feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
