### PR TITLE
XWIKI-24867: Home link for a subwiki alias points to the main wiki

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
@@ -99,9 +99,14 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
 }
 
 .xobject-action {
-  display: block;
-  position: absolute;
-  top: 2px;
+    display: block;
+    position: absolute;
+    top: -5px;
+    padding: 7px;
+}
+
+.xobject-action.delete {
+    right: 0px;
 }
 
 .xobject-title .delete {
@@ -110,7 +115,11 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
 }
 
 .xobject-title .edit {
-  right: 16px;
+  right: 28px;
+}
+
+.xobject-row {
+    min-height: 24px;
 }
 
 /* XProperty definition */
@@ -228,10 +237,14 @@ The default state is collapsed for xobjects and xproperties, but expanded for xc
 }
 
 .xproperty-title .tools .tool {
-  width: 16px;
-  height: 16px;
-  float: left;
-  background: transparent none center no-repeat;
+    width: 16px;
+    height: 16px;
+    padding: 4px;
+    box-sizing: content-box;
+    background-clip: content-box;
+    float: left;
+    background: transparent none center no-repeat;
+    margin-top: -4px;
 }
 
 .xproperty-title .tools .move {


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24867

# Changes

## Description

* Added `#aliasHomePage($alias)` macro in `XWikiServerClassSheet.xml` to resolve the alias homepage in the correct subwiki scope.
* Fixed generated links so they use the configured alias host or path instead of pointing to the main wiki root.
* Passed the custom link into `#displayField` to keep the layout consistent.

## Clarifications

* Alias documents live on the main wiki, so unqualified references like `Main.WebHome` were defaulting to the main wiki's URL.
* Standard URL generation uses the primary wiki domain, ignoring the alias. We rewrite the base URL with the alias server value to support both path-based (`/wiki/<alias>/`) and domain-based setups.

# Screenshots & Video
<img width="997" height="405" alt="Screenshot 2026-09-14 at 8 48 24 PM" src="https://github.com/user-attachments/assets/589f063a-6371-43cc-8cdd-ce9e8d10d945" />

# Executed Tests

* Verified locally on path-based routing (`xwiki.virtual.usepath=1`) that the alias Home link correctly opens `http://localhost:8080/xwiki/wiki/testalias/view/Main/`.
* Tested fallback to `Main.WebHome` when the alias homepage field is left empty.
* Ran `mvn clean install` on the module to verify XML validity.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
* `stable-16.10.x`
* `stable-16.4.x`